### PR TITLE
允许按槽位在本场战斗中禁用某一瓶药水

### DIFF
--- a/src/Runtime/SolverController.cs
+++ b/src/Runtime/SolverController.cs
@@ -181,6 +181,7 @@ internal static class SolverController
             UnattendedTestRunner.DeepSearchBudgetOverrideMilliseconds,
             includeTurnSetup,
             theftPolicy,
+            _combat.BannedPotionSlots.ToHashSet(),
             new SearchDiagnosticsSink(
                 message => Entry.Logger.Info(message),
                 message => Entry.Logger.Debug(message)),
@@ -961,6 +962,33 @@ internal static class SolverController
         _combat.PendingCompleteProjectionBaseline = null;
         Entry.Logger.Info(
             $"[CombatSolver/Test] THEFT_POLICY_CHANGED previous={previous?.ToString() ?? "-"} current={policy}");
+        SolverOverlay.RefreshControls();
+        RequestSearch(host, state, SearchReason.Manual);
+    }
+
+    public static IReadOnlySet<int> BannedPotionSlots => _combat.BannedPotionSlots;
+
+    /// <summary>
+    /// Turns one potion slot on or off for this combat. Clearing the continuation is what makes the change take
+    /// effect: without it a matching cross-turn state would reuse the route that was planned under the old
+    /// constraint, and the setting would look like it did nothing.
+    /// </summary>
+    public static void TogglePotionSlotBan(NGame host, CombatState state, int slot)
+    {
+        AssertMainThread();
+        if (_deployment != null)
+        {
+            Entry.Logger.Info("[CombatSolver/Test] POTION_BAN_REJECT reason=deploying");
+            return;
+        }
+        bool banned = !_combat.BannedPotionSlots.Remove(slot);
+        if (banned)
+            _combat.BannedPotionSlots.Add(slot);
+        _combat.ContinuationSource = null;
+        _combat.PendingCompleteProjectionBaseline = null;
+        Entry.Logger.Info(
+            $"[CombatSolver/Test] POTION_BAN_CHANGED slot={slot} banned={banned} " +
+            $"all={string.Join(',', _combat.BannedPotionSlots.Order())}");
         SolverOverlay.RefreshControls();
         RequestSearch(host, state, SearchReason.Manual);
     }

--- a/src/Runtime/SolverControllerSessions.cs
+++ b/src/Runtime/SolverControllerSessions.cs
@@ -30,6 +30,12 @@ internal sealed class SolverCombatSession
     public SolverResult? ContinuationSource { get; set; }
     public bool FullAutoEnabled { get; set; }
     public SolverTheftPolicy? TheftPolicy { get; set; }
+
+    /// <summary>
+    /// Potion slots the player has taken off the table for this combat. Keyed by slot, not by potion id, because
+    /// a player can carry two of the same potion and may well want to spend exactly one of them.
+    /// </summary>
+    public HashSet<int> BannedPotionSlots { get; } = [];
     public CompleteProjectionBaseline? PendingCompleteProjectionBaseline { get; set; }
     public ManualProjectionBaseline? PendingManualProjectionBaseline { get; set; }
     public ManualProjectionComparison? LastManualProjectionComparison { get; set; }

