### PR TITLE
知识恶魔的诅咒不该进出牌动作的选牌游标

### DIFF
--- a/src/Search/CombatBeamSolver.Expansion.cs
+++ b/src/Search/CombatBeamSolver.Expansion.cs
@@ -2691,7 +2691,14 @@ internal sealed partial class CombatBeamSolver
     {
         List<PlanCardChoice> choices = [.. action.GetActionChoicesInExecutionOrder()];
         if (action.Kind == PlanActionKind.PlayCard && action.TurnStartChoices is { Count: > 0 })
-            choices.AddRange(action.TurnStartChoices);
+        {
+            // Knowledge Demon curses are never taken through a cursor. They are read straight off the raw plan
+            // list by KnowledgeDemonChoiceSupport.Resolve during the enemy turn, which for a card that forces the
+            // turn to end runs in AdvanceRound - after EndActionChoices has already asserted this cursor. Leaving
+            // them here makes AssertConsumed report a choice that was never this cursor's to take.
+            choices.AddRange(action.TurnStartChoices
+                .Where(choice => choice.Effect != PlanChoiceEffect.ApplyKnowledgeCurse));
+        }
         return choices.Count == 0 ? null : choices;
     }
 


### PR DESCRIPTION
## 现象

`SEARCH_FAILURE`，整轮搜索终止：

```
InvalidPlannedChoiceBranchException: 回合开始仍有 1 个计划选牌没有触发；
下一个=KNOWLEDGE_DEMON:1:2/ApplyKnowledgeCurse/None/
```

在 `0.25.1` 上出现。改成单线程不影响，不是并发问题。

## 链路

堆栈直接指到 `ActionChoicesForReplay`：

```
AssertConsumed()
 ← EndActionChoices()
   ← Replay()
     ← ReplayAction()
       ← ResolveRoundChoiceBranches(node, action, snapshot, unresolvedPrimaryChoice, maxFinalBranches)
         ← Expand(node)
```

`unresolvedPrimaryChoice` 不为 null，说明走的是 `Expansion.cs:656` 出牌那条调用，动作是 `PlayCard`。

完整过程：

1. 一张会强制结束回合的牌，在展开时敌方回合跟着跑了一遍（`forcedTurnEnd = finalSnapshot.Turn > node.Turn`）。这一段里知识恶魔发动诅咒，`ResolveRoundChoiceBranches` 把 `ApplyKnowledgeCurse` 挂到这个 `PlayCard` 动作的 `TurnStartChoices` 上。
2. 重放该动作时，`ActionChoicesForReplay` 把整份 `TurnStartChoices` 塞进出牌用的选牌游标。
3. `ManualPlay` 只消费这张牌自己的选择。诅咒轮不到，因为敌方回合还没跑。
4. `finally` 里的 `EndActionChoices` 调 `AssertConsumed`，诅咒还卡在游标里，抛异常。
5. 真正该消费它的 `AdvanceRound` 在下一行，永远走不到。

## 为什么这样改是安全的

知识恶魔的选择从来不走游标，它由 `KnowledgeDemonChoiceSupport.Resolve` 直接从原始计划列表按 `SourceId` 查找。仓库里已经有四处在把它挡在游标和 UI 之外：`AdvanceRound`（`Expansion.cs:1894`）、`LiveEndTurnRiskEvaluator`、`SolverOverlaySnapshot`、`SolverController`（按 `Timing`）。`ActionChoicesForReplay` 是漏掉的第五处。

更进一步，**游标里的 `ApplyKnowledgeCurse` 条目按构造就不可能被消费**：

- `TryTake` 靠 `Matches()`，其中一条是 `choice.Effect == request.Effect`。
- 所有 `TurnStartChoiceRequest` 的构造点，`Effect` 只可能是 `Discard` / `DiscardAndDraw` / `Exhaust` / `GenerateToHand` / `MoveToHand` / `Transform`；`ResolveActionCardChoice` 用的是 `spec.Effect`，而没有任何 `CardChoiceSpec` 带 `ApplyKnowledgeCurse` —— 这个值全代码库只被 `KnowledgeDemonChoiceSupport.BuildChoices` 写进 `PlanCardChoice`。

所以 `Matches()` 对它永远为假。它出现在游标里只能制造假失败，不可能暴露真问题；删掉它对检测能力的损失为零，其余条目照常核对。

过滤后 `AdvanceRound` 仍然收到未过滤的 `action.TurnStartChoices`，诅咒照常被消费。

## 虚空形态不受影响

`51fa730`（v0.22.9）之前这行只对 `action.CardId == "VOID_FORM"` 生效是有道理的：虚空形态自己接一个额外回合，那些选择确实要在出牌期间消费。但 `AdvanceRound` 里 `if (!takingExtraTurn)` 把整个敌方回合块都包住，额外回合不跑敌人行动，所以虚空形态的 `TurnStartChoices` 里不可能有诅咒。

## 验证

headless A/B，同一份请求，只加载 CombatSolver + RitsuLib（其余 mod 临时移出 `mods/`）：

| 构建 | `SEARCH_FAILURE` |
|---|---|
| `c2630a0`（当前 main） | **1**，异常与上面一致 |
| `c2630a0` + 本 PR | **0** |

修复后那次搜索正常出结果：`RESULT phase=Deep expanded=5729`，逐回合 `TURN_OUTCOME` 正常，`UI_STATE state=ready`。

场景：`REGENT` / `KNOWLEDGE_DEMON_BOSS` / 进阶 10 / `actIndexForTest=1` / 玩家问题包里的战前 `run` 存档 / `initialEnemyMoveIds=["CURSE_OF_KNOWLEDGE_MOVE"]` / `enemyCurrentHp=150` / `forceShortSearchOnly` + `shortSearchBudgetOverrideMilliseconds=3000`。

有一点先说清楚：**这不是一份自判定的 coverage 夹具**。全自动会停在第 1 回合的 `deploying`，所以运行判定始终是 `Failed / wait_combat_end`，修复前后都一样；有效的判据是日志里 `SEARCH_FAILURE` 的条数。战前存档和完整请求 JSON 我这边留着，需要的话可以补上，或者按你的格式补一份能自判定的夹具。

另外一个观察，供参考：触发条件不需要搜到很深。在这个夹具里第一次诅咒（`counter=0`）就能复现，关键在于那次诅咒落在**出牌动作**还是**结束回合动作**上。

## 和 #3 的关系

#3 打的是同一句报错，但改的是另一处：把 `EndActionChoices` 的豁免从 `PendingTurnStartChoice == null` 放宽为 `!HasPendingChoice`。你当时的意见是那样会在诅咒挂起时一并跳过其他未消费选择、可能掩盖真正的阶段错位 —— 这个顾虑对那个改法成立。

本 PR 不动校验条件，只是不把一类按构造无法被消费的条目放进游标，所以不存在掩盖问题。

#3 指出的那条路径（敌方回合因诅咒挂起时，游标里合法条目也还没消费）本 PR 没有覆盖，也没有夹具，先不合并进来。