### PR TITLE
按药水本身的价值定价，而不是一律 9 点血

### DIFF
--- a/src/Search/PotionUsePolicy.cs
+++ b/src/Search/PotionUsePolicy.cs
@@ -17,11 +17,49 @@ internal static class PotionUsePolicy
     public static int AdditionalRequiredUseStrategicHpCost(int strategicHpCost)
         => Math.Max(0, strategicHpCost - SolverWeights.PotionMinimumHpSaved);
 
+    /// <summary>
+    /// Potions the solver must be clearly rewarded for spending, because their effect is hard to replace.
+    /// </summary>
+    /// <remarks>
+    /// Ambergris is deliberately absent: <see cref="MeetsAmbergrisRestriction"/> already holds it to a far higher
+    /// bar (a fraction of maximum HP), and that calculation is written against the baseline cost.
+    /// </remarks>
+    private static readonly HashSet<string> HighValuePotionIds =
+    [
+        "GLOWWATER_POTION",
+        "SWIFT_POTION",
+        "GAMBLERS_BREW",
+        "DUPLICATOR",
+        "OROBIC_ACID",
+        "POT_OF_GHOULS",
+    ];
+
+    private static readonly HashSet<string> ElevatedValuePotionIds =
+    [
+        "DISTILLED_CHAOS",
+        "CLARITY",
+        "RADIANT_TINCTURE",
+        "CURE_ALL",
+        "LIQUID_MEMORIES",
+        "BOTTLED_POTENTIAL",
+        "TOUCH_OF_INSANITY",
+    ];
+
+    /// <summary>
+    /// The HP a route must save to justify spending this potion. Token potions are free to spend; everything else
+    /// costs at least the baseline, and the two value tiers cost more so a cheap potion is spent before a scarce one.
+    /// </summary>
     public static int StrategicHpCost(PotionModel potion, bool renewablePotionShapedRock = false)
-        => potion.Rarity == PotionRarity.Token
-            || renewablePotionShapedRock && potion is PotionShapedRock
-                ? 0
-                : SolverWeights.PotionMinimumHpSaved;
+    {
+        if (potion.Rarity == PotionRarity.Token || renewablePotionShapedRock && potion is PotionShapedRock)
+            return 0;
+        string id = potion.Id.Entry;
+        if (HighValuePotionIds.Contains(id))
+            return SolverWeights.PotionHighValueHpSaved;
+        if (ElevatedValuePotionIds.Contains(id))
+            return SolverWeights.PotionElevatedValueHpSaved;
+        return SolverWeights.PotionMinimumHpSaved;
+    }
 
     public static bool RequiresOpeningUse(PotionModel potion)
         => potion is DexterityPotion

--- a/src/Search/SolverWeights.cs
+++ b/src/Search/SolverWeights.cs
@@ -69,6 +69,12 @@ internal static class SolverWeights
     public const int EliteSoldHpThreshold = 10;
     public const int BossSoldHpThreshold = 15;
     public const int PotionMinimumHpSaved = 9;
+
+    /// <summary>Potions whose effect is worth roughly twice a baseline potion.</summary>
+    public const int PotionHighValueHpSaved = PotionMinimumHpSaved * 2;
+
+    /// <summary>Potions worth roughly one and a half times a baseline potion. Rounded up from 13.5.</summary>
+    public const int PotionElevatedValueHpSaved = (PotionMinimumHpSaved * 3 + 1) / 2;
     // This is the minimum cross-turn no-progress horizon and the UI projection horizon. It is not a
     // total turn cap: every new historical combat improvement restarts the no-progress window.
     public const int SetupValueHorizonTurns = 16;


### PR DESCRIPTION
## 问题

`PotionUsePolicy.StrategicHpCost` 对所有非 Token 药水返回同一个常数 `PotionMinimumHpSaved`（9）。于是路线只会挑「能省最多血」的那一瓶，完全不考虑哪一瓶更难替代。玩家同时带一瓶廉价药水和一瓶稀缺药水时，求解器可能把稀缺的那瓶喝掉，只因为它多省了 1 点血。

## 改动

目前采用了非常粗糙的启发式方法，把明显高价值的药水和低价值药水区分开。

分两档，分别为基准价的 2 倍与 1.5 倍：

- **2 倍（18）**：`GLOWWATER_POTION` `SWIFT_POTION` `GAMBLERS_BREW` `DUPLICATOR` `OROBIC_ACID` `POT_OF_GHOULS`
- **1.5 倍（14）**：`DISTILLED_CHAOS` `CLARITY` `RADIANT_TINCTURE` `CURE_ALL` `LIQUID_MEMORIES` `BOTTLED_POTENTIAL` `TOUCH_OF_INSANITY`

上层管线本来就是逐瓶累加 `StrategicHpCost` 的（`SimulatedCombatState.ConsumePotion` → `PredictedPotionUse` → `PotionStrategicCost`），所以只需要改这一个函数，没有新增任何机制。

## 例外

**龙涎香不在任何一档里。** `MeetsAmbergrisRestriction` 已经把它卡在「必须省下最大生命的 40%」，以常见的 70–90 最大生命计算是 28–36 点，比 2 倍档的 18 严格得多。而且 `EffectiveStrategicHpCost` 那段计算是按基准价 9 写的（`strategicHpCost + ambergrisCount * (AmbergrisRequiredHpSaved - PotionMinimumHpSaved)`），把它放进分档表会算成 `18 + (32 − 9) = 41`，反而错。

## 分档表的来源与局限

分档是玩家侧的经验判断，不是从代码推导出来的，所以这是最可能需要 review 调整的部分。

另外要诚实说明：静态分档抓不到情境价值（火焰药水对高血 Boss 和对小怪不是一个价）。它只解决「贵的别被白喝掉」这一类粗粒度错误。

## 已知的后续问题（本 PR 不含）

排查过程中发现一个更根本的缺陷，想单独提出来讨论：**药水价值目前只进入准入闸门，不进入排序比较。**

`IsEligible` 的 Smart 分支是一道「整条路线 vs 完全不吃药基线」的全有全无闸门，它从不问「把便宜那瓶去掉会不会一样好」——没有边际检查。而在 `FinalPlanOrdering` 的排序链里，`PotionCount` 严格排在两条生命轴之后，所以「贵的 + 便宜的」只要比「只喝贵的」多省 1 点血就先赢，`PotionCount` 根本没机会被问到；药水的档位压根没进排序。

结果是本 PR 的分档在这种场合下形同虚设。我认为正确的修法是把 `PotionStrategicCost` 折进生命轴（比较 `hpDeficit × 权重 + potionStrategicCost`），这本来就是「一瓶药值 N 点血」的字面含义。想先听你对这个方向的看法再动手。

## 验证

`dotnet build -c Release`：0 warning / 0 error。未运行 `tools/run-unattended-test.ps1`。
