### PR TITLE
虚空形态的免费格是有限的，按最贵的几张牌计价

### DIFF
--- a/src/Search/CombatBeamSolver.StateEvaluation.cs
+++ b/src/Search/CombatBeamSolver.StateEvaluation.cs
@@ -12,6 +12,7 @@ using MegaCrit.Sts2.Core.Models.Cards;
 using MegaCrit.Sts2.Core.Models.Events;
 using MegaCrit.Sts2.Core.Models.Orbs;
 using MegaCrit.Sts2.Core.Models.Powers;
+using CombatSolver.Engine.InCombat.Mirrors.Hooks.Card;
 using MegaCrit.Sts2.Core.Models.Potions;
 using MegaCrit.Sts2.Core.Models.Relics;
 using MegaCrit.Sts2.Core.MonsterMoves.MonsterMoveStateMachine;
@@ -219,7 +220,12 @@ internal sealed partial class CombatBeamSolver
             simulator,
             combat,
             playerState,
-            _player.Creature);
+            _player.Creature)
+            + VoidFormOpportunityValue(
+                simulator,
+                combat,
+                playerState,
+                _player.Creature);
         int futureResourceValue = combat.GetAmount<EnergyNextTurnPower>(_player.Creature) * 16
             + combat.GetAmount<DrawCardsNextTurnPower>(_player.Creature) * 8
             + combat.GetAmount<StarNextTurnPower>(_player.Creature) * 8
@@ -431,6 +437,56 @@ internal sealed partial class CombatBeamSolver
             }
         }
         return (best[energyCapacity, starCapacity], zeroCostPlayableCount);
