### PR TITLE
按 Boss 战后实际留下多少血来计权战损，并修正单 Boss 收尾层的判定

### DIFF
--- a/src/Runtime/CombatRootSnapshot.cs
+++ b/src/Runtime/CombatRootSnapshot.cs
@@ -31,7 +31,8 @@ internal sealed class CombatRootSnapshot
     public CombatSide CurrentSide { get; }
     public PlayerTurnPhase PlayerPhase { get; }
     public RoomType? EncounterRoomType { get; }
-    public bool IsActEndingBoss { get; }
+    public BossHpRelief BossHpRelief { get; }
+    public bool IsActEndingBoss => BossHpRelief != BossHpRelief.None;
     public double CaptureElapsedMilliseconds { get; }
     public int CapturedCardCount { get; }
     public int CapturedPowerCount { get; }
@@ -59,7 +60,7 @@ internal sealed class CombatRootSnapshot
         CombatSide currentSide,
         PlayerTurnPhase playerPhase,
         RoomType? encounterRoomType,
-        bool isActEndingBoss,
+        BossHpRelief bossHpRelief,
         double captureElapsedMilliseconds,
         int capturedCardCount,
         int capturedPowerCount,
@@ -86,7 +87,7 @@ internal sealed class CombatRootSnapshot
         CurrentSide = currentSide;
         PlayerPhase = playerPhase;
         EncounterRoomType = encounterRoomType;
-        IsActEndingBoss = isActEndingBoss;
+        BossHpRelief = bossHpRelief;
         CaptureElapsedMilliseconds = captureElapsedMilliseconds;
         CapturedCardCount = capturedCardCount;
         CapturedPowerCount = capturedPowerCount;
@@ -190,7 +191,7 @@ internal sealed class CombatRootSnapshot
             state.CurrentSide,
             playerState.Phase,
             state.Encounter?.RoomType,
-            ActEndingBossPolicy.IsRecoveryFight(state),
+            ActEndingBossPolicy.ResolveHpRelief(state),
             stopwatch.Elapsed.TotalMilliseconds,
             cardCount,
             powerCount,

--- a/src/Runtime/SolverDiagnostics.cs
+++ b/src/Runtime/SolverDiagnostics.cs
@@ -188,6 +188,7 @@ internal static class SolverDiagnostics
             .Append(" death_turn=").Append(result.DeathTurn?.ToString() ?? "-")
             .Append(" only_death_routes=").Append(result.OnlyDeathRoutesFound)
             .Append(" act_ending_boss=").Append(result.IsActEndingBoss)
+            .Append(" boss_hp_relief=").Append(result.BossHpRelief)
             .Append(" engine_risk=").Append(result.Snapshot.HasRisk)
             .Append(" unsupported_intent=").Append(result.Forecast.HasUnsupportedIntent)
             .Append(" modeled_damage_exact=").Append(result.Forecast.IsExactForModeledDamage)

--- a/src/Search/ActEndingBossPolicy.cs
+++ b/src/Search/ActEndingBossPolicy.cs
@@ -4,18 +4,41 @@ using MegaCrit.Sts2.Core.Runs;
 
 namespace CombatSolver;
 
+/// <summary>
+/// How much the HP this fight costs actually matters to the run.
+/// </summary>
+internal enum BossHpRelief
+{
+    /// <summary>Normal fight: HP carries straight into the next one and is weighted in full.</summary>
+    None,
+
+    /// <summary>Clearing the act restores most of the damage taken, so HP spent here is largely refunded.</summary>
+    ActClearHeal,
+
+    /// <summary>Nothing follows this fight, so only surviving it matters.</summary>
+    RunEnding,
+}
+
 internal static class ActEndingBossPolicy
 {
-    public static bool IsRecoveryFight(CombatState combatState)
+    public static BossHpRelief ResolveHpRelief(CombatState combatState)
     {
         if (combatState.Encounter?.RoomType != RoomType.Boss)
-            return false;
+            return BossHpRelief.None;
 
         RunState runState = combatState.RunState as RunState
             ?? throw new InvalidOperationException("Boss 战没有可识别的 RunState。");
         if (runState.CurrentActIndex < runState.Acts.Count - 1)
-            return true;
+            return BossHpRelief.ActClearHeal;
 
-        return runState.Act.SecondBossEncounter?.Id == combatState.Encounter.Id;
+        // Final act. A single boss is the run's last fight; when the act has two, only the second one is,
+        // and HP carries from the first into it exactly like a normal fight.
+        return runState.Act.SecondBossEncounter is not { } second
+            || second.Id == combatState.Encounter.Id
+                ? BossHpRelief.RunEnding
+                : BossHpRelief.None;
     }
+
+    public static bool IsRecoveryFight(CombatState combatState)
+        => ResolveHpRelief(combatState) != BossHpRelief.None;
 }

