### PR TITLE
feat: 搜索中实时展示当前最优，停止时提交最优

### DIFF
--- a/src/Runtime/SolverController.cs
+++ b/src/Runtime/SolverController.cs
@@ -68,7 +68,7 @@ internal static class SolverController
     private static CancellationTokenSource _combatDeferredOperationCancellation = new();
 
     public static bool IsSearching
-        => _search != null
+        => _search is { StopRequestedByUser: false }
            || _deferredSearchCts != null
            || PlayerTurnSetupCoordinator.IsSearching;
     public static bool IsDeploying => _deployment != null;
@@ -928,7 +928,8 @@ internal static class SolverController
                         battleDamage,
                         searchPolicy,
                         token,
-                        progress => PublishSearchProgress(search, progress));
+                        progress => PublishSearchProgress(search, progress),
+                        best => PublishSearchBest(search, best));
                 }
                 finally
                 {
@@ -1188,18 +1189,29 @@ internal static class SolverController
         if (!IsSearching)
             return;
 
-        bool controllerSearchCanceled = _search != null || _deferredSearchCts != null;
-        int? generation = _search?.Generation;
+        SolverSearchSession? search = _search;
+        bool controllerSearchCanceled = search != null || _deferredSearchCts != null;
+        int? generation = search?.Generation;
         _combat.FullAutoEnabled = false;
         _combat.AutomaticSearchPaused = true;
         CancelDeferredSearch();
-        CancelSearch();
+        if (search != null)
+        {
+            search.StopResult = Volatile.Read(ref search.BestResult);
+            search.StopRequestedByUser = true;
+            search.Cancellation.Cancel();
+        }
+        else
+        {
+            CancelSearch();
+        }
         bool stoppedTurnSetupSearch = PlayerTurnSetupCoordinator.StopSearchByUser();
         if (controllerSearchCanceled || stoppedTurnSetupSearch)
             SearchCompletionNotifier.Notify(SearchCompletionNotificationKind.Canceled);
         _combat.PendingCompleteProjectionBaseline = null;
         _combat.PendingManualProjectionBaseline = null;
-        SolverOverlay.ShowSearchStopped(host);
+        if (search == null)
+            SolverOverlay.ShowSearchStopped(host);
         Entry.Logger.Info(
             $"[CombatSolver/Test] SEARCH_STOPPED_BY_USER generation={generation?.ToString() ?? "-"} " +
             $"turn_setup={stoppedTurnSetupSearch.ToString().ToLowerInvariant()} automatic_search_paused=true");
@@ -1550,20 +1562,31 @@ internal static class SolverController
     public static void RefreshSearchProgress()
     {
         AssertMainThread();
-        if (_search is not { } search)
+        if (_search is not { StopRequestedByUser: false } search)
             return;
         SolverProgress? progress = Volatile.Read(ref search.Progress);
-        if (progress == null || ReferenceEquals(progress, search.RenderedProgress))
+        SolverResult? best = Volatile.Read(ref search.BestResult);
+        if (progress == null
+            || ReferenceEquals(progress, search.RenderedProgress)
+                && ReferenceEquals(best, search.RenderedBestResult))
             return;
         long now = System.Environment.TickCount64;
         if (now - search.LastProgressRenderAt < SolverWeights.ProgressUiIntervalMilliseconds)
             return;
         search.LastProgressRenderAt = now;
+        SolverOverlaySnapshot? bestSnapshot = ReferenceEquals(best, search.RenderedBestResult) || best == null
+            ? null
+            : SolverOverlaySnapshot.CaptureWithReviewedWorldlines(
+                best,
+                UnexpectedReplanCount > 0,
+                _combat.ReviewedWorldlinesTotal + progress.ReviewedWorldlines);
         search.RenderedProgress = progress;
+        search.RenderedBestResult = best;
         SolverOverlay.ShowProgress(
             progress,
             search.DeployWhenReady,
-            _combat.ReviewedWorldlinesTotal);
+            _combat.ReviewedWorldlinesTotal,
+            bestSnapshot);
     }
 
     public static void ObserveMainThreadFrameGap(TimeSpan gap)