--- a/src/Search/CombatBeamSolver.Expansion.cs
+++ b/src/Search/CombatBeamSolver.Expansion.cs
@@ -261,6 +261,7 @@ internal sealed partial class CombatBeamSolver
         {
             PotionModel? potion = simulatedCombat.GetPotionAtSlot(_player, potionSlot);
             if (potion == null
+                || _bannedPotionSlots.Contains(potionSlot)
                 || !simulatedCombat.IsPotionAvailable(_player, potionSlot)
                 || !PotionOnUseSupport.CanSearch(potion)
                 || PotionUsePolicy.RequiresOpeningUse(potion)

--- a/src/Search/CombatBeamSolver.ParallelExpansion.cs
+++ b/src/Search/CombatBeamSolver.ParallelExpansion.cs
@@ -597,6 +597,7 @@ internal sealed partial class CombatBeamSolver
         {
             PotionModel? potion = simulatedCombat.GetPotionAtSlot(_player, potionSlot);
             if (potion == null
+                || _bannedPotionSlots.Contains(potionSlot)
                 || !simulatedCombat.IsPotionAvailable(_player, potionSlot)
                 || !PotionOnUseSupport.CanSearch(potion)
                 || PotionUsePolicy.RequiresOpeningUse(potion)

--- a/src/Search/CombatBeamSolver.cs
+++ b/src/Search/CombatBeamSolver.cs
@@ -48,6 +48,7 @@ internal sealed partial class CombatBeamSolver(
     private readonly bool _detailedDiagnostics = policy.DetailedDiagnostics;
     private readonly int? _maximumPotionUses = maximumPotionUses;
     private readonly SolverTheftPolicy? _theftPolicy = policy.TheftPolicy;
+    private readonly IReadOnlySet<int> _bannedPotionSlots = policy.BannedPotionSlots;
     private readonly SolverPotionPolicy _potionPolicy = potionPolicyOverride
         ?? (policy.TheftPolicy == SolverTheftPolicy.PreserveResources
             ? SolverPotionPolicy.Smart

--- a/src/Search/SearchPolicySnapshot.cs
+++ b/src/Search/SearchPolicySnapshot.cs
@@ -13,6 +13,7 @@ internal sealed record SearchPolicySnapshot(
     int? DeepBudgetOverrideMilliseconds,
     bool IncludeTurnSetup,
     SolverTheftPolicy? TheftPolicy,
+    IReadOnlySet<int> BannedPotionSlots,
     SearchDiagnosticsSink Diagnostics,
     SearchFramePressureSignal FramePressureSignal,
     SearchMemoryPressureSignal MemoryPressureSignal);

--- a/src/UI/SolverOverlay.cs
+++ b/src/UI/SolverOverlay.cs
@@ -1,5 +1,7 @@
 using Godot;
 using MegaCrit.Sts2.Core.Combat;
+using MegaCrit.Sts2.Core.Context;
+using MegaCrit.Sts2.Core.Entities.Players;
 using MegaCrit.Sts2.Core.Localization.Fonts;
 using MegaCrit.Sts2.Core.Nodes;
 
@@ -49,6 +51,8 @@ internal static class SolverOverlay
     private static PanelContainer? _feedbackBanner;
     private static Label? _feedbackBannerLabel;
     private static HBoxContainer? _theftPolicyControls;
+    private static HFlowContainer? _potionBanControls;
+    private static string? _renderedPotionBanState;
     private static Button? _preserveResourcesButton;
     private static Button? _letEscapeButton;
     private static bool _collapsed;
@@ -500,6 +504,7 @@ internal static class SolverOverlay
         }
 
         CombatState? combat = CombatManager.Instance.DebugOnlyGetState();
+        RefreshPotionBanControls(combat, solverDisabled);
         bool showTheftPolicy = combat != null
             && CombatManager.Instance.IsInProgress
             && TheftEncounterStrategy.IsApplicable(combat);
@@ -528,6 +533,75 @@ internal static class SolverOverlay
                     : SolverButtonStyle.Secondary);
             _renderedTheftPolicy = policy;
         }
+    }
+
+    /// <summary>
+    /// One toggle per occupied potion slot, letting the player take a specific bottle off the table for this
+    /// combat. Keyed by slot because two copies of the same potion must be distinguishable.
+    /// </summary>
+    private static void RefreshPotionBanControls(CombatState? combat, bool solverDisabled)
+    {
+        if (_potionBanControls == null || !GodotObject.IsInstanceValid(_potionBanControls))
+            return;
+        Player? player = combat == null ? null : LocalContext.GetMe(combat);
+        bool show = player != null && CombatManager.Instance.IsInProgress;
+        _potionBanControls.Visible = show;
+        if (!show)
+        {
+            _renderedPotionBanState = null;
+            return;
+        }
+
+        IReadOnlySet<int> banned = SolverController.BannedPotionSlots;
+        List<(int Slot, string Title)> slots = [];
+        for (int slot = 0; slot < player!.PotionSlots.Count; slot++)
+        {
+            if (player.GetPotionAtSlotIndex(slot) is { } potion)
+                slots.Add((slot, potion.Title.GetFormattedText()));
+        }
+        string state = string.Join(
+            '|',
+            slots.Select(item => $"{item.Slot}:{item.Title}:{banned.Contains(item.Slot)}"));
+        bool disabled = solverDisabled || SolverController.IsDeploying;
+        if (_renderedPotionBanState == state)
+        {
+            foreach (Node child in _potionBanControls.GetChildren())
+            {
+                if (child is Button existing)
+                    existing.Disabled = disabled;
+            }
+            return;
+        }
+        _renderedPotionBanState = state;
+        foreach (Node child in _potionBanControls.GetChildren())
+        {
+            _potionBanControls.RemoveChild(child);
+            child.QueueFree();
+        }
+        foreach ((int slot, string title) in slots)
+        {
+            bool isBanned = banned.Contains(slot);
+            Button button = CreateButton(isBanned ? $"✕ {title}" : title, false);
+            button.CustomMinimumSize = new Vector2(0, SolverUiTokens.Size.ButtonHeight);
+            button.TooltipText = isBanned
+                ? "本场禁止使用这瓶药水，点击解除"
+                : "点击后本场不再考虑这瓶药水";
+            button.Disabled = disabled;
+            int captured = slot;
+            button.Pressed += () => OnPotionBanPressed(captured);
+            SolverUiTokens.ApplyButtonStyle(
+                button,
+                isBanned ? SolverButtonStyle.Danger : SolverButtonStyle.Secondary);
+            _potionBanControls.AddChild(button);
+        }
+    }
+
+    private static void OnPotionBanPressed(int slot)
+    {
+        CombatState? combat = CombatManager.Instance.DebugOnlyGetState();
+        if (combat == null || NGame.Instance is not { } host)
+            return;
+        SolverController.TogglePotionSlotBan(host, combat, slot);
     }
 
     public static void Hide()
@@ -1029,6 +1103,16 @@ internal static class SolverOverlay
         _letEscapeButton.Pressed += () => OnTheftPolicyPressed(SolverTheftPolicy.LetEscape);
         _theftPolicyControls.AddChild(_letEscapeButton);
         footer.AddChild(_theftPolicyControls);
+
+        _potionBanControls = new HFlowContainer
+        {
+            Name = "PotionBans",
+            Visible = false,
+            SizeFlagsHorizontal = Control.SizeFlags.ExpandFill,
+            MouseFilter = Control.MouseFilterEnum.Pass,
+        };
+        _potionBanControls.AddThemeConstantOverride("separation", SolverUiTokens.Spacing.Xs);
+        footer.AddChild(_potionBanControls);
 
         _recalculateButton = CreateButton("重新计算", false);
         _recalculateButton.CustomMinimumSize = new Vector2(112, SolverUiTokens.Size.ButtonHeight);


### PR DESCRIPTION
## 问题

全局的 `SolverPotionPolicy.RequireAtLeastOne`（设置里的「至少用一瓶」）无法表达**用哪一瓶**。玩家真正需要的粒度是按场、按瓶：把发光水留给 Boss，先把便宜的那瓶喝掉。

## 为什么先做「禁用」

三态设计是 自动 / 禁用 / 必用。本 PR 只做**禁用**，因为它是唯一不可能出错的那一半：

- 禁用只会让路线变差，**不会让路线变错**；
- 不需要退回逻辑，也不需要向玩家解释「为什么没做到」；
- 完全不涉及部署链路。

「必用」需要约束 + 达不成时退回 + 明确告知玩家，那是另一个 PR 的事。做完之后 `RequireAtLeastOne` 会退化成它的一个特例。

## 实现要点

**在分支生成处生效，不是事后过滤。** 条件加在 `Expansion` 与 `ParallelExpansion` 两个 expander 的药水循环里，被禁用的槽位从不进入搜索，不浪费搜索预算。

**按槽位而不是按药水 ID。** 仓库支持同名药水重复持有（`duplicate_potion_ids=true`），玩家带两瓶同样的药水时「用一瓶留一瓶」必须能表达。槽位在一场战斗内是稳定的，因为 `ConsumePotion` 只把该槽位置空、不重排。

**整体照抄 `SetTheftPolicy`**，包括最关键的一点：切换时清空 `ContinuationSource`。不清空的话，跨回合状态一致时会直接复用按旧约束算出的路线，表现就是「设置没生效」——这是我在另一个功能上排查了三轮才定位到的同一类症状，所以在代码注释里也写下了原因。部署中拒绝改动，与偷窃策略一致。

**UI**：覆盖层底部按槽位显示开关。footer 本身是 `HFlowContainer`，所以这里也用嵌套的 `HFlowContainer` 并占满一行——用 `HBoxContainer` 会变成一个不可换行的宽子节点，药水一多就把操作按钮顶出去。只在药水集合或禁用集合真正变化时重建子节点。可用为中性样式，只有玩家真正设置过的禁用才高亮。

## 可能需要 review 的取舍

1. **只按场生效，不写入设置文件。** 我认为「这场留着」和「永远别用」是两种不同的诉求，后者已经由全局策略覆盖。如果你希望有持久化的黑名单，是另一个层次的设计。
2. **UI 位置**。我放在了 footer 里偷窃策略旁边，因为那是现成的按场控件区。如果你觉得药水带更适合放在路线面板里，我可以挪。

## 验证

`dotnet build -c Release`：0 warning / 0 error。实机验证过：切换开关会触发重搜、被禁用的药水不再出现在路线里、`POTION_BAN_CHANGED` 日志正常。未运行 `tools/run-unattended-test.ps1`。

## 与其它 PR 的关系

与我同时提的另外三个 PR 相互独立，但在 `SearchPolicySnapshot.cs` / `SolverController.cs` / `CombatBeamSolver.cs` 上会有文本冲突（都是在同一处加字段）。合并顺序任意，我可以按你决定的顺序 rebase。
