### PR TITLE
把同一次搜索里的备选用药路线一起报出来，省掉反复重算

### DIFF
--- a/src/Runtime/SolverDiagnostics.cs
+++ b/src/Runtime/SolverDiagnostics.cs
@@ -184,6 +184,10 @@ internal static class SolverDiagnostics
             .Append(" potion_hp_saved=").Append(result.PotionHpSaved)
             .Append(" potion_hp_required=").Append(result.PotionHpRequired)
             .Append(" potion_branches_rejected=").Append(result.PotionBranchesRejected)
+            .Append(" world_lines=").Append(string.Join(
+                ",",
+                result.WorldLines.Select(line =>
+                    $"{(line.PotionCount == 0 ? "-" : string.Join('+', line.PotionTitles))}:{line.HpLost}")))
             .Append(" theft_policy=").Append(result.TheftPolicy?.ToString() ?? "-")
             .Append(" outstanding_stolen_resource=").Append(result.OutstandingStolenResource)
             .Append(" elapsed_ms=").Append(result.Elapsed.TotalMilliseconds.ToString("F0"))

--- a/src/Search/CombatBeamSolver.FinalPlanOrdering.cs
+++ b/src/Search/CombatBeamSolver.FinalPlanOrdering.cs
@@ -24,6 +24,9 @@ internal sealed partial class CombatBeamSolver
         private int ScalePotionCost(int strategicHpCost)
             => PotionUsePolicy.SmartRequiredHpSaved(strategicHpCost, bossHpRelief);
 
+        /// <summary>Distinct potion sets reported as alternatives. Enough to compare, few enough to read.</summary>
+        private const int MaximumWorldLines = 6;
+
         public FinalPlanSelection Select(
             IReadOnlyList<(SearchNode Node, SimulationSnapshot Snapshot)> evaluated,
             int initialHp,
@@ -264,6 +267,30 @@ internal sealed partial class CombatBeamSolver
                         : "本场药水策略没有可执行路线。");
             }
             var selectedCandidate = selected[0];
+            // Every distinct potion set already present in the final candidate set, so the player can see what
+            // spending or holding a specific bottle is worth without paying for another full search.
+            List<RouteWorldLine> worldLines = [];
+            string SelectedPotionKey(int index) => string.Join(
+                '+',
+                selected[index].Node.Actions
+                    .Where(action => action.Kind == PlanActionKind.UsePotion)
+                    .Select(action => action.PotionTitle)
+                    .OrderBy(title => title, StringComparer.Ordinal));
+            string selectedKey = SelectedPotionKey(0);
+            HashSet<string> seenPotionKeys = [];
+            int firstPotionFreeIndex = -1;
+            for (int index = 0; index < selected.Count; index++)
+            {
+                string key = SelectedPotionKey(index);
+                if (key.Length == 0 && firstPotionFreeIndex < 0)
+                    firstPotionFreeIndex = index;
+                if (!seenPotionKeys.Add(key) || worldLines.Count >= MaximumWorldLines)
+                    continue;
+                worldLines.Add(BuildWorldLine(index, key));
+            }
+            // The no-potion line is the one comparison a player always wants, so keep it even if the cap hit first.
+            if (firstPotionFreeIndex >= 0 && !worldLines.Any(line => line.PotionCount == 0))
+                worldLines.Add(BuildWorldLine(firstPotionFreeIndex, string.Empty));
             int potionBranchesRejected = policyCandidates.Count(candidate => candidate.PotionCount > 0)
                 - policyEligibleCandidates.Count(candidate => candidate.PotionCount > 0);
             int potionHpSaved = selectedCandidate.PotionCount == 0
@@ -301,7 +328,19 @@ internal sealed partial class CombatBeamSolver
                     selectedCandidate.Score),
                 potionBranchesRejected,
                 potionHpSaved,
-                potionHpRequired);
+                potionHpRequired,
+                worldLines);
+
+            RouteWorldLine BuildWorldLine(int index, string key) => new(
+                selected[index].Node.Actions
+                    .Where(action => action.Kind == PlanActionKind.UsePotion)
+                    .Select(action => action.PotionTitle)
+                    .OrderBy(title => title, StringComparer.Ordinal)
+                    .ToArray(),
+                selected[index].StrategicHpDeficit,
+                selected[index].PotionCount,
+                selected[index].Features.AllEnemiesDead,
+                string.Equals(key, selectedKey, StringComparison.Ordinal));
         }
     }
 

--- a/src/Search/CombatBeamSolver.Models.cs
+++ b/src/Search/CombatBeamSolver.Models.cs
@@ -304,7 +304,8 @@ internal sealed partial class CombatBeamSolver
         FinalPlanCandidate Candidate,
         int PotionBranchesRejected,
         int PotionHpSaved,