@@ -1590,6 +1613,12 @@ internal static class SolverController
     {
         if (ReferenceEquals(_search, search))
             Volatile.Write(ref search.Progress, progress);
+    }
+
+    private static void PublishSearchBest(SolverSearchSession search, SolverResult result)
+    {
+        if (ReferenceEquals(_search, search))
+            Volatile.Write(ref search.BestResult, result);
     }
 
     private static string DescribeReplanAudit()
@@ -1671,12 +1700,17 @@ internal static class SolverController
             $"p95_gap_ms={search.FramePercentile(0.95d):F1} p99_gap_ms={search.FramePercentile(0.99d):F1} " +
             $"max_gap_ms={search.MaxFrameGapMilliseconds:F1} over_33ms={search.FramesOver33Milliseconds} " +
             $"over_50ms={search.FramesOver50Milliseconds} over_100ms={search.FramesOver100Milliseconds}");
-
-        if (task.IsCanceled)
+        SolverResult? stoppedResult = search.StopRequestedByUser
+            ? search.StopResult
+            : null;
+        if (task.IsCanceled && stoppedResult == null)
         {
             _combat.PendingCompleteProjectionBaseline = null;
             _combat.PendingManualProjectionBaseline = null;
-            SearchCompletionNotifier.Notify(SearchCompletionNotificationKind.Canceled);
+            if (!search.StopRequestedByUser)
+                SearchCompletionNotifier.Notify(SearchCompletionNotificationKind.Canceled);
+            else
+                SolverOverlay.ShowSearchStopped(host);
             Entry.Logger.Info($"[CombatSolver/Test] SEARCH_CANCELED generation={generation}");
             return;
         }
@@ -1699,6 +1733,14 @@ internal static class SolverController
             Entry.Logger.Error($"[CombatSolver/Test] SEARCH_FAILURE generation={generation} exception={ex}");
             return;
         }
+        if (search.StopRequestedByUser && stoppedResult == null)
+        {
+            _combat.PendingCompleteProjectionBaseline = null;
+            _combat.PendingManualProjectionBaseline = null;
+            SolverOverlay.ShowSearchStopped(host);
+            Entry.Logger.Info($"[CombatSolver/Test] SEARCH_STOPPED_WITHOUT_RESULT generation={generation}");
+            return;
+        }
 
         CombatState searchedState = search.State;
         LiveCombatStamp searchedStamp = search.Stamp;
@@ -1718,12 +1760,12 @@ internal static class SolverController
                 host,
                 "[b]战斗路线求解器[/b]\n战斗状态在计算期间发生变化，已丢弃过期结果。\n" +
                 SolverUiTokens.BugReportUploadInstructionRichText);
-            SearchCompletionNotifier.Notify(SearchCompletionNotificationKind.Stale);
+            if (!search.StopRequestedByUser)
+                SearchCompletionNotifier.Notify(SearchCompletionNotificationKind.Stale);
             Entry.Logger.Info($"[CombatSolver/Test] SEARCH_STALE generation={generation}");
             return;
         }
-
-        SolverResult result = task.Result;
+        SolverResult result = (stoppedResult ?? task.Result).CreatePublicationSnapshot();
         CompleteProjectionBaseline? recalculationBaseline = _combat.PendingCompleteProjectionBaseline;
         ManualProjectionBaseline? manualBaseline = _combat.PendingManualProjectionBaseline;
         _combat.PendingCompleteProjectionBaseline = null;
@@ -1765,27 +1807,32 @@ internal static class SolverController
         if (UnattendedTestRunner.IsActive)
             LastCompletedResultForTesting = result;
         _combat.ContinuationSource = result;
-        BattleDamageTracker.RegisterPlan(searchedState, result);
         CombatBugReportExporter.RecordCheckpoint(
             searchedState,
-            "search_completed",
+            search.StopRequestedByUser ? "search_stopped_best" : "search_completed",
             result,
             DescribeReplanAudit());