--- a/src/Search/CombatBeamSolver.FinalPlanOrdering.cs
+++ b/src/Search/CombatBeamSolver.FinalPlanOrdering.cs
@@ -8,12 +8,34 @@ internal sealed partial class CombatBeamSolver
         bool enforcePotionDirectives,
         bool renewablePotionShapedRock,
         SolverTheftPolicy? theftPolicy,
+        BossHpRelief bossHpRelief,
         PotionFreePolicyBaseline? potionFreePolicyBaseline,
         int initialPlayerMaxHp,
         SearchDiagnosticsSink diagnostics,
         bool detailedDiagnostics,
         BattleDamageSnapshot battleDamage)
     {
+        /// <summary>
+        /// Quarters of a normal fight's HP weight. A boss whose act clear refunds most of the damage is worth a
+        /// quarter; the run's last fight is worth nothing beyond surviving it.
+        /// </summary>
+        private readonly int _hpWeightQuarters = bossHpRelief switch
+        {
+            BossHpRelief.RunEnding => 0,
+            BossHpRelief.ActClearHeal => 1,
+            _ => 4,
+        };
+
+        /// <summary>
+        /// The HP a potion must save to be worth spending, scaled by how much HP is worth in this fight. When HP
+        /// buys nothing, no amount of saved HP justifies a potion and only the win/lose escape in
+        /// <see cref="PotionUsePolicy.IsEligible"/> can still admit one.
+        /// </summary>
+        private int ScalePotionCost(int strategicHpCost)
+            => _hpWeightQuarters == 0
+                ? int.MaxValue / 4
+                : strategicHpCost * 4 / _hpWeightQuarters;
+
         public FinalPlanSelection Select(
             IReadOnlyList<(SearchNode Node, SimulationSnapshot Snapshot, RouteAnnotations Annotations)> evaluated,
             int initialHp,
@@ -163,7 +185,7 @@ internal sealed partial class CombatBeamSolver
                          candidate.EffectivePotionPolicy,
                          candidate.OptionalPotionCount,
                          candidate.Snapshot.AutomaticPotionUseCount,
-                         candidate.OptionalPotionStrategicCost,
+                         ScalePotionCost(candidate.OptionalPotionStrategicCost),
                          potionFreeWon,
                          potionFreeStrategicHpDeficit,
                          anyRouteWon,
@@ -180,11 +202,17 @@ internal sealed partial class CombatBeamSolver
                         potionFreePlayerHp,
                         candidate.Snapshot.PlayerHp))
                 .OrderByDescending(candidate => candidate.Features.AllEnemiesDead)
+                // Survival used to be implied by the HP deficit being maximal on a death route. Once HP can be
+                // weighted down to nothing it has to be stated, or a run-ending boss would rank a lethal route.
+                .ThenBy(candidate => candidate.Snapshot.PlayerDead
+                    || candidate.Snapshot.ProjectedPlayerHp <= 0
+                        ? 1
+                        : 0)
                 .ThenBy(candidate => theftPolicy == SolverTheftPolicy.PreserveResources
                     ? candidate.Features.OutstandingStolenResource
                     : 0)
-                .ThenBy(candidate => candidate.PolicyHpDeficit)
-                .ThenBy(candidate => candidate.HealthResourceCost)
+                .ThenBy(candidate => candidate.PolicyHpDeficit * _hpWeightQuarters)
+                .ThenBy(candidate => candidate.HealthResourceCost * _hpWeightQuarters)
                 .ThenByDescending(candidate => candidate.Features.LongTermResourceValue)
                 .ThenBy(candidate => candidate.Features.AngerCopiesGenerated)
                 .ThenBy(candidate => CombatBeamSolver.PolicyBoundaryRank(candidate.Features.BoundaryReason))
@@ -211,7 +239,7 @@ internal sealed partial class CombatBeamSolver
                           candidate.EffectivePotionPolicy,
                           candidate.OptionalPotionCount,
                           candidate.Snapshot.AutomaticPotionUseCount,
-                          candidate.OptionalPotionStrategicCost,
+                          ScalePotionCost(candidate.OptionalPotionStrategicCost),
                           potionFreeWon,
                           potionFreeStrategicHpDeficit,
                           anyRouteWon,

