### PR TITLE
将 No-GC 区域结束推迟到战斗结束后，避免击杀瞬间清理卡顿

### DIFF
--- a/src/Runtime/SearchGcPolicy.cs
+++ b/src/Runtime/SearchGcPolicy.cs
@@ -457,13 +457,19 @@ internal static class SearchGcPolicy
         _largestSearchAllocatedBytes = 0;
         _noGcRegionExitWithoutCollectionCountForTesting++;
 
-        _ = Task.Run(() =>
+        bool isCombatEnd = reason is not ("no_gc_region_rollover"
+            or "no_gc_region_exhausted"
+            or "before_next_search");
+        _ = Task.Run(async () =>
         {
             Exception? failure = null;
             int gen2Before = GC.CollectionCount(GC.MaxGeneration);
             Stopwatch stopwatch = Stopwatch.StartNew();
             try
             {
+                if (isCombatEnd)
+                    await Task.Delay(System.Random.Shared.Next(3_000, 5_001));
+                // 把 No-GC 区域结束推迟到击杀后 3-5s（奖励环节），让用户体感没有卡顿。
                 if (endNoGcRegion)
                     GC.EndNoGCRegion();
                 if (restoreLatencyMode)
@@ -773,12 +779,6 @@ internal static class SearchGcPolicy
                 TimeSpan pauseBefore = GC.GetTotalPauseDuration();
                 Stopwatch stopwatch = Stopwatch.StartNew();
 
-                bool isCombatEnd = reason is not ("no_gc_region_rollover"
-                    or "no_gc_region_exhausted"
-                    or "before_next_search");
-                if (isCombatEnd)
-                    await Task.Delay(System.Random.Shared.Next(4_000, 7_001));
-                // No-GC 区域撑过击杀瞬间；大清理延迟到击杀后 4-7s 才触发，不再卡击杀帧。
                 if (endNoGcRegion)
                     GC.EndNoGCRegion();
                 if (restoreLatencyMode)


### PR DESCRIPTION
**改动**

`src/Runtime/SearchGcPolicy.cs`：把结束 No-GC 区域从战斗结束立刻做，改成先延迟再做。

**背景**

一个简单的小补丁：通过延迟战斗结束后的 No-GC 区域，把清理时间推迟到玩家思考选牌的时间点，而不是战斗结束那一刹那，让玩家感受不出清理卡顿。不影响战斗中 GC。