-        SolverOverlay.ShowResult(
-            host,
-            SolverOverlaySnapshot.CaptureWithReviewedWorldlines(
-                result,
-                UnexpectedReplanCount > 0,
-                _combat.ReviewedWorldlinesTotal));
-        SearchCompletionNotifier.Notify(SearchCompletionNotificationKind.Succeeded);
-        Entry.Logger.Info(SolverDiagnostics.DescribeResult(result));
-        if (search.DeployWhenReady)
+        SolverOverlaySnapshot overlaySnapshot = SolverOverlaySnapshot.CaptureWithReviewedWorldlines(
+            result,
+            UnexpectedReplanCount > 0,
+            _combat.ReviewedWorldlinesTotal);
+        if (search.StopRequestedByUser)
+            overlaySnapshot = overlaySnapshot with { StatusText = "计算已停止 · 当前最优" };
+        SolverOverlay.ShowResult(host, overlaySnapshot);
+        if (!search.StopRequestedByUser)
+            SearchCompletionNotifier.Notify(SearchCompletionNotificationKind.Succeeded);
+        if (!search.StopRequestedByUser && search.DeployWhenReady)
         {
             StartDeployment(host, searchedState, result);
         }
-        else if (_combat.FullAutoEnabled)
+        else if (!search.StopRequestedByUser && _combat.FullAutoEnabled)
         {
             StartFullAutoDeployment(host, searchedState, result);
+        }
+        else if (search.StopRequestedByUser)
+        {
+            Entry.Logger.Info(
+                $"[CombatSolver/Test] SEARCH_STOPPED_RESULT generation={generation} expanded={result.ExpandedNodes}");
         }
     }
 

--- a/src/Runtime/SolverControllerSessions.cs
+++ b/src/Runtime/SolverControllerSessions.cs
@@ -73,6 +73,10 @@ internal sealed class SolverSearchSession(
     public int MaxDegreeOfParallelism { get; set; } = 1;
     public SolverProgress? Progress;
     public SolverProgress? RenderedProgress { get; set; }
+    public SolverResult? BestResult;
+    public SolverResult? RenderedBestResult { get; set; }
+    public bool StopRequestedByUser { get; set; }
+    public SolverResult? StopResult { get; set; }
     public long LastProgressRenderAt { get; set; } = Environment.TickCount64;
     public int FrameCount { get; private set; }
     public int FramesOver33Milliseconds { get; private set; }

--- a/src/Search/CombatBeamSolver.Phases.cs
+++ b/src/Search/CombatBeamSolver.Phases.cs
@@ -56,6 +56,8 @@ internal sealed partial class CombatBeamSolver
         int gen2AtStart = GC.CollectionCount(2);
         TimeSpan gcPauseAtStart = GC.GetTotalPauseDuration();
         Stopwatch stopwatch = Stopwatch.StartNew();
+        int initialHp = root.InitialPlayerHp;
+        int sellThreshold = SoldHpThreshold();
         using ParallelExpansionExecutor? parallelExpansionExecutor = expansionParallelism > 1
             ? new ParallelExpansionExecutor(this, expansionParallelism)
             : null;
@@ -88,6 +90,55 @@ internal sealed partial class CombatBeamSolver
                 elapsedMs,
                 $"{(checkpointPhase || _profile.Phase == SolverSearchPhase.Short ? "快速搜索" : "深化搜索")}·{phase}"));
         }
+        long lastBestResultMs = -100;
+        void PublishBestResult(
+            IReadOnlyList<SearchNode> retained,
+            int searchedLayers,
+            bool budgetReached,
+            bool force = false)
+        {
+            if (bestResultCallback == null)
+                return;
+            long elapsedMs = stopwatch.ElapsedMilliseconds;
+            if (!force && elapsedMs - lastBestResultMs < 100)
+                return;
+            List<SearchNode> viable = retained
+                .Where(node => node.ActionCount > 0 && node.Snapshot.HasSimulator)
+                .DistinctBy(node => node.Snapshot)
+                .ToList();
+            if (viable.Count == 0)
+                return;
+            List<SearchNode> candidates = Retention.RankBest(viable, _profile.BeamWidth * 4);
+            List<(SearchNode Node, SimulationSnapshot Snapshot, RouteAnnotations Annotations)> evaluated = candidates
+                .Select(node => (Node: node, Snapshot: node.Snapshot, Annotations: BuildRouteAnnotations(node)))
+                .ToList();
+            FinalPlanSelection currentOrdering;
+            try
+            {
+                currentOrdering = FinalOrdering.Select(evaluated, initialHp, emitDiagnostics: false);
+            }
+            catch (PotionPolicyUnsatisfiedException)
+            {
+                return;
+            }
+            bool onlyDeathRoutesFound = evaluated.All(candidate =>
+                candidate.Snapshot.PlayerDead || candidate.Snapshot.ProjectedPlayerHp <= 0);
+            SolverResult current = MaterializeResult(
+                currentOrdering,
+                onlyDeathRoutesFound,
+                searchedLayers,
+                budgetReached,
+                stopwatch,
+                allocatedBytesAtStart,
+                gen0AtStart,
+                gen1AtStart,
+                gen2AtStart,
+                gcPauseAtStart,
+                sellThreshold);
+            lastBestResultMs = stopwatch.ElapsedMilliseconds;
+            bestResultCallback(current);
+        }
+
 
         PublishProgress(_startTurnNumber, 0, 0, 1, 0, "初始化", force: true);
         IReadOnlyList<(IReadOnlyList<PlanCardChoice> Choices, SimulationSnapshot Snapshot)> rootCandidates =