+    }
+
+    /// <summary>
+    /// Void Form waives the cost of the first N cards played each turn. Unlike the free-attack powers it is not
+    /// limited to one card type and it waives stars as well as energy, so the slots are worth what the most
+    /// expensive cards in hand would have cost - not what the whole hand would have cost.
+    /// </summary>
+    /// <remarks>
+    /// Without this the hand looks strictly cheaper than it is. The cost hook only asks whether any free slot is
+    /// left, not which card would occupy it, so while the counter is below the amount every card in hand reports
+    /// zero and <see cref="CalculateReachableHandPotential"/> concludes the entire hand is affordable.
+    ///
+    /// X-cost cards are excluded on purpose. <c>GetStarCostWithModifiers</c> and its energy counterpart return the
+    /// whole resource pool for them before the cost-modifier hook runs, so an X card still spends everything
+    /// inside the free window: the slot is consumed and buys nothing. Counting it here would recreate the same
+    /// over-statement one card at a time.
+    /// </remarks>
+    private static int VoidFormOpportunityValue(
+        CombatPredictionSimulator simulator,
+        SimulatedCombatState combat,
+        SimPlayerCombatState playerState,
+        Creature owner)
+    {
+        if (combat.GetPower<VoidFormPower>(owner) is not { } power)
+            return 0;
+        // Peek so that merely scoring a state does not make every later fork copy the counter.
+        int freeUses = power.Amount
+            - simulator.StateStore.Peek(power, () => new VoidFormPredictionState(power)).CardsPlayedThisTurn;
+        if (freeUses <= 0)
+            return 0;
+
+        return playerState.Hand.Cards
+            .Where(card => !card.Preview.EnergyCost.CostsX
+                && !card.Preview.HasStarCostX
+                && combat.CanPlayCard(simulator, card))
+            .Select(card =>
+            {
+                int normalEnergy = Math.Max(
+                    0,
+                    (int)Math.Ceiling((double)card.Preview.EnergyCost.GetWithModifiers(CostModifiers.Local)));
+                int currentEnergy = Math.Max(0, card.GetEnergyCostWithModifiers(simulator, playerState));
+                int normalStars = Math.Max(0, card.Preview.CurrentStarCost);
+                int currentStars = Math.Max(0, card.GetStarCostWithModifiers(simulator, playerState));
+                return Math.Max(0, normalEnergy - currentEnergy) * 16
+                    + Math.Max(0, normalStars - currentStars) * 8
+                    + Math.Min(16, Math.Max(1, (int)Math.Ceiling(CardChoiceSupport.CardValue(card.Preview))));
+            })
+            .OrderDescending()
+            .Take(freeUses)
+            .Sum();
     }
 
     private static int FreeCardOpportunityValue(


### PR DESCRIPTION
## 问题

`CalculateReachableHandPotential` 用 `GetEnergyCostWithModifiers` / `GetStarCostWithModifiers` 逐张算手牌成本。虚空形态的成本钩子只判断"还有没有剩余免费格"，不判断这张牌会不会占用它：

```csharp
// ModifyStarCostMirrors.HandleVoidFormPower
... && context.StateStore.Get(power, ...).CardsPlayedThisTurn < power.Amount
    ? 0
    : context.Cost;
```

所以在计数器还没到上限时，**手里每一张牌都报 0 费**。背包于是得出"整手牌全都打得出去"，而实际上只有前 N 张免费。`zeroCostPlayableCount` 同样被灌水。

这不影响模拟层——真正打牌时 `SpendResources` 会逐张重算，扣费是对的，不会产出非法计划。但这个值喂给保路和打分，会让虚空形态下的局面看起来比实际宽松得多。

## 改动

补一条 `VoidFormOpportunityValue`，形状照抄已有的 `FreeCardOpportunityValue`：按"这张牌本来要花多少"排序，只取前 `freeUses` 张。三点不同：

1. **不限牌型** —— 虚空形态对所有牌生效，不像 `FreeAttackPower` 那样按类型分。
2. **同时计入省下的星星**，不只是能量。伽马爆破省的是 3 星、0 能量，只看能量会把它算成毫无收益。
3. `freeUses` 用 `Amount` 减去本回合已打出的张数，不是 `Amount`。

权重沿用本文件既有的能量 `16` / 星星 `8`（见 `futureResourceValue`）。

读计数器用 `Peek` 而不是 `Get`，避免只是给状态打分就让后续所有 fork 复制它。

## X 费牌明确排除

这一条值得单独说，因为它是原版的一个不明显的行为。`CardModel.GetStarCostWithModifiers()`：

```csharp
if (HasStarCostX)
    return Owner.PlayerCombatState?.Stars ?? 0;   // 提前返回，走不到 Hook.ModifyStarCost
```

`SpendResources` 直接拿这个值当 `starsToSpend`。能量的 X 费也是同样的提前返回。

也就是说：**虚空形态的减免对 X 费牌无效**。星尘之类的牌在免费窗口里照样把星星全花光，免费格被占掉却什么都没换到。把它们算进机会价值里，等于把同一个高估问题按张复制一遍，所以在 `Where` 里排除。

（已在 `sts2.dll` 中核实。`VoidFormPower.ShouldSkip` 本身并不排除 X 费牌 —— 它只看归属、牌堆和计数器；真正的原因是 X 费牌根本不进这个钩子。）

## 来源与验证范围

来自一次玩家实战：虚空形态下手里同时有伽马爆破（3 星）和星尘（X 星），求解器把免费格给了星尘，伽马爆破因此没打出去，也没上易伤。

需要说明验证到什么程度：

- 编译通过，0 警告 0 错误。
- 隔离场景 headless 实验（1 个免费格、手牌只有星尘和伽马爆破、敌人分别设为打不死和能打死）里，**改动前求解器就已经把免费格给了伽马爆破**。所以我没有能稳定复现那次实战选择的最小夹具，这个改动不是靠复现驱动的。
- 它是按代码本身的正确性提的：钩子无法表达"只有前 N 张免费"，因此逐张调用它来估整手牌成本必然高估可打出的量。这一条独立于上面那次实战是否由它引起。

如果你希望先有夹具再考虑合并，我完全理解 —— 可以先挂着，等我拿到能复现的问题包再补。