### PR TITLE
fix: 修复知识恶魔首回合诅咒重放导致的 SEARCH_FAILURE

### DIFF
--- a/docs/DEVELOPMENT_NOTES.md
+++ b/docs/DEVELOPMENT_NOTES.md
@@ -4,6 +4,11 @@
 > 本文是项目的持续记录。每次改变搜索语义、评分、模拟覆盖、性能策略、UI 或测试方式时，都应同步更新对应章节和文末变更记录。  
 > “未来构想”均不是已经实现的功能。
 
+## 未发布：知识恶魔诅咒重放豁免
+
+- 知识恶魔 boss 首回合自动搜索以 `InvalidPlannedChoiceBranchException`（“回合开始仍有 1 个计划选牌没有触发；下一个=…/ApplyKnowledgeCurse/None/”）终止整轮搜索。知识恶魔的诅咒选牌由 `PendingKnowledgeDemonChoice` 独立消费、不经回合开始选牌游标；`EndActionChoices` 的豁免条件只认 `PendingTurnStartChoice`，敌回合因诅咒提前 `PendingChoice` 退出时会对未消费到底的游标误执行 `AssertConsumed()`。
+- 豁免条件改为 `!HasPendingChoice`（`PendingTurnStartChoice != null || PendingKnowledgeDemonChoice != null`），敌方诅咒暂停不再误清点；整轮正常完成时 `roundChoices` / `Replay` 的 `AssertConsumed()` 仍捕获真正遗漏的选择。
+- 该异常仍属“精确计划分支失效”，按既有 `InvalidPlannedChoiceBranchException` 通道只淘汰候选；其它执行异常继续中止搜索。
 ## 0.18.0：集中修复批次
 
 - 本节记录 `0.17.2` 发布后的 29 项集中修复；全部问题已结案并进入 `0.18.0` 发布准备。

--- a/docs/TEST_MATRIX.md
+++ b/docs/TEST_MATRIX.md
@@ -4,6 +4,11 @@
 
 同一版 DLL 的场景默认复用 marker 记录的 headless 游戏进程：首条命令直接启动游戏，完成后返回主菜单等待下一条请求；后续命令只向该测试 PID 投递。测试使用独立 `APPDATA/LOCALAPPDATA`、关闭 Steam，并只在隔离设置中确认允许加载 Mod；RitsuLib 在 headless 生命周期内从创意工坊版本目录临时投影到带所有权标记的本地目录，退出时删除。发现未由 marker 管理的塔 2 进程时拒绝运行。只有重新编译需要加载新 DLL，或最后一批显式传入 `-ExitOnComplete` 时才退出游戏。同一战斗能容纳的行动继续合并到一个批次夹具中连续执行。
 
+## 未发布
+
+| 场景 | 结果 | 验证内容 | 日期 |
+| --- | --- | --- | --- |
+| `KNOWLEDGE-DEMON-CURSE-REPLAY` | 待验证 | 知识恶魔 boss 首回合自动搜索此前以 `InvalidPlannedChoiceBranchException`（`ApplyKnowledgeCurse` 未消费）终止整轮。本次修复 `EndActionChoices` 豁免条件为 `!HasPendingChoice`（覆盖 `PendingKnowledgeDemonChoice`）。本次仅编译验证通过（`dotnet build -c Release`，0 警告 / 0 错误）；actual/simulated 严格差分与 `-VerifyIncrementalSearch` 夹具尚未运行。 | 2026-08-30 |
 ## 0.18.0
 
 | 场景 | 结果 | 验证内容 | 日期 |

--- a/src/Search/SimulatedCombatState.ActionChoices.cs
+++ b/src/Search/SimulatedCombatState.ActionChoices.cs
@@ -28,7 +28,7 @@ internal sealed partial class SimulatedCombatState :
     {
         TurnStartChoiceCursor cursor = _activeActionChoices
             ?? throw new InvalidOperationException("模拟状态没有活动的动作选择游标。");
-        if (PendingTurnStartChoice == null)
+        if (!HasPendingChoice)
             cursor.AssertConsumed();
         _activeActionChoices = null;
     }


### PR DESCRIPTION
**改动**

`src/Search/SimulatedCombatState.ActionChoices.cs:31`，`EndActionChoices()` 的豁免条件：

```diff
-        if (PendingTurnStartChoice == null)
+        if (!HasPendingChoice)
             cursor.AssertConsumed();
```

`HasPendingChoice`（`src/Search/SimulatedCombatState.cs:459`）= `PendingTurnStartChoice != null || PendingKnowledgeDemonChoice != null`。

**背景**

求解器把“玩家回合 → 敌方回合 → 下一玩家回合”当作一整段流程，用一份“待办清单”记录这段里规划的所有选择，走完时核对是否有遗漏。知识恶魔在敌方回合会发动诅咒，弹出“从几张诅咒牌里选一张”的选择；求解器把这类选择归到敌方回合、用一条独立逻辑处理。

这段流程在“敌方回合选诅咒”时会先暂停。原规则是暂停就跳过清单核对，但跳过条件只认“玩家回合开始的选牌”这一种暂停，不认“敌方诅咒”这种。于是它没被跳过，反而去核对一份因暂停还没走完的清单，把“选诅咒”当成遗漏项，抛出 `InvalidPlannedChoiceBranchException`，整轮搜索终止（`SEARCH_FAILURE`）。

本次改动把跳过条件放宽为认所有这类暂停（玩家回合选牌待处理 或 敌方诅咒待处理），因此敌方回合因诅咒暂停时不再误核对；清单中真正遗漏的选择仍会被核对出来。配套的“清单过滤诅咒项”（`roundChoices` 已排除 `ApplyKnowledgeCurse`，`CombatBeamSolver.Expansion.cs:1214-1217`）在主分支已存在，本次未改。

**验证**

- 已执行：`dotnet build CombatSolver.csproj -c Release` 通过（0 warning / 0 error）。
- 未执行：actual/simulated 严格差分、`-VerifyIncrementalSearch`、知识恶魔首回合重放 headless 夹具。

**文档同步**

- `docs/DEVELOPMENT_NOTES.md`：补根因与 `!HasPendingChoice` 豁免语义。
- `docs/TEST_MATRIX.md`：登记知识恶魔首回合诅咒重放场景（待验证）。

**风险**

- `PendingKnowledgeDemonChoice` 仅由知识恶魔设置，`!HasPendingChoice` 对其它怪物路径行为不变。
- 豁免只影响“存在待处理选择而提前退出”时；正常完成路径的 `AssertConsumed()` 不变。
- 未提升版本、未打包、未部署。

---

复现附件：知识恶魔 boss 问题包（`CombatSolver-KNOWLEDGE_DEMON_BOSS-*.zip`），见后续评论。