@@ -172,7 +223,6 @@ internal sealed partial class CombatBeamSolver
         double potionFreeBoundaryFallbackScore = double.NegativeInfinity;
         SearchNode? potionBoundaryFallback = null;
         double potionBoundaryFallbackScore = double.NegativeInfinity;
-        int initialHp = root.InitialPlayerHp;
         int searchedTurnLayers = 0;
         bool timeBudgetReached = false;
 
@@ -387,6 +437,10 @@ internal sealed partial class CombatBeamSolver
                 List<SearchNode> prunedPlays = Prune(nextPlays);
                 ReleaseDroppedSnapshots(nextPlays, prunedPlays);
                 active = prunedPlays;
+                PublishBestResult(
+                    [.. completed, .. active],
+                    searchedTurnLayers,
+                    timeBudgetReached);
                 if (_detailedDiagnostics && searchedTurnLayers == 0)
                 {
                     policy.Diagnostics.Info(
@@ -425,6 +479,11 @@ internal sealed partial class CombatBeamSolver
             List<SearchNode> retainedAfterRound = [.. completed, .. frontier];
             ReleaseDroppedSnapshots(ended, retainedAfterRound);
             searchedTurnLayers++;
+            PublishBestResult(
+                retainedAfterRound,
+                searchedTurnLayers,
+                timeBudgetReached,
+                force: true);
             if (_detailedDiagnostics)
             {
                 policy.Diagnostics.Info(
@@ -487,15 +546,43 @@ internal sealed partial class CombatBeamSolver
         bool onlyDeathRoutesFound = evaluated.All(candidate =>
             candidate.Snapshot.PlayerDead || candidate.Snapshot.ProjectedPlayerHp <= 0);
         _run.ReusedNodeSnapshots += evaluated.Count;
-        int sellThreshold = SoldHpThreshold();
         FinalPlanSelection ordering = FinalOrdering.Select(
             evaluated,
             initialHp,
             emitDiagnostics: true);
+        SolverResult result = MaterializeResult(
+            ordering,
+            onlyDeathRoutesFound,
+            searchedTurnLayers,
+            timeBudgetReached,
+            stopwatch,
+            allocatedBytesAtStart,
+            gen0AtStart,
+            gen1AtStart,
+            gen2AtStart,
+            gcPauseAtStart,
+            sellThreshold,
+            finalMeasurement);
+        foreach (SearchNode candidate in finalCandidates)
+            candidate.Snapshot.ReleaseSimulator();
+        return result;
+    }
+
+    private SolverResult MaterializeResult(
+        FinalPlanSelection ordering,
+        bool onlyDeathRoutesFound,
+        int searchedTurnLayers,
+        bool timeBudgetReached,
+        Stopwatch stopwatch,
+        long allocatedBytesAtStart,
+        int gen0AtStart,
+        int gen1AtStart,
+        int gen2AtStart,
+        TimeSpan gcPauseAtStart,
+        int sellThreshold,
+        SearchMeasurement? finalMeasurement = null)
+    {
         FinalPlanCandidate selectedCandidate = ordering.Candidate;
-        int potionBranchesRejected = ordering.PotionBranchesRejected;
-        int potionHpSaved = ordering.PotionHpSaved;
-        int potionHpRequired = ordering.PotionHpRequired;
         int annotatedFutureSold = selectedCandidate.Annotations.SoldHpByTurn.Values.Sum();
         if (annotatedFutureSold != selectedCandidate.FutureSold)
         {
@@ -503,7 +590,6 @@ internal sealed partial class CombatBeamSolver
                 $"卖血路径状态不一致：节点累计 {selectedCandidate.FutureSold}，逐回合累计 {annotatedFutureSold}。");
         }
         SearchNode best = selectedCandidate.Node with { Score = selectedCandidate.Score };
-
         SimulationSnapshot finalSnapshot = selectedCandidate.Snapshot;
         RouteAnnotations annotations = selectedCandidate.Annotations;
         IReadOnlyList<CachedContinuation> continuations = BuildContinuations(best);
@@ -573,8 +659,11 @@ internal sealed partial class CombatBeamSolver
                     .ToArray(),
             })
             .ToArray();
-        _run.Performance.End(SearchMetricPhase.FinalSelection, finalMeasurement);
-        stopwatch.Stop();
+        if (finalMeasurement is { } measurement)
+        {
+            _run.Performance.End(SearchMetricPhase.FinalSelection, measurement);
+            stopwatch.Stop();
+        }
         long workerAllocatedBytes =
             GC.GetAllocatedBytesForCurrentThread() - allocatedBytesAtStart
             + _run.OffThreadAllocatedBytes;
@@ -582,9 +671,8 @@ internal sealed partial class CombatBeamSolver
         int gen1Collections = GC.CollectionCount(1) - gen1AtStart;
         int gen2Collections = GC.CollectionCount(2) - gen2AtStart;
         TimeSpan gcPauseDuration = GC.GetTotalPauseDuration() - gcPauseAtStart;
-        // 必须在返回前把节点链和模拟器图压平成运行时真正需要的数据。
-        // Coordinator 会在深化期间保留短搜结果；这里若返回 SearchNode/SimulationSnapshot，
-        // 短搜的全部父链和每步模拟器都会成为长寿命 GC 根。
+        // Both final and live-best publications are flattened here. Nothing returned retains a
+        // SearchNode, SimulationSnapshot, or CombatPredictionSimulator from the pruning graph.
         SelectedSearchPlan selectedPlan = new(
             annotatedActions,
             best.ActionCount,
@@ -610,17 +698,29 @@ internal sealed partial class CombatBeamSolver
             finalSnapshot.ShufflesCrossed,
             finalSnapshot.BoundaryReason,
             finalSnapshot.PredictionGaps.ToArray());
-        foreach (SearchNode candidate in finalCandidates)
-            candidate.Snapshot.ReleaseSimulator();
+        bool deepTriggered = _shortCheckpointMilliseconds is { } shortCheckpoint
+            && stopwatch.ElapsedMilliseconds > shortCheckpoint;
+        double shortMilliseconds = deepTriggered
+            ? Math.Min(stopwatch.Elapsed.TotalMilliseconds, _shortCheckpointMilliseconds!.Value)
+            : stopwatch.Elapsed.TotalMilliseconds;
         return new SolverResult
         {
-            SearchPhase = _profile.Phase,
+            SearchPhase = deepTriggered ? SolverSearchPhase.Deep : SolverSearchPhase.Short,
+            DeepSearchTriggered = deepTriggered,
+            SingleSessionSearch = true,
+            ShortSearchElapsed = TimeSpan.FromMilliseconds(shortMilliseconds),
+            DeepSearchElapsed = stopwatch.Elapsed - TimeSpan.FromMilliseconds(shortMilliseconds),
             TotalSearchElapsed = stopwatch.Elapsed,
             TotalWorkerAllocatedBytes = workerAllocatedBytes,
+            ShortExpandedNodes = deepTriggered ? 0 : _run.Expanded,
+            DeepExpandedNodes = deepTriggered ? _run.Expanded : 0,
+            ShortTransitionCount = deepTriggered ? 0 : _run.TransitionCount,
+            DeepTransitionCount = deepTriggered ? _run.TransitionCount : 0,
             TotalGen0Collections = gen0Collections,
             TotalGen1Collections = gen1Collections,
             TotalGen2Collections = gen2Collections,
             TotalGcPauseDuration = gcPauseDuration,
+            TotalMaxObservedGcPause = _run.WorkPacer.MaxObservedGcPause,
             ForkMetric = _run.Performance.Snapshot(SearchMetricPhase.Fork),
             ActionMetric = _run.Performance.Snapshot(SearchMetricPhase.Action),
             CardExecutionMetric = _run.Performance.Snapshot(SearchMetricPhase.CardExecution),
@@ -692,9 +792,9 @@ internal sealed partial class CombatBeamSolver
             ProjectedBattleHpLost = battleDamage.HpLostSoFar + futureHpLost,
             BattlePotionsUsedSoFar = battleDamage.PotionsUsedSoFar,
             PotionCount = selectedCandidate.PotionCount,
-            PotionHpSaved = potionHpSaved,
-            PotionHpRequired = potionHpRequired,
-            PotionBranchesRejected = potionBranchesRejected,
+            PotionHpSaved = ordering.PotionHpSaved,
+            PotionHpRequired = ordering.PotionHpRequired,
+            PotionBranchesRejected = ordering.PotionBranchesRejected,
             TheftPolicy = _theftPolicy,
             OutstandingStolenResource = finalSnapshot.OutstandingStolenResource,
             SoldHpThreshold = sellThreshold,

--- a/src/Search/CombatBeamSolver.cs
+++ b/src/Search/CombatBeamSolver.cs
@@ -33,7 +33,8 @@ internal sealed partial class CombatBeamSolver(
     SolverPotionPolicy? potionPolicyOverride = null,
     PotionFreePolicyBaseline? potionFreePolicyBaseline = null,
     int? maximumPotionUses = null,
-    IReadOnlyList<PlanAction>? fixedPrefixActions = null)
+    IReadOnlyList<PlanAction>? fixedPrefixActions = null,
+    Action<SolverResult>? bestResultCallback = null)
 {
     private readonly SolverSearchProfile _profile = searchProfile ?? SolverSearchProfile.Short;
     private readonly SearchRunContext _run = new(

--- a/src/Search/CombatPlan.cs
+++ b/src/Search/CombatPlan.cs
@@ -476,6 +476,11 @@ internal sealed record CachedContinuation(
 
 internal sealed class SolverResult
 {
+    // Publication clones share only immutable arrays/read-only maps. Callers clone again before
+    // adding main-thread completion metrics so a worker-published instance is never mutated.
+    public SolverResult CreatePublicationSnapshot()
+        => (SolverResult)MemberwiseClone();
+
     public SolverSearchPhase SearchPhase { get; internal set; } = SolverSearchPhase.Short;
     public bool DeepSearchTriggered { get; internal set; }
     public bool DeepSearchImprovedResult { get; internal set; }

--- a/src/Search/CombatSearchCoordinator.cs
+++ b/src/Search/CombatSearchCoordinator.cs
@@ -10,8 +10,12 @@ internal static class CombatSearchCoordinator
         BattleDamageSnapshot battleDamage,
         SearchPolicySnapshot policy,
         CancellationToken cancellationToken,
-        Action<SolverProgress>? progressCallback)
+        Action<SolverProgress>? progressCallback,
+        Action<SolverResult>? bestResultCallback = null)
     {
+        void PublishBest(SolverResult result)
+            => bestResultCallback?.Invoke(result.CreatePublicationSnapshot());
+
         SolverSearchProfile shortProfile = policy.ShortProfile;
         if (policy.ShortBudgetOverrideMilliseconds is { } shortBudget)
             shortProfile = shortProfile with { SoftTimeBudgetMilliseconds = shortBudget };
@@ -45,8 +49,10 @@ internal static class CombatSearchCoordinator
                 policy,
                 cancellationToken,
                 progressCallback,
-                shortProfile).Solve();
+                shortProfile,
+                bestResultCallback: bestResultCallback).Solve();
             PopulateSingleSessionTotals(shortResult, shortProfile.SoftTimeBudgetMilliseconds, deepTriggered: false);
+            PublishBest(shortResult);
             if (!policy.PotionStrategy.HasForcedDirectives)
             {
                 shortResult = AuditRequiredPotionUse(
@@ -59,6 +65,7 @@ internal static class CombatSearchCoordinator
                     shortProfile,
                     shortCheckpointMilliseconds: null,
                     primary: shortResult);
+                PublishBest(shortResult);
                 shortResult = AuditSmartPotionUse(
                     root,
                     displayNames,
@@ -69,6 +76,7 @@ internal static class CombatSearchCoordinator
                     shortProfile,
                     shortCheckpointMilliseconds: null,
                     primary: shortResult);
+                PublishBest(shortResult);
                 shortResult = AuditOpeningPowerUse(
                     root,
                     displayNames,
@@ -79,6 +87,7 @@ internal static class CombatSearchCoordinator
                     shortProfile,
                     shortCheckpointMilliseconds: null,
                     primary: shortResult);
+                PublishBest(shortResult);
             }
             if (policy.MeasurePhasePerformance)
                 policy.Diagnostics.Info(SolverDiagnostics.DescribeSearchPhasePerformance(shortResult));
@@ -106,7 +115,8 @@ internal static class CombatSearchCoordinator
             cancellationToken,
             progressCallback,
             deepProfile,
-            shortCheckpointMilliseconds: shortProfile.SoftTimeBudgetMilliseconds).Solve();
+            shortCheckpointMilliseconds: shortProfile.SoftTimeBudgetMilliseconds,
+            bestResultCallback: bestResultCallback).Solve();
         if (policy.MeasurePhasePerformance)
             policy.Diagnostics.Info(SolverDiagnostics.DescribeSearchPhasePerformance(result));
         bool deepTriggered = result.Elapsed.TotalMilliseconds > shortProfile.SoftTimeBudgetMilliseconds;