-        int PotionHpRequired);
+        int PotionHpRequired,
+        IReadOnlyList<RouteWorldLine> WorldLines);
 
     private sealed record PendingTurnOutcome(
         SearchNode Node,

--- a/src/Search/CombatBeamSolver.Phases.cs
+++ b/src/Search/CombatBeamSolver.Phases.cs
@@ -635,6 +635,7 @@ internal sealed partial class CombatBeamSolver
                 ExplicitPotionCount = annotatedActions.Count(action =>
                     action.Kind == PlanActionKind.UsePotion),
                 PotionHpSaved = potionHpSaved,
+                WorldLines = ordering.WorldLines,
                 PotionHpRequired = potionHpRequired,
                 PotionBranchesRejected = potionBranchesRejected,
                 TheftPolicy = _theftPolicy,

--- a/src/Search/CombatPlan.cs
+++ b/src/Search/CombatPlan.cs
@@ -1201,6 +1201,21 @@ internal sealed record SelectedSearchPlan(
     int ActionCount,
     double Score);
 
+/// <summary>
+/// One alternative the search already found: the best route among those using exactly this set of potions.
+/// </summary>
+/// <remarks>
+/// These come from the final candidate set of the search that just ran, so each line is the best route the beam
+/// <em>kept</em> for that potion set, not the best route that exists for it. Treat the numbers as a floor on how
+/// well that world line can go, not as an authoritative comparison.
+/// </remarks>
+internal sealed record RouteWorldLine(
+    IReadOnlyList<string> PotionTitles,
+    int HpLost,
+    int PotionCount,
+    bool Won,
+    bool IsSelected);
+
 /// <summary>最终路线的只读标量摘要；不持有 CombatPredictionSimulator。</summary>
 internal sealed record SolverSnapshot(
     bool HasRisk,
@@ -1355,6 +1370,7 @@ internal sealed class SolverResult
     public required int ExplicitPotionCount { get; init; }
     public int ProjectedBattlePotionCount => BattlePotionsUsedSoFar + PotionCount;
     public required int PotionHpSaved { get; internal set; }
+    public required IReadOnlyList<RouteWorldLine> WorldLines { get; init; }
     public required int PotionHpRequired { get; internal set; }
     public required int PotionBranchesRejected { get; init; }
     public required SolverTheftPolicy? TheftPolicy { get; init; }
@@ -1483,6 +1499,7 @@ internal sealed class SolverResult
             PotionCount = remainingPotionCount,
             ExplicitPotionCount = remainingExplicitPotionCount,
             PotionHpSaved = remainingPotionCount == 0 ? 0 : PotionHpSaved,
+            WorldLines = WorldLines,
             PotionHpRequired = remainingPotionCost,
             PotionBranchesRejected = 0,
             TheftPolicy = TheftPolicy,

--- a/src/UI/SolverOverlaySnapshot.cs
+++ b/src/UI/SolverOverlaySnapshot.cs
@@ -378,6 +378,15 @@ internal sealed record SolverOverlaySnapshot(
         return $"{source}：{effect} {string.Join('、', choice.Cards.Select(card => card.Title))}";
     }
 
+    private static string FormatWorldLine(RouteWorldLine line)
+    {
+        string label = line.PotionCount == 0
+            ? "不交药"
+            : string.Join('+', line.PotionTitles);
+        string body = $"{label} 掉 {line.HpLost}{(line.Won ? string.Empty : "（未确认胜利）")}";
+        return line.IsSelected ? $"[b]{body}[/b]" : body;
+    }
+
     private static string BuildDetails(
         SolverResult result,
         int displayedTurn,
@@ -397,6 +406,14 @@ internal sealed record SolverOverlaySnapshot(
             $"[color={SolverUiTokens.Palette.TextMutedHex}]防守[/color]  本回合最高可起防 {result.MaxBlockByTurn.GetValueOrDefault(displayedTurn)}  │  路线实际起防 {result.ActualBlockByTurn.GetValueOrDefault(displayedTurn)}  │  卖血 {result.SoldHpByTurn.GetValueOrDefault(displayedTurn)}",
             $"[color={SolverUiTokens.Palette.TextMutedHex}]边界[/color]  {BoundaryText(result.BoundaryReason)}  │  停止洗牌分支 {result.ShuffleBranchesPruned}  │  不可避免战损 {result.UnavoidableHpLost}",
         ];
+        if (result.WorldLines.Count > 1)
+        {
+            detailLines.Insert(
+                4,
+                $"[color={SolverUiTokens.Palette.TextMutedHex}]世界线[/color]  " +
+                string.Join("  │  ", result.WorldLines.Select(FormatWorldLine)) +
+                "  （同一次搜索的候选，非精确重算）");
+        }
         if (result.TheftPolicy is { } theftPolicy)
         {
             detailLines.Insert(


### PR DESCRIPTION
## 问题

玩家常需要的信息不是「最优路线是什么」，而是「只交这瓶药能省多少血」「不交药要多花多少血」。现在每问一次都要改设置再从头搜一遍 —— 而答案其实**已经在刚刚那次搜索的候选集里**。

## 改动

从最终候选集里按「用了哪几瓶药」分组，每组取全序里最靠前的那条，最多 6 条，展示在详情行并标出当前选中的是哪条。

不交药的那条永远保留 —— 这是玩家最常要的对照，不能被上限挤掉。

**零额外搜索成本**：只读已有候选，不新建节点、不持有 simulator。

## 诚实性

每条线是 beam **保留下来**的该用药组合的最优路线，不是该组合真正的最优路线。这一点写在 `RouteWorldLine` 的注释里，UI 上也标了「同一次搜索的候选，非精确重算」。数字应当读作那条世界线的下限，而不是权威对比。

## 备注

由 #17 拆分而来（#17 已关闭）。与 #21、#22、#15 相互独立，可单独合并。