### PR TITLE
第三方 Mod 替换被镜像的 OnPlay 时，停在声明过的不支持边界

### DIFF
--- a/src/Prediction/IncompatibleGameplayModException.cs
+++ b/src/Prediction/IncompatibleGameplayModException.cs
@@ -4,21 +4,23 @@ internal sealed class IncompatibleGameplayModException : NotSupportedException
 {
     public string ModId { get; }
     public string ModName { get; }
-    public string SubscriberType { get; }
+
+    /// <summary>What was found, e.g. a ModHelper subscriber type or a Harmony patch on a mirrored method.</summary>
+    public string Subject { get; }
+
+    /// <summary>Where it was found, e.g. <c>run</c> or <c>combat</c>.</summary>
     public string Scope { get; }
 
     public IncompatibleGameplayModException(
         string modId,
         string modName,
-        string subscriberType,
+        string subject,
         string scope)
-        : base(
-            $"Unsupported gameplay ModHelper {scope} subscriber {subscriberType} " +
-            $"from mod {DescribeMod(modName, modId)}.")
+        : base($"Unsupported gameplay {scope} extension {subject} from mod {DescribeMod(modName, modId)}.")
     {
         ModId = modId;
         ModName = modName;
-        SubscriberType = subscriberType;
+        Subject = subject;
         Scope = scope;
     }
 

--- a/src/Prediction/PredictionModHookSubscriberCapture.cs
+++ b/src/Prediction/PredictionModHookSubscriberCapture.cs
@@ -56,6 +56,7 @@ internal sealed class PredictionModHookSubscriberCapture
             ValidateSubscriber(subscriber, "run");
         foreach (AbstractModel subscriber in combatSubscribers)
             ValidateSubscriber(subscriber, "combat");
+        PredictionModPatchAudit.ValidateCardOnPlay(EnumerateAuditableCards(runState, combat));
 
         Dictionary<Player, int> maxHandSizes = [];
         foreach (Player player in combat.Players)
@@ -125,6 +126,24 @@ internal sealed class PredictionModHookSubscriberCapture
         return result;
     }
 
+    /// <summary>
+    /// Every card type the root can reach without in-combat generation. Generated card types are not knowable at
+    /// capture time, so they stay outside this audit.
+    /// </summary>
+    private static IEnumerable<CardModel> EnumerateAuditableCards(RunState runState, CombatState combat)
+    {
+        foreach (Player player in combat.Players)
+        {
+            foreach (CardModel card in player.PlayerCombatState?.AllCards ?? [])
+                yield return card;
+        }
+        foreach (Player player in runState.Players)
+        {
+            foreach (CardModel card in player.Deck.Cards)
+                yield return card;
+        }
+    }
+
     private static void ValidateSubscriber(
         AbstractModel subscriber,
         string scope)