--- a/src/Search/CombatBeamSolver.Phases.cs
+++ b/src/Search/CombatBeamSolver.Phases.cs
@@ -703,6 +703,7 @@ internal sealed partial class CombatBeamSolver
             DeathTurn = annotations.DeathTurn,
             OnlyDeathRoutesFound = onlyDeathRoutesFound,
             IsActEndingBoss = _isActEndingBoss,
+            BossHpRelief = _bossHpRelief,
             Elapsed = stopwatch.Elapsed,
             Continuations = continuations,
         };

--- a/src/Search/CombatBeamSolver.cs
+++ b/src/Search/CombatBeamSolver.cs
@@ -46,6 +46,7 @@ internal sealed partial class CombatBeamSolver(
     private readonly int _startTurnNumber = root.StartTurnNumber;
     private readonly int _initialEnemyCount = root.Enemies.Count;
     private readonly bool _isActEndingBoss = root.IsActEndingBoss;
+    private readonly BossHpRelief _bossHpRelief = root.BossHpRelief;
     private readonly bool _detailedDiagnostics = policy.DetailedDiagnostics;
     private readonly int? _maximumPotionUses = maximumPotionUses;
     private readonly IReadOnlyList<PlanAction> _fixedPrefixActions = fixedPrefixActions ?? [];
@@ -77,6 +78,7 @@ internal sealed partial class CombatBeamSolver(
         _enforcePotionDirectives,
         root.HasRenewablePotionShapedRock,
         _theftPolicy,
+        _bossHpRelief,
         potionFreePolicyBaseline,
         root.InitialPlayerMaxHp,
         policy.Diagnostics,

--- a/src/Search/CombatPlan.cs
+++ b/src/Search/CombatPlan.cs
@@ -590,6 +590,7 @@ internal sealed class SolverResult
     public required int? DeathTurn { get; init; }
     public required bool OnlyDeathRoutesFound { get; init; }
     public required bool IsActEndingBoss { get; init; }
+    public required BossHpRelief BossHpRelief { get; init; }
     public required TimeSpan Elapsed { get; init; }
     public required IReadOnlyList<CachedContinuation> Continuations { get; init; }
     public bool WasReused { get; init; }
@@ -704,6 +705,7 @@ internal sealed class SolverResult
             DeathTurn = DeathTurn,
             OnlyDeathRoutesFound = OnlyDeathRoutesFound,
             IsActEndingBoss = IsActEndingBoss,
+            BossHpRelief = BossHpRelief,
             Elapsed = TimeSpan.Zero,
             Continuations = Continuations.Where(item => item.StartTurnNumber > cached.StartTurnNumber).ToList(),
             WasReused = true,


### PR DESCRIPTION
## 问题

`ActEndingBossPolicy.IsRecoveryFight` 对两种「打完就不再需要血」的情形给出了相反的结论：

```csharp
return runState.Act.SecondBossEncounter?.Id == combatState.Encounter.Id;
```

最后一层只有一个 Boss 时 `SecondBossEncounter` 为 `null`，整个表达式恒为 `false` —— **「打赢就通关」的那场仗，血量仍按全额计价**，求解器会为了省血放弃更稳的路线。而双 Boss 的第二个反而判为 `true`。

## 改动

三态 `BossHpRelief` 取代布尔：

| 值 | 场合 | 血量权重 |
|---|---|---|
| `ActClearHeal` | 非最终层 Boss | 1/4（过关回复大部分战损，进阶 2 及以上） |
| `RunEnding` | 最终层唯一 Boss，或双 Boss 的第二个 | 0（只要活着） |
| `None` | 其余，含双 Boss 的第一个 | 全额（血原样带进第二场） |

计权作用在 `PolicyHpDeficit`、`HealthResourceCost` 两条排序轴，以及药水机会成本 `ScalePotionCost` —— 一场血不值钱的仗里，省下的血不该再成为交药的理由。

血量权重能降到 0 之后，「活着」不再能由「战损最大」隐含表达，所以排序里显式加了一条生存轴；否则 `RunEnding` 的 Boss 战可能把致死路线排在最前。

`IsRecoveryFight` 保留为 `ResolveHpRelief() != None`，现有调用点行为不变（除上述单 Boss 修正）。

## 备注

本 PR 与 #15 及另两个拆分 PR 相互独立，可单独合并。若与它们一同合并，`CombatBeamSolver.FinalPlanOrdering.cs` 会有少量文本冲突，建议先合本 PR。