@@ -115,6 +125,7 @@ internal static class CombatSearchCoordinator
         result.DeepSearchImprovedResult = false;
         result.SingleSessionSearch = true;
         PopulateSingleSessionTotals(result, shortProfile.SoftTimeBudgetMilliseconds, deepTriggered);
+        PublishBest(result);
         if (!policy.PotionStrategy.HasForcedDirectives)
         {
             result = AuditRequiredPotionUse(
@@ -127,6 +138,7 @@ internal static class CombatSearchCoordinator
                 deepProfile,
                 shortProfile.SoftTimeBudgetMilliseconds,
                 result);
+            PublishBest(result);
             result = AuditSmartPotionUse(
                 root,
                 displayNames,
@@ -137,6 +149,7 @@ internal static class CombatSearchCoordinator
                 deepProfile,
                 shortProfile.SoftTimeBudgetMilliseconds,
                 result);
+            PublishBest(result);
             result = AuditOpeningPowerUse(
                 root,
                 displayNames,
@@ -147,6 +160,7 @@ internal static class CombatSearchCoordinator
                 deepProfile,
                 shortProfile.SoftTimeBudgetMilliseconds,
                 result);
+            PublishBest(result);
         }
         policy.Diagnostics.Info(
             $"[CombatSolver/Test] SEARCH_SESSION mode=single_anytime " +

--- a/src/UI/SolverOverlay.cs
+++ b/src/UI/SolverOverlay.cs
@@ -66,6 +66,7 @@ internal static class SolverOverlay
     private static SolverButtonStyle? _renderedExecuteButtonStyle;
     private static SolverTheftPolicy? _renderedTheftPolicy;
     private static SolverOverlaySnapshot? _lastSnapshot;
+    private static SolverOverlaySnapshot? _searchBestSnapshot;
     private static string? _lastMessageText;
     private static int _lastSearchingTurn;
     private static bool _lastSearchDeployWhenReady;
@@ -187,6 +188,7 @@ internal static class SolverOverlay
     public static void ShowSearchStopped(Node host)
     {
         _lastSnapshot = null;
+        _searchBestSnapshot = null;
         _lastMessageText = null;
         EnsureCreated(host);
         _deployQueued = false;
@@ -202,7 +204,8 @@ internal static class SolverOverlay
     public static void ShowProgress(
         SolverProgress progress,
         bool deployWhenReady,
-        long reviewedWorldlinesBeforeSearch)
+        long reviewedWorldlinesBeforeSearch,
+        SolverOverlaySnapshot? bestSnapshot = null)
     {
         if (_layer == null || !GodotObject.IsInstanceValid(_layer) || !_layer.Visible)
             return;
@@ -210,6 +213,9 @@ internal static class SolverOverlay
         _lastSearchingTurn = progress.CurrentTurnNumber;
         _lastSearchDeployWhenReady = deployWhenReady;
         _lastReviewedWorldlinesBeforeSearch = reviewedWorldlinesBeforeSearch;
+        if (bestSnapshot != null)
+            _searchBestSnapshot = bestSnapshot;
+        SolverOverlaySnapshot? routeSnapshot = _searchBestSnapshot;
         SetStatus(
             "后台计算中",
             Accent,
@@ -218,7 +224,9 @@ internal static class SolverOverlay
                 : $"第 {progress.CurrentTurnNumber} 回合");
         if (_summaryText != null)
         {
-            _summaryText.Visible = false;
+            _summaryText.Visible = routeSnapshot != null;
+            if (routeSnapshot != null)
+                _summaryText.Text = SolverUiTokens.AdaptRichTextToActiveTheme(routeSnapshot.SummaryText);
         }
         if (_progressText != null)
         {
@@ -233,7 +241,47 @@ internal static class SolverOverlay
             _searchProgressBar.MaxValue = Math.Max(1, progress.MaxNodes);
             _searchProgressBar.Value = Math.Clamp(progress.ExpandedNodes, 0, progress.MaxNodes);
         }
+        if (routeSnapshot != null)
+            PopulateSearchRoute(routeSnapshot);
         RefreshControls();
+    }
+
+    private static void PopulateSearchRoute(SolverOverlaySnapshot snapshot)
+    {
+        SetRouteVisibility(true);
+        if (_potionOutcomeLabel != null)
+        {
+            _potionOutcomeLabel.Visible = snapshot.ProjectedBattlePotionCount > 0;
+            _potionOutcomeLabel.Text = $"预计用{snapshot.ProjectedBattlePotionCount}瓶药";
+        }
+        if (_hpOutcomeLabel != null)
+        {
+            _hpOutcomeLabel.Visible = true;
+            _hpOutcomeLabel.Text = snapshot.HpOutcomeText;
+            _hpOutcomeLabel.AddThemeColorOverride(
+                "font_color",
+                snapshot.ProjectedBattleHpLost > 0 ? Danger : Success);
+        }
+        if (_deathOutcomeLabel != null)
+            _deathOutcomeLabel.Visible = snapshot.OnlyDeathRoutesFound;
+        for (int index = 0; index < SolverWeights.UiTurnRows; index++)
+        {
+            SetRouteRowVisible(index, index < snapshot.Turns.Count);
+            if (index >= snapshot.Turns.Count)
+                continue;
+            SolverOverlayTurnSnapshot turn = snapshot.Turns[index];
+            RouteRows[index].TurnLabel.Text = $"第 {turn.Turn} 回合";
+            RouteRows[index].Populate(turn);
+            string outcome = turn.CombatEnded
+                ? "战斗结束"
+                : turn.HpLoss > 0
+                    ? $"-{turn.HpLoss} HP"
+                    : "0 HP";
+            RouteRows[index].SetOutcome(
+                outcome,
+                turn.CombatEnded ? Success : turn.HpLoss > 0 ? Danger : TextMuted,
+                $"余 {turn.EnergyLeft} 费");
+        }
     }
 
     public static void ShowSearching(
@@ -243,6 +291,7 @@ internal static class SolverOverlay
         long reviewedWorldlinesBeforeSearch)
     {
         _lastSnapshot = null;
+        _searchBestSnapshot = null;
         _lastMessageText = null;
         _lastSearchingTurn = turn;
         _lastSearchDeployWhenReady = deployWhenReady;
@@ -301,6 +350,7 @@ internal static class SolverOverlay
     public static void ShowResult(Node host, SolverOverlaySnapshot snapshot)
     {
         _lastSnapshot = snapshot;
+        _searchBestSnapshot = null;
         _lastMessageText = null;
         EnsureCreated(host);
         _deployQueued = false;


### PR DESCRIPTION
搜索进行中，在每个剪枝与回合收束点从当前保留候选复用最终判定（FinalOrdering.Select）构建当前最优路线，实时推给界面；玩家点击“停止计算”时，提交此刻已算出的最优路线（而非丢弃），并抑制自动部署。

跨线程使用不可变快照，不持有 SearchNode/SimulationSnapshot；原生回合准备选项（PlayerTurnSetupCoordinator）暂未接入停止提交，保留原有取消行为。

已通过 Release 编译（0 警告 0 错误）；实际战斗中停止交互与后续手动部署尚未可见验证。