@@ -144,7 +163,7 @@ internal sealed class PredictionModHookSubscriberCapture
             throw new IncompatibleGameplayModException(
                 modId,
                 mod.manifest.name ?? string.Empty,
-                type.FullName ?? type.Name,
+                $"ModHelper subscriber {type.FullName ?? type.Name}",
                 scope);
         }
         throw new PredictionUnsupportedException(

--- a/src/Prediction/PredictionModPatchAudit.cs
+++ b/src/Prediction/PredictionModPatchAudit.cs
@@ -1,0 +1,97 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Entities.Cards;
+using MegaCrit.Sts2.Core.GameActions.Multiplayer;
+using MegaCrit.Sts2.Core.Modding;
+using MegaCrit.Sts2.Core.Models;
+
+namespace CombatSolver;
+
+/// <summary>
+/// Root-capture guard against third-party Harmony patches that replace gameplay behavior the engine mirrors.
+/// </summary>
+/// <remarks>
+/// Mirrors read live model data, so third-party patches to canonical data (energy cost, dynamic vars, keywords,
+/// rarity) are followed automatically and are deliberately not audited. A replaced <see cref="CardModel.OnPlay"/>
+/// is different in kind: <c>CardOnPlayInferrer</c> reads the original, unpatched IL by design, and the
+/// bespoke mirrors are keyed on the vanilla card type. The engine therefore keeps executing the vanilla recipe it
+/// was written against and silently produces a route for a card the game no longer plays that way, which the
+/// project's "unknown semantics must fail explicitly" constraint forbids.
+/// </remarks>
+internal static class PredictionModPatchAudit
+{
+    private const string OnPlayName = "OnPlay";
+    private static readonly ConcurrentDictionary<Type, ForeignPatch?> CardOnPlayPatches = new();
+
+    private readonly record struct ForeignPatch(string ModId, string ModName, string Description);
+
+    /// <summary>
+    /// Throws when any card reachable from the captured root has a third-party patch on its mirrored OnPlay.
+    /// </summary>
+    /// <remarks>
+    /// This is a best-effort boundary: card types that only appear later through in-combat generation are not
+    /// visible at capture time and are not audited here.
+    /// </remarks>
+    public static void ValidateCardOnPlay(IEnumerable<CardModel> cards)
+    {
+        foreach (CardModel card in cards)
+        {
+            if (CardOnPlayPatches.GetOrAdd(card.GetType(), FindForeignOnPlayPatch) is not { } foreign)
+                continue;
+            throw new IncompatibleGameplayModException(
+                foreign.ModId,
+                foreign.ModName,
+                foreign.Description,
+                "combat");
+        }
+    }
+
+    private static ForeignPatch? FindForeignOnPlayPatch(Type cardType)
+    {
+        MethodInfo? onPlay = AccessTools.Method(
+            cardType,
+            OnPlayName,
+            [typeof(PlayerChoiceContext), typeof(CardPlay)]);
+        if (onPlay == null)
+            return null;
+
+        Patches? patches = Harmony.GetPatchInfo(onPlay);
+        if (patches == null)
+            return null;
+
+        foreach (Patch patch in patches.Prefixes
+                     .Concat(patches.Postfixes)
+                     .Concat(patches.Transpilers)
+                     .Concat(patches.Finalizers))
+        {
+            if (TryDescribeForeignPatch(patch, onPlay) is { } foreign)
+                return foreign;
+        }
+        return null;
+    }
+
+    private static ForeignPatch? TryDescribeForeignPatch(Patch patch, MethodInfo target)
+    {
+        Type? patchType = patch.PatchMethod.DeclaringType;
+        if (patchType == null)
+            return null;
+
+        var mod = AssemblyInfo.ModForType(patchType, out bool isBaseGame);
+        if (isBaseGame)
+            return null;
+        // Same policy as the ModHelper subscriber audit: mods that declare themselves gameplay-neutral are trusted.
+        if (mod?.manifest?.affectsGameplay is false)
+            return null;
+        if (mod?.manifest?.id is not { Length: > 0 } modId)
+            return null;
+        if (string.Equals(modId, Entry.ModId, StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        return new ForeignPatch(
+            modId,
+            mod.manifest.name ?? string.Empty,
+            $"Harmony patch {patchType.FullName}.{patch.PatchMethod.Name} on mirrored "
+            + $"{target.DeclaringType?.FullName}.{target.Name}");
+    }
+}


### PR DESCRIPTION
## 问题

引擎从不执行 `CardModel.OnPlay`：bespoke 镜像按**原版卡牌类型**分派，`CardOnPlayInferrer` 也刻意读取**未打补丁的原始 IL**（`GetOriginalIl()`）。这两个设计我都理解——后者如果读打过补丁的 IL，transpiler 会打乱模式识别。

但代价是：当其它 Mod 用 Harmony 替换某张牌的 `OnPlay` 时，这类改动在整条链路上都不可见，引擎会继续按它当初写的原版配方模拟，**静默给出一条这张牌早已不那么运作的路线**。

## 实测案例

某个平衡性 Mod 把预借时间重做为「0 费，对自己施加 3 层灾厄，获得 1(2) 能量」，用 `[HarmonyPrefix]` 替换 `BorrowedTime.OnPlay`。求解器的表现：

- 能量值本身读的是实机 `DynamicVars`，是对的；
- 但 `CardOnPlaySupport` 里那行 `Apply<BorrowedTimePower>(ExtraCost)` 仍然执行，导致本回合后续每张牌贵 1 费，净收益塌成 +1；
- 而 Mod 实际施加的 3 层 `DoomPower` 完全没有进入模拟，于是「回合结束时 HP ≤ 3 直接死亡」这条约束被丢掉，**在残血时会规划出必死的回合**。

**这是一类问题，不是一张卡。** 同一个 Mod 还重做了 `Stoke` / `Spite` / `Glow` / `Fuel` / `GuidingStar` 的 `OnPlay`，每一张都对应 `CardGenerationCardMirrors` / `BespokeCardMirrors` / `CardEffectSpecRegistry` 里的一处硬编码。

## 与项目自身约束的冲突

README 写着「运行时遇到尚未支持的新版本或第三方战斗语义时，求解器会明确停止在不支持边界，不会把未完成模拟误报为胜利」，`AGENTS.md` §1 也写着「未知语义必须显式失败或形成明确搜索边界」。但 `PredictionModHookSubscriberCapture.ValidateSubscriber` 只覆盖 RitsuLib `ModHelper` 订阅者，裸 Harmony 补丁不在雷达上——所以这里是静默算错，而不是停在边界。

## 改动

在根抓取时（`PredictionModHookSubscriberCapture.Capture`，现有的第三方 Mod 校验阶段）审计根可达的每个卡牌类型的 `OnPlay` 是否被第三方 Harmony 补丁替换，命中则抛 `IncompatibleGameplayModException`，沿用现有订阅者的放行策略（原版与 `affects_gameplay: false` 的 Mod 放行）。

**刻意不审计 canonical 数据**——耗能、动态变量、关键字、稀有度。镜像读的就是实机值，本来就会跟随，所以纯数值 Mod 完全不受影响，只有真正会算错的**行为替换**才停。这个区分是这个 PR 的主要价值：它不是「装了 Mod 就罢工」。

`IncompatibleGameplayModException` 的 `SubscriberType` 泛化为 `Subject`，使同一个异常既能描述订阅者也能描述补丁。

## 已知边界

- 战斗中动态生成的卡牌类型在抓取时不可知，不在本次审计范围内。
- powers / relics / monster moves 的镜像同理尚未纳入。后续可以用现成的 `MethodMirrorRegistryDescriptor` 清单统一枚举——那是它已经维护的机器可读镜像清单，我没有在本 PR 里动它，因为想先确认方向。

## 取舍

**只合这个 PR，装了这类 Mod 的玩家会完全失去求解器。** 这比静默算错诚实，但不可用。

我认为它应该和一个**公开的镜像注册入口**配对，让改了行为的 Mod 能把自己的语义补回来。一个最小设想：

```csharp
// 公开、稳定的最小面，避免暴露 SimulatedCombatState / PredictedCard 全貌
public interface ICardOnPlayEffects
{
    void GainEnergy(int amount);
    void ApplyPowerToOwner(Type powerType, int amount);
    void DrawCards(int count);
    void AttackTarget(decimal damage, int hitCount);
    void Unsupported(string reason);   // 显式退回边界
}

public static class CombatSolverMirrors
{
    public static void RegisterCardOnPlay(Type cardType, Action<CardModel, ICardOnPlayEffects> mirror);
}
```

注册在 Mod 初始化阶段完成，正好落在 `MethodMirrorRegistry`「所有注册必须早于首次查询」的现有约束内；没注册的补丁仍然走本 PR 的边界。

只是初步讨论，它需要确定对外暴露多少模拟层类型才能做，等待后续讨论。

## 验证

`dotnet build -c Release`：0 warning / 0 error。未运行 `tools/run-unattended-test.ps1`。
