### PR TITLE
fix: disable solver in multiplayer sessions and skip noGC on mobile

### DIFF
--- a/src/Runtime/Entry.cs
+++ b/src/Runtime/Entry.cs
@@ -72,7 +72,8 @@ public static class Entry
     {
         if (!Enabled
             || state.CurrentSide != CombatSide.Player
-            || NGame.Instance == null)
+            || NGame.Instance == null
+            || SolverController.IsMultiplayerSession)
             return;
         if (SolverController.SolverDisabled)
         {
@@ -115,6 +116,7 @@ public static class Entry
 
         if (!Enabled
             || SolverController.SolverDisabled
+            || SolverController.IsMultiplayerSession
             || !UnattendedTestRunner.AutomaticTurnSearchEnabled
             || !CombatManager.Instance.IsInProgress
             || !ReferenceEquals(CombatManager.Instance.DebugOnlyGetState(), state)

--- a/src/Runtime/PlayerTurnSetupPatches.cs
+++ b/src/Runtime/PlayerTurnSetupPatches.cs
@@ -164,6 +164,7 @@ internal static class PlayerTurnSetupCoordinator
         if (_invokingOriginalSetup
             || !Entry.Enabled
             || SolverController.SolverDisabled
+            || SolverController.IsMultiplayerSession
             || SolverController.AutomaticSearchPaused
             || !ReferenceEquals(LocalContext.GetMe(manager.DebugOnlyGetState()), player)
             || player.PlayerCombatState == null

--- a/src/Runtime/SearchGcPolicy.cs
+++ b/src/Runtime/SearchGcPolicy.cs
@@ -66,7 +66,13 @@ internal static class SearchGcPolicy
         Started,
         InsufficientMemory,
         RegionSizeUnsupported,
+        PlatformUnsupported,
     }
+
+    // Mobile .NET runtimes (Android/iOS) do not support GC.TryStartNoGCRegion; skip straight to the
+    // SustainedLowLatency fallback instead of calling into it.
+    private static readonly bool NoGcRegionSupported =
+        !OperatingSystem.IsAndroid() && !OperatingSystem.IsIOS();
 
     internal static void ResetCountersForTesting()
     {
@@ -601,6 +607,8 @@ internal static class SearchGcPolicy
         long totalSize,
         long lohSize)
     {
+        if (!NoGcRegionSupported)
+            return NoGcRegionStartOutcome.PlatformUnsupported;
         try
         {
             return GC.TryStartNoGCRegion(
@@ -623,6 +631,7 @@ internal static class SearchGcPolicy
             NoGcRegionStartOutcome.Started => "started",
             NoGcRegionStartOutcome.InsufficientMemory => "insufficient_memory",
             NoGcRegionStartOutcome.RegionSizeUnsupported => "region_size_unsupported",
+            NoGcRegionStartOutcome.PlatformUnsupported => "platform_unsupported",
             _ => throw new ArgumentOutOfRangeException(nameof(outcome)),
         };
 

--- a/src/Runtime/SolverController.cs
+++ b/src/Runtime/SolverController.cs
@@ -9,6 +9,7 @@ using MegaCrit.Sts2.Core.Entities.Players;
 using MegaCrit.Sts2.Core.GameActions;
 using MegaCrit.Sts2.Core.Helpers;
 using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Multiplayer.Game;
 using MegaCrit.Sts2.Core.Nodes;
 using MegaCrit.Sts2.Core.Runs;
 using MegaCrit.Sts2.Core.Saves;
@@ -55,6 +56,15 @@ internal static class SolverController
     public static bool IsSearching => _search != null || PlayerTurnSetupCoordinator.IsSearching;
     public static bool IsDeploying => _deployment != null;
     public static bool SolverDisabled => _solverDisabled;
+
+    /// <summary>
+    /// True whenever the current run is a networked multiplayer session (host or client).
+    /// The solver must stay fully inert in this case: the game's own multiplayer turn
+    /// synchronization has no concept of a client silently auto-planning another player's turn.
+    /// </summary>
+    public static bool IsMultiplayerSession
+        => RunManager.Instance.IsInProgress && RunManager.Instance.NetService.Type.IsMultiplayer();
+
     public static bool FullAutoEnabled => _combat.FullAutoEnabled;
     public static bool AutomaticSearchPaused => _combat.AutomaticSearchPaused;
     public static bool StopFullAutoOnCombatEnd => _stopFullAutoOnCombatEnd;


### PR DESCRIPTION
## Summary
- 多人联机对局下强制禁用求解器：在 `Entry.cs` 的回合开始钩子、`PlayerTurnSetupPatches.cs` 的回合准备拦截入口都新增 `SolverController.IsMultiplayerSession`（基于 `RunManager.Instance.NetService.Type.IsMultiplayer()`）判断，联机时直接静默跳过，不受用户设置开关影响。
- 该判断特意放在原有 `SolverDisabled` 判断之前，因此联机时游戏内悬浮窗完全不会被创建，而不是像"用户手动禁用"那样弹出"求解器已禁用"的提示窗。
- 移动端 GC 策略修复：`SearchGcPolicy.cs` 检测 `OperatingSystem.IsAndroid()/IsIOS()`，移动端直接跳过 `GC.TryStartNoGCRegion` 调用，复用既有的 `SustainedLowLatency` 回退路径，避免调用移动端运行时不支持的 API。

## Test plan
- [x] `dotnet build CombatSolver.csproj -c Debug`（0 警告 0 错误）
- [ ] 联机对局中验证求解器悬浮窗不出现、不自动搜索/托管
- [ ] 移动端构建下验证战斗搜索不再因 noGC 区域异常而崩溃
