### PR TITLE
在 UI 显示已查阅世界线计数

### DIFF
--- a/src/Runtime/SolverController.cs
+++ b/src/Runtime/SolverController.cs
@@ -89,6 +89,7 @@ internal static class SolverController
     public static bool StopFullAutoOnWorseRecalculation => _stopFullAutoOnWorseRecalculation;
     public static SolverTheftPolicy? TheftPolicy => _combat.TheftPolicy;
     internal static SolverResult? CurrentResultForBugReport => _combat.LatestResult ?? _combat.ContinuationSource;
+    internal static long ExploredNodesTotal => _combat.ExploredNodesTotal;
     internal static string ReplanAuditForBugReport => DescribeReplanAudit();
     internal static string BuildBugReportDescription(string playerDescription)
         => CombatBugReportDescription.AppendAutomaticClassification(
@@ -387,6 +388,7 @@ internal static class SolverController
         CancelSearch();
         _combat.State = state;
         _combat.LatestResult = result;
+        _combat.ExploredNodesTotal += result.ShortExpandedNodes + result.DeepExpandedNodes;
         _combat.LatestStamp = stamp;
         _combat.ContinuationSource = result;
         _combat.SearchesStarted++;
@@ -1726,6 +1728,7 @@ internal static class SolverController
         result.MainThreadFramesOver50Milliseconds = search.FramesOver50Milliseconds;
         result.MainThreadFramesOver100Milliseconds = search.FramesOver100Milliseconds;
         _combat.LatestResult = result;
+        _combat.ExploredNodesTotal += result.ShortExpandedNodes + result.DeepExpandedNodes;
         _combat.LatestStamp = searchedStamp;
         if (UnattendedTestRunner.IsActive)
             LastCompletedResultForTesting = result;

--- a/src/Runtime/SolverControllerSessions.cs
+++ b/src/Runtime/SolverControllerSessions.cs
@@ -40,6 +40,7 @@ internal sealed class SolverCombatSession
     public Dictionary<(int Slot, string PotionId), SolverPotionDirective> PotionDirectives { get; } = [];
     public Dictionary<ReplanCause, int> ReplanCounts { get; } = [];
     public int SearchesStarted { get; set; }
+    public long ExploredNodesTotal { get; set; }
     public int ContinuationsReused { get; set; }
     public IReadOnlyList<string> LastContinuationDifferences { get; set; } = [];
     public int? LastSolverDeployedTurn { get; set; }

--- a/src/Search/CombatSearchCoordinator.cs
+++ b/src/Search/CombatSearchCoordinator.cs
@@ -15,6 +15,31 @@ internal static class CombatSearchCoordinator
         SolverSearchProfile shortProfile = policy.ShortProfile;
         if (policy.ShortBudgetOverrideMilliseconds is { } shortBudget)
             shortProfile = shortProfile with { SoftTimeBudgetMilliseconds = shortBudget };
+        // 让“已查阅世界线”跨主搜与药水审计单调递增：给进度回调包一层累计偏移，
+        // 每个新求解器从上次累计处继续，避免展示层在审计接手时归零。
+        if (progressCallback != null)
+        {
+            long sessionBase = 0;
+            int lastExpanded = 0;
+            Action<SolverProgress> original = progressCallback;
+            progressCallback = p =>
+            {
+                if (p.ExpandedNodes < lastExpanded)
+                    sessionBase += lastExpanded;
+                lastExpanded = p.ExpandedNodes;
+                original(new SolverProgress(
+                    p.StartTurnNumber,
+                    p.CurrentTurnNumber,
+                    p.CompletedTurnLayers,
+                    p.PlayDepth,
+                    checked((int)Math.Min(int.MaxValue, sessionBase + p.ExpandedNodes)),
+                    p.MaxNodes,
+                    p.FrontierNodes,
+                    p.EndedNodes,
+                    p.ElapsedMilliseconds,
+                    p.Phase));
+            };
+        }
         if (policy.ForceShortOnly)
         {
             SolverResult shortResult = new CombatBeamSolver(

--- a/src/UI/SolverOverlay.cs
+++ b/src/UI/SolverOverlay.cs
@@ -39,6 +39,7 @@ internal static class SolverOverlay
     private static Label? _deathOutcomeLabel;
     private static Label? _potionOutcomeLabel;
     private static Label? _hpOutcomeLabel;
+    private static Label? _explorationLabel;
     private static RichTextLabel? _detailsText;
     private static SolverDetailsButton? _detailsButton;
     private static Button? _recalculateButton;
@@ -199,6 +200,7 @@ internal static class SolverOverlay
             _searchProgressBar.MaxValue = Math.Max(1, progress.MaxNodes);
             _searchProgressBar.Value = Math.Clamp(progress.ExpandedNodes, 0, progress.MaxNodes);
         }
+        UpdateExplorationLabel(progress.ExpandedNodes);
         RefreshControls();
     }
 
@@ -234,6 +236,7 @@ internal static class SolverOverlay
             _hpOutcomeLabel.Visible = false;
         if (_deathOutcomeLabel != null)
             _deathOutcomeLabel.Visible = false;
+        UpdateExplorationLabel(0);
         for (int index = 0; index < SolverWeights.UiTurnRows; index++)
         {
             SetRouteRowVisible(index, index < 3);
@@ -321,6 +324,8 @@ internal static class SolverOverlay
             _hpOutcomeLabel.Text = snapshot.HpOutcomeText;
             _hpOutcomeLabel.AddThemeColorOverride("font_color", snapshot.ProjectedBattleHpLost > 0 ? Danger : Success);
         }
+        if (_explorationLabel != null)
+            _explorationLabel.Text = $"已查阅 {SolverController.ExploredNodesTotal:N0} 个世界线";
         if (_detailsButton != null)
             _detailsButton.Visible = true;
         if (_detailsText != null)
@@ -871,6 +876,13 @@ internal static class SolverOverlay
         _potionStrategyButton.Pressed += TogglePotionStrategy;
         header.AddChild(_potionStrategyButton);
 
+        _explorationLabel = CreateTextLabel(
+            "已查阅 0 个世界线",
+            SolverUiTokens.Type.Caption,
+            SolverUiTokens.Palette.TextSecondary,
+            FontType.Regular);
+        _explorationLabel.SizeFlagsHorizontal = Control.SizeFlags.ShrinkEnd;
+        header.AddChild(_explorationLabel);
         _settingsButton = CreateHeaderButton("设置", 54);
         _settingsButton.Pressed += ToggleSettings;
         if (SolverUiTokens.IsLightTheme)
@@ -893,6 +905,11 @@ internal static class SolverOverlay
         return header;
     }
 
+    private static void UpdateExplorationLabel(long liveExpanded)
+    {
+        if (_explorationLabel != null)
+            _explorationLabel.Text = $"已查阅 {SolverController.ExploredNodesTotal + liveExpanded:N0} 个世界线";
+    }
     private static Control CreateFeedbackBanner()
     {
         _feedbackBanner = new PanelContainer


### PR DESCRIPTION
**改动**

在 UI 的求解器面板头部（折叠/展开均显示）添加"已查阅 N 个世界线"计数：显示本场战斗求解器累计评估的候选战局走向数。世界线的语义：一条从当前局面出发、被完整模拟到战斗胜利或者失败，亦或者被搜索边界截断的完整战斗发展路径，即求解器评估过的"一种可能的战局走向"。
