### PR TITLE
完善求解器路线显示与界面操作

### DIFF
--- a/src/Runtime/Entry.cs
+++ b/src/Runtime/Entry.cs
@@ -89,6 +89,8 @@ public static class Entry
             SolverOverlay.ShowDisabled(NGame.Instance);
             return;
         }
+        if (!SolverController.PrepareAutomaticSearchForTurn(NGame.Instance, state))
+            return;
         if (PlayerTurnSetupCoordinator.IsManaging(state))
         {
             Logger.Info("[CombatSolver/Test] TURN_STARTED_DEFERRED_TO_SETUP reason=native_choice_pending");
@@ -133,6 +135,8 @@ public static class Entry
             || SolverController.SolverDisabled
             || SolverController.IsMultiplayerSession
             || !UnattendedTestRunner.AutomaticTurnSearchEnabled
+            || !SolverController.AutomaticCalculationEnabled
+            || SolverController.AutomaticSearchPaused
             || !CombatManager.Instance.IsInProgress
             || !ReferenceEquals(CombatManager.Instance.DebugOnlyGetState(), state)
             || state.CurrentSide != CombatSide.Player

--- a/src/Runtime/PlayerTurnSetupPatches.cs
+++ b/src/Runtime/PlayerTurnSetupPatches.cs
@@ -124,6 +124,7 @@ internal static class PlayerTurnSetupCoordinator
         InitialSearchContext? initialSearch,
         IReadOnlyList<PlanCardChoice>? replayChoices)
     {
+
         public CombatState Combat { get; } = combat;
         public int LifecycleGeneration { get; } = SolverController.CombatLifecycleGeneration;
         public Player Player { get; } = player;
@@ -132,10 +133,9 @@ internal static class PlayerTurnSetupCoordinator
         public InitialSearchContext? InitialSearch { get; } = initialSearch;
         public IReadOnlyList<PlanCardChoice>? ReplayChoices { get; } = replayChoices;
         public SolverResult? Result { get; set; }
-        public SolverProgress? Progress;
-        public SearchProgressDisplayState ProgressDisplay { get; } = new();
+        public SearchInteractionState Interaction { get; } =
+            initialSearch?.SearchPolicy.Interaction ?? new SearchInteractionState();
         public int SearchState;
-        public int AdoptCurrentResultRequestState;
         public TaskCompletionSource ManualRecalculationRequested { get; set; } = new(
             TaskCreationOptions.RunContinuationsAsynchronously);
         public int ManualSearchState;
@@ -150,10 +150,6 @@ internal static class PlayerTurnSetupCoordinator
             => Result?.TurnSetupChoices ?? ReplayChoices;
         public TaskCompletionSource PlanReady { get; } = new(
             TaskCreationOptions.RunContinuationsAsynchronously);
-        public bool AdoptCurrentResultRequested
-            => Volatile.Read(ref AdoptCurrentResultRequestState) != 0;
-        public void RequestAdoptCurrentResult()
-            => Interlocked.Exchange(ref AdoptCurrentResultRequestState, 1);
     }
 
     private static readonly Type CombatTurnStateType = typeof(CombatManager).Assembly.GetType(
@@ -198,6 +194,29 @@ internal static class PlayerTurnSetupCoordinator
            && (ReferenceEquals(_active, active)
                || (_active == null && Volatile.Read(ref active.DisposeState) != 0));
 
+    private static void RefreshSearchProgress(ActivePlan active)
+    {
+        if (!IsCurrentActivePlan(active) || !SolverOverlay.IsVisible
+            || !active.Interaction.TryCreateDisplayProgress(
+                System.Environment.TickCount64,
+                out SolverProgress progress))
+        {
+            return;
+        }
+        SolverOverlaySnapshot? preview = progress.RoutePreview == null
+            ? null
+            : SolverOverlaySnapshot.CaptureRoutePreview(progress.RoutePreview);
+        active.Interaction.RenderedRouteAdoptionSeed = preview == null
+            ? null
+            : progress.RouteAdoptionSeed;
+        SolverOverlay.ShowProgress(
+            progress,
+            active.DeployAfterSetup,
+            SolverController.ReviewedWorldlinesTotal,
+            preview);
+        SolverOverlay.RefreshControls();
+    }
+
     public static bool TryInterceptSetup(
         CombatManager manager,
         object turnState,
@@ -210,6 +229,7 @@ internal static class PlayerTurnSetupCoordinator
             || !_activeOperation.IsCompleted
             || !Entry.Enabled
             || SolverController.SolverDisabled
+            || !SolverController.AutomaticCalculationEnabled
             || SolverController.IsMultiplayerSession
             || SolverController.AutomaticSearchPaused
             || !ReferenceEquals(LocalContext.GetMe(manager.DebugOnlyGetState()), player)
@@ -279,6 +299,8 @@ internal static class PlayerTurnSetupCoordinator
         return true;
     }
 
+    public static bool IsStoppingSearch => _active?.Interaction.StopRequested == true;
+
     public static bool IsManaging(CombatState combat)
         => _active is { } active
            && IsCurrentActivePlan(active)
@@ -289,21 +311,66 @@ internal static class PlayerTurnSetupCoordinator
            || _active is { InitialSearch: not null, Result: null, SearchState: 1 }
            || _active is { ManualSearchState: 1 };
 
-    public static bool CanAdoptCurrentSearchResult
-        => _active is { AdoptCurrentResultRequested: false } active
+    public static bool CanApplyCurrentTurn
+        => _active is { } active
+           && active.Interaction.CurrentTakeoverRequest == null
+           && active.Interaction.CanAcceptTakeover
            && (active.SearchState == 1 || active.ManualSearchState == 1)
-           && Volatile.Read(ref active.Progress)?.CurrentBestResult != null;
+           && Volatile.Read(ref active.Interaction.Progress)?.RoutePreview != null;
 
-    public static bool IsAdoptingCurrentSearchResult
-        => _active?.AdoptCurrentResultRequested == true;
+    public static bool IsApplyingCurrentTurn
+        => _active?.Interaction.IsApplyingCurrentTurn == true;
 
-    public static void AdoptCurrentSearchResult()
+    public static bool CanAdoptCurrentRoute
+        => _active is { } active
+           && (active.Interaction.StoppedResult != null
+               || active.Interaction.CurrentTakeoverRequest == null
+                   && active.Interaction.RenderedRouteAdoptionSeed != null
+                   && active.Interaction.CanAcceptTakeover
+                   && (active.SearchState == 1 || active.ManualSearchState == 1));
+
+    public static bool IsAdoptingCurrentRoute
+        => _active?.Interaction.IsAdoptingRoute == true;
+
+    public static void InvalidateRenderedRouteAdoptionSeed()
     {
-        if (!CanAdoptCurrentSearchResult || _active is not { } active)
+        if (_active != null)
+            _active.Interaction.RenderedRouteAdoptionSeed = null;
+    }
+
+    public static void ApplyCurrentTurn()
+    {
+        if (!CanApplyCurrentTurn || _active is not { } active)
             return;
-        active.RequestAdoptCurrentResult();
+        active.DeployAfterSetup = true;
+        active.TakeoverRequested = true;
+        if (!active.Interaction.RequestApplyCurrentTurn())
+            return;
         SolverOverlay.RefreshControls();
-        Entry.Logger.Info("[CombatSolver/Test] UI_ACTION action=turn_setup_adopt_current_search_result");
+        Entry.Logger.Info("[CombatSolver/Test] UI_ACTION action=turn_setup_apply_current_turn");
+    }
+
+    public static void AdoptCurrentRoute()
+    {
+        if (_active is not { } active)
+            return;
+        SolverResult? stoppedResult = active.Interaction.TakeStoppedResult(
+            LiveCombatStamp.Capture(active.Combat));
+        if (stoppedResult != null)
+        {
+            if (NGame.Instance is { } host)
+                SolverController.ShowTurnSetupResultPreview(host, stoppedResult);
+            SolverOverlay.RefreshControls();
+            Entry.Logger.Info("[CombatSolver/Test] UI_ACTION action=turn_setup_adopt_stopped_route");
+            return;
+        }
+        SolverRouteAdoptionSeed? seed = active.Interaction.RenderedRouteAdoptionSeed;
+        if (seed == null || !active.Interaction.RequestAdoptRoute(seed))
+            return;
+        SolverOverlay.RefreshControls();
+        Entry.Logger.Info(
+            $"[CombatSolver/Test] UI_ACTION action=turn_setup_adopt_current_route " +
+            $"candidate_version={seed.CandidateVersion}");
     }
 
     internal static int ManualRecalculationCompletedCountForTesting
@@ -471,6 +538,16 @@ internal static class PlayerTurnSetupCoordinator
         _active?.Choices.ReleaseVisibleSurface();
     }
 
+    public static bool TryStopSearchAtCurrentRoute()
+    {
+        if (_active is not { InitialSearch: not null, Result: null, SearchState: 1 } active
+            || active.Interaction.RenderedRouteAdoptionSeed is not { } seed)
+        {
+            return false;
+        }
+        return active.Interaction.RequestAdoptRoute(seed, stopAfterResult: true);
+    }
+
     public static bool StopSearchByUser()
     {
         if (ReferenceEquals(_deferredSetupCancellation, _cancellation)
@@ -631,11 +708,13 @@ internal static class PlayerTurnSetupCoordinator
             SolverSettingsSnapshot settings = SolverSettings.Capture();
             SolverDisplayNames displayNames = SolverDisplayNames.Capture(combat);
             BattleDamageSnapshot battleDamage = BattleDamageTracker.Observe(combat);
+            SearchInteractionState interaction = new();
             SearchPolicySnapshot searchPolicy = SolverController.CaptureSearchPolicy(
                 settings,
                 combat,
                 includeTurnSetup: true,
-                theftPolicy: SolverController.ResolveTheftPolicy(combat));
+                theftPolicy: SolverController.ResolveTheftPolicy(combat),
+                interaction: interaction);
             long rootCaptureAllocatedAtStart = GC.GetTotalAllocatedBytes(precise: false);
             CombatRootSnapshot rootSnapshot;
             try
@@ -968,12 +1047,11 @@ internal static class PlayerTurnSetupCoordinator
                 settings,
                 active.Combat,
                 includeTurnSetup: true,
-                theftPolicy: SolverController.ResolveTheftPolicy(active.Combat)),
+                theftPolicy: SolverController.ResolveTheftPolicy(active.Combat),
+                interaction: active.Interaction),
             original.RootSnapshot);
         int turn = active.Player.PlayerCombatState!.TurnNumber;
-        active.Progress = null;
-        active.ProgressDisplay.Restart(System.Environment.TickCount64);
-        Interlocked.Exchange(ref active.AdoptCurrentResultRequestState, 0);
+        active.Interaction.ResetForSearch();
         Interlocked.Exchange(ref active.ManualSearchState, 1);
         SolverOverlay.ShowSearching(
             host,
@@ -997,14 +1075,14 @@ internal static class PlayerTurnSetupCoordinator
                         refreshed.Settings.NoGcRegionBudgetBytes,
                         refreshed.SearchPolicy.MemoryPressureSignal,
                         active.Token);
-                    return CombatSearchCoordinator.Solve(
+                    SolverResult result = CombatSearchCoordinator.Solve(
                         refreshed.RootSnapshot,
                         refreshed.DisplayNames,
                         refreshed.BattleDamage,
                         refreshed.SearchPolicy,
                         active.Token,
-                        progress => Volatile.Write(ref active.Progress, progress),
-                        () => active.AdoptCurrentResultRequested);
+                        active.Interaction.PublishProgress);
+                    return active.Interaction.FinalizeWorkerResult(result);
                 }
                 finally
                 {
@@ -1013,23 +1091,11 @@ internal static class PlayerTurnSetupCoordinator
             }, active.Token);
             while (!solveTask.IsCompleted)
             {
-                SolverProgress? progress = Volatile.Read(ref active.Progress);
-                if (IsCurrentActivePlan(active)
-                    && active.ProgressDisplay.TryCreate(
-                        progress,
-                        System.Environment.TickCount64,
-                        out SolverProgress displayProgress))
-                {
-                    SolverOverlay.ShowProgress(
-                        displayProgress,
-                        deployWhenReady: false,
-                        SolverController.ReviewedWorldlinesTotal);
-                }
+                RefreshSearchProgress(active);
                 await host.ToSignal(host.GetTree(), SceneTree.SignalName.ProcessFrame);
                 active.Token.ThrowIfCancellationRequested();
             }
             SolverResult result = await solveTask;
-            Interlocked.Exchange(ref active.AdoptCurrentResultRequestState, 0);
             if (!IsCurrentActivePlan(active))
                 return;
             if (result.TurnSetupChoices.Count == 0)
@@ -1060,7 +1126,6 @@ internal static class PlayerTurnSetupCoordinator
         }
         finally
         {
-            Interlocked.Exchange(ref active.AdoptCurrentResultRequestState, 0);
             Interlocked.Exchange(ref active.ManualSearchState, 0);
             if (!active.ReplayDrivingStarted)
                 active.Choices.ReleaseVisibleSurface();
@@ -1086,9 +1151,9 @@ internal static class PlayerTurnSetupCoordinator
             await active.PlanReady.Task.WaitAsync(active.Token);
             return false;
         }
+        active.Interaction.ResetForSearch();
         int turn = active.Player.PlayerCombatState!.TurnNumber;
         active.Choices.RecordSearchStarted();
-        active.ProgressDisplay.Restart(System.Environment.TickCount64);
         SolverOverlay.ShowSearching(
             host,
             turn,
@@ -1112,14 +1177,14 @@ internal static class PlayerTurnSetupCoordinator
                         initialSearch.Settings.NoGcRegionBudgetBytes,
                         initialSearch.SearchPolicy.MemoryPressureSignal,
                         active.Token);
-                    return CombatSearchCoordinator.Solve(
+                    SolverResult result = CombatSearchCoordinator.Solve(
                         initialSearch.RootSnapshot,
                         initialSearch.DisplayNames,
                         initialSearch.BattleDamage,
                         initialSearch.SearchPolicy,
                         active.Token,
-                        progress => Volatile.Write(ref active.Progress, progress),
-                        () => active.AdoptCurrentResultRequested);
+                        active.Interaction.PublishProgress);
+                    return active.Interaction.FinalizeWorkerResult(result);
                 }
                 finally
                 {
@@ -1128,27 +1193,14 @@ internal static class PlayerTurnSetupCoordinator
             }, active.Token);
             while (!solveTask.IsCompleted)
             {
-                SolverProgress? progress = Volatile.Read(ref active.Progress);
-                if (IsCurrentActivePlan(active)
-                    && active.ProgressDisplay.TryCreate(
-                        progress,
-                        System.Environment.TickCount64,
-                        out SolverProgress displayProgress))
-                {
-                    SolverOverlay.ShowProgress(
-                        displayProgress,
-                        deployWhenReady: false,
-                        SolverController.ReviewedWorldlinesTotal);
-                }
+                RefreshSearchProgress(active);
                 await host.ToSignal(host.GetTree(), SceneTree.SignalName.ProcessFrame);
                 active.Token.ThrowIfCancellationRequested();
             }
             result = await solveTask;
-            Interlocked.Exchange(ref active.AdoptCurrentResultRequestState, 0);
         }
         catch (OperationCanceledException)
         {
-            Interlocked.Exchange(ref active.AdoptCurrentResultRequestState, 0);
             bool ownsCurrentLifecycle = ReferenceEquals(_active, active)
                 && SolverController.IsCurrentCombatLifecycle(
                     active.Combat,
@@ -1171,7 +1223,6 @@ internal static class PlayerTurnSetupCoordinator
         }
         catch (Exception ex)
         {
-            Interlocked.Exchange(ref active.AdoptCurrentResultRequestState, 0);
             if (!IsCurrentActivePlan(active))
             {
                 active.PlanReady.TrySetResult();
@@ -1187,7 +1238,8 @@ internal static class PlayerTurnSetupCoordinator
             active.PlanReady.TrySetResult();
             return false;
         }
-        if (SolverController.SolverDisabled || SolverController.AutomaticSearchPaused)
+        if (SolverController.SolverDisabled
+            || SolverController.AutomaticSearchPaused && !active.Interaction.StopRequested)
         {
             if (active.SearchState != 2 && ReferenceEquals(_active, active))
                 SearchCompletionNotifier.Notify(SearchCompletionNotificationKind.Canceled);
@@ -1204,7 +1256,12 @@ internal static class PlayerTurnSetupCoordinator
         active.Result = result;
         active.Choices.RecordPlanReady();
         SolverController.ShowTurnSetupResultPreview(host, result);
-        if (active.TakeoverRequested)
+        if (active.Interaction.StopRequested)
+        {
+            active.Interaction.PreserveStoppedResult(result, LiveCombatStamp.Capture(active.Combat));
+            SolverOverlay.ShowSearchStopped(host);
+        }
+        else if (active.TakeoverRequested)
             StartReplayDriver(active, host);
         else
             active.Choices.ReleaseVisibleSurface();

--- a/src/Runtime/SolverController.cs
+++ b/src/Runtime/SolverController.cs
@@ -72,14 +72,49 @@ internal static class SolverController
            || _deferredSearchCts != null
            || PlayerTurnSetupCoordinator.IsSearching;
     public static bool IsDeploying => _deployment != null;
+    public static bool IsStoppingSearch
+        => _search?.Interaction.StopRequested == true || PlayerTurnSetupCoordinator.IsStoppingSearch;
     public static bool SolverDisabled => _solverDisabled;
-    public static bool CanAdoptCurrentSearchResult
-        => _search is { AdoptCurrentResultRequested: false } search
-               && Volatile.Read(ref search.Progress)?.CurrentBestResult != null
-           || PlayerTurnSetupCoordinator.CanAdoptCurrentSearchResult;
-    public static bool IsAdoptingCurrentSearchResult
-        => _search?.AdoptCurrentResultRequested == true
-           || PlayerTurnSetupCoordinator.IsAdoptingCurrentSearchResult;
+    public static bool CanApplyCurrentTurn
+        => _search is { } search
+               && search.Interaction.CurrentTakeoverRequest == null
+               && search.Interaction.CanAcceptTakeover
+               && Volatile.Read(ref search.Interaction.Progress)?.RoutePreview != null
+           || PlayerTurnSetupCoordinator.CanApplyCurrentTurn;
+    public static bool IsApplyingCurrentTurn
+        => _search?.Interaction.IsApplyingCurrentTurn == true
+           || PlayerTurnSetupCoordinator.IsApplyingCurrentTurn;
+    public static bool CanAdoptCurrentRoute
+        => _search is { } search
+               && search.Interaction.CurrentTakeoverRequest == null
+               && search.Interaction.RenderedRouteAdoptionSeed != null
+               && search.Interaction.CanAcceptTakeover
+           || HasCurrentStoppedRoute()
+           || PlayerTurnSetupCoordinator.CanAdoptCurrentRoute;
+    public static bool IsAdoptingCurrentRoute
+        => _search?.Interaction.IsAdoptingRoute == true
+           || PlayerTurnSetupCoordinator.IsAdoptingCurrentRoute;
+
+
+    internal static void InvalidateRenderedRouteAdoptionSeed()
+    {
+        if (_search != null)
+            _search.Interaction.RenderedRouteAdoptionSeed = null;
+        PlayerTurnSetupCoordinator.InvalidateRenderedRouteAdoptionSeed();
+    }
+
+    public static bool CanExecuteCurrentTurn
+    {
+        get
+        {
+            CombatState? state = CombatManager.Instance.DebugOnlyGetState();
+            if (state == null || !CombatManager.Instance.IsInProgress)
+                return false;
+            return _combat.LatestResult != null
+                    && _combat.LatestStamp == LiveCombatStamp.Capture(state)
+                || PlayerTurnSetupCoordinator.CanTakeOverTurnSetup(state);
+        }
+    }
 
     /// <summary>
     /// True whenever the current run is a networked multiplayer session (host or client).
@@ -91,6 +126,8 @@ internal static class SolverController
 
     public static bool FullAutoEnabled => _combat.FullAutoEnabled;
     public static bool AutomaticSearchPaused => _combat.AutomaticSearchPaused;
+    public static bool AutomaticCalculationEnabled => SolverSettings.Current.AutomaticCalculationEnabled;
+    public static bool HasCalculatedThisCombat => _combat.SearchesStarted > 0 || _combat.LatestResult != null;
     public static bool StopFullAutoOnCombatEnd => _stopFullAutoOnCombatEnd;
     public static bool StopFullAutoOnDeathTurn => _stopFullAutoOnDeathTurn;
     public static bool StopFullAutoOnWorseRecalculation => _stopFullAutoOnWorseRecalculation;
@@ -157,6 +194,43 @@ internal static class SolverController
         if (!UnattendedTestRunner.IsActive)
             throw new InvalidOperationException("搜索会话取消入口只能在无人测试中使用。");
         CancelSearch();
+    }
+
+
+    private static bool HasCurrentStoppedRoute()
+    {
+        CombatState? state = CombatManager.Instance.DebugOnlyGetState();
+        return state != null
+            && CombatManager.Instance.IsInProgress
+            && _combat.StoppedSearch is { StoppedResult: not null, StoppedStamp: { } stamp }
+            && stamp == LiveCombatStamp.Capture(state);
+    }
+
+    private static bool TryAdoptStoppedRoute()
+    {
+        CombatState? state = CombatManager.Instance.DebugOnlyGetState();
+        NGame? host = NGame.Instance;
+        if (state == null || host == null || _combat.StoppedSearch is not { } stopped)
+            return false;
+        LiveCombatStamp stamp = LiveCombatStamp.Capture(state);
+        SolverResult? result = stopped.TakeStoppedResult(stamp);
+        _combat.StoppedSearch = null;
+        if (result == null)
+            return false;
+
+        _combat.LatestResult = result;
+        _combat.LatestStamp = stamp;
+        _combat.ContinuationSource = result;
+        BattleDamageTracker.RegisterPlan(state, result);
+        SolverOverlaySnapshot snapshot = SolverOverlaySnapshot.CaptureWithReviewedWorldlines(
+            result,
+            UnexpectedReplanCount > 0,
+            _combat.ReviewedWorldlinesTotal);
+        SolverOverlay.ShowResult(host, MarkRouteAdopted(snapshot));
+        SolverOverlay.RefreshControls();
+        Entry.Logger.Info(
+            $"[CombatSolver/Test] STOPPED_ROUTE_ADOPTED turn={result.StartTurnNumber} actions={result.BestNode.Actions.Count}");
+        return true;
     }
 
     internal static Task StartCombatDeferredOperation(
@@ -317,7 +391,8 @@ internal static class SolverController
         SolverSettingsSnapshot settings,
         CombatState state,
         bool includeTurnSetup,
-        SolverTheftPolicy? theftPolicy)
+        SolverTheftPolicy? theftPolicy,
+        SearchInteractionState? interaction = null)
     {
         FramePressureSignal.ResetPressure(
             recoveryEnabled: !string.Equals(
@@ -351,7 +426,10 @@ internal static class SolverController
                 message => Entry.Logger.Info(message),
                 message => Entry.Logger.Debug(message)),
             FramePressureSignal,
-            new SearchMemoryPressureSignal());
+            new SearchMemoryPressureSignal())
+        {
+            Interaction = interaction,
+        };
     }
 
     public static void BeginCombat(ICombatState? state)
@@ -413,7 +491,9 @@ internal static class SolverController
         _combat.State = state;
         _combat.LatestResult = result;
         _combat.LatestStamp = stamp;
-        _combat.ContinuationSource = result;
+        _combat.ContinuationSource = result.ResultScope == SolverResultScope.CurrentTurnAdoption
+            ? null
+            : result;
         _combat.SearchesStarted++;
         _combat.ReplanCounts[ReplanCause.InitialSearch] = _combat.ReplanCounts.GetValueOrDefault(ReplanCause.InitialSearch) + 1;
         if (UnattendedTestRunner.IsActive)
@@ -424,19 +504,27 @@ internal static class SolverController
         BattleDamageTracker.RegisterPlan(state, result);
         CombatBugReportExporter.RecordCheckpoint(
             state,
-            "turn_setup_result",
+            result.ResultScope switch
+            {
+                SolverResultScope.CurrentTurnAdoption => "turn_setup_current_turn_adopted",
+                SolverResultScope.RouteAdoption => "turn_setup_route_adopted",
+                _ => "turn_setup_result",
+            },
             result,
             DescribeReplanAudit());
-        SolverOverlay.ShowResult(
-            host,
-            SolverOverlaySnapshot.CaptureWithReviewedWorldlines(
-                result,
-                UnexpectedReplanCount > 0,
-                _combat.ReviewedWorldlinesTotal));
+        SolverOverlaySnapshot snapshot = SolverOverlaySnapshot.CaptureWithReviewedWorldlines(
+            result,
+            UnexpectedReplanCount > 0,
+            _combat.ReviewedWorldlinesTotal);
+        if (result.ResultScope == SolverResultScope.RouteAdoption)
+            snapshot = MarkRouteAdopted(snapshot);
+        SolverOverlay.ShowResult(host, snapshot);
         Entry.Logger.Info(
-            $"[CombatSolver/Test] TURN_SETUP_RESULT_ACCEPTED turn={player.PlayerCombatState.TurnNumber}");
+            $"[CombatSolver/Test] TURN_SETUP_RESULT_ACCEPTED turn={player.PlayerCombatState.TurnNumber} " +
+            $"scope={result.ResultScope}");
         Entry.Logger.Info(SolverDiagnostics.DescribeResult(result));
-        if (_combat.FullAutoEnabled)
+        if (_combat.FullAutoEnabled
+            && result.ResultScope != SolverResultScope.CurrentTurnAdoption)
         {
             Task fullAutoTask = StartCombatDeferredOperation(
                 token => StartFullAutoAfterTurnSetupAsync(host, state, result, token));
@@ -451,16 +539,17 @@ internal static class SolverController
     {
         AssertMainThread();
         RecordReviewedWorldlines(result);
-        SolverOverlay.ShowResult(
-            host,
-            SolverOverlaySnapshot.CaptureWithReviewedWorldlines(
-                result,
-                UnexpectedReplanCount > 0,
-                _combat.ReviewedWorldlinesTotal));
+        SolverOverlaySnapshot snapshot = SolverOverlaySnapshot.CaptureWithReviewedWorldlines(
+            result,
+            UnexpectedReplanCount > 0,
+            _combat.ReviewedWorldlinesTotal);
+        if (result.ResultScope == SolverResultScope.RouteAdoption)
+            snapshot = MarkRouteAdopted(snapshot);
+        SolverOverlay.ShowResult(host, snapshot);
         SearchCompletionNotifier.Notify(SearchCompletionNotificationKind.Succeeded);
         Entry.Logger.Info(
             $"[CombatSolver/Test] TURN_SETUP_RESULT_PREVIEW turn={result.StartTurnNumber} " +
-            "native_choice_pending=true");
+            $"scope={result.ResultScope} native_choice_pending=true");
         Entry.Logger.Info(SolverDiagnostics.DescribeResult(result));
     }
 
@@ -661,6 +750,7 @@ internal static class SolverController
     public static void RequestSearch(NGame host, CombatState state, SearchReason reason, bool deployWhenReady = false)
     {
         AssertMainThread();
+        _combat.StoppedSearch = null;
         SolverDispatcher.Ensure(host);
         int? searchTurn = LocalContext.GetMe(state)?.PlayerCombatState?.TurnNumber;
         if (_combat.DeployAfterTurnSetupTurn == searchTurn)
@@ -882,7 +972,8 @@ internal static class SolverController
                 settings,
                 state,
                 includeTurnSetup: false,
-                theftPolicy: theftPolicy);
+                theftPolicy: theftPolicy,
+                interaction: search.Interaction);
             search.MaxDegreeOfParallelism = searchPolicy.MaxDegreeOfParallelism;
             setupStage = "combat_root_snapshot";
             long rootCaptureAllocatedAtStart = GC.GetTotalAllocatedBytes(precise: false);
@@ -954,14 +1045,14 @@ internal static class SolverController
                         settings.NoGcRegionBudgetBytes,
                         searchPolicy.MemoryPressureSignal,
                         token);
-                    return CombatSearchCoordinator.Solve(
+                    SolverResult result = CombatSearchCoordinator.Solve(
                         rootSnapshot,
                         displayNames,
                         battleDamage,
                         searchPolicy,
                         token,
-                        progress => PublishSearchProgress(search, progress),
-                        () => search.AdoptCurrentResultRequested);
+                        progress => PublishSearchProgress(search, progress));
+                    return search.Interaction.FinalizeWorkerResult(result);
                 }
                 finally
                 {
@@ -1181,6 +1272,68 @@ internal static class SolverController
             RequestSearch(host, state, SearchReason.FullAuto);
     }
 
+    public static bool PrepareAutomaticSearchForTurn(NGame host, CombatState state)
+    {
+        AssertMainThread();
+        int turn = LocalContext.GetMe(state)?.PlayerCombatState?.TurnNumber ?? -1;
+        if (_combat.AutomaticSearchPaused
+            && _combat.AutomaticSearchPausedTurn is { } stoppedTurn
+            && stoppedTurn != turn)
+        {
+            _combat.AutomaticSearchPaused = false;
+            _combat.AutomaticSearchPausedTurn = null;
+            Entry.Logger.Info(
+                $"[CombatSolver/Test] AUTOMATIC_SEARCH_STOP_CLEARED stopped_turn={stoppedTurn} current_turn={turn}");
+        }
+        if (!AutomaticCalculationEnabled)
+        {
+            SolverOverlay.ShowManualCalculationReady(host, HasCalculatedThisCombat);
+            return false;
+        }
+        if (_combat.AutomaticSearchPaused)
+        {
+            SolverOverlay.ShowSearchStopped(host);
+            return false;
+        }
+        return true;
+    }
+
+    public static void SetAutomaticCalculationEnabled(bool enabled, bool persist = true)
+    {
+        AssertMainThread();
+        if (persist)
+        {
+            SolverSettings.Update(SolverSettings.Current with
+            {
+                AutomaticCalculationEnabled = enabled,
+            });
+        }
+        if (!enabled)
+            _combat.FullAutoEnabled = false;
+        Entry.Logger.Info(
+            $"[CombatSolver/Test] AUTOMATIC_CALCULATION enabled={enabled.ToString().ToLowerInvariant()}");
+        SolverOverlay.RefreshControls();
+
+        NGame? host = NGame.Instance;
+        CombatState? state = CombatManager.Instance.DebugOnlyGetState();
+        if (host == null || state == null || !CombatManager.Instance.IsInProgress)
+            return;
+        if (!enabled)
+        {
+            if (!IsSearching)
+                SolverOverlay.ShowManualCalculationReady(host, HasCalculatedThisCombat);
+            return;
+        }
+        if (!_combat.AutomaticSearchPaused
+            && !IsSearching
+            && !IsDeploying
+            && UnattendedTestRunner.AutomaticTurnSearchEnabled
+            && CanSolve(state, out _))
+        {
+            RequestSearch(host, state, SearchReason.AutoTurnStart);
+        }
+    }
+
     public static void SetSolverDisabled(bool disabled, bool persist = true)
     {
         AssertMainThread();
@@ -1217,6 +1370,7 @@ internal static class SolverController
         if (game != null
             && state != null
             && UnattendedTestRunner.AutomaticTurnSearchEnabled
+            && AutomaticCalculationEnabled
             && CanSolve(state, out _))
         {
             RequestSearch(game, state, SearchReason.AutoTurnStart);
@@ -1233,34 +1387,73 @@ internal static class SolverController
         int? generation = _search?.Generation;
         _combat.FullAutoEnabled = false;
         _combat.AutomaticSearchPaused = true;
+        _combat.AutomaticSearchPausedTurn = LocalContext.GetMe(
+            CombatManager.Instance.DebugOnlyGetState())?.PlayerCombatState?.TurnNumber;
         CancelDeferredSearch();
-        CancelSearch();
-        bool stoppedTurnSetupSearch = PlayerTurnSetupCoordinator.StopSearchByUser();
-        if (controllerSearchCanceled || stoppedTurnSetupSearch)
+        bool stoppingControllerAtCandidate = _search is { } search
+            && search.Interaction.RenderedRouteAdoptionSeed is { } seed
+            && search.Interaction.RequestAdoptRoute(seed, stopAfterResult: true);
+        bool stoppingSetupAtCandidate = _search == null
+            && PlayerTurnSetupCoordinator.TryStopSearchAtCurrentRoute();
+        bool stoppingAtCandidate = stoppingControllerAtCandidate || stoppingSetupAtCandidate;
+        if (!stoppingAtCandidate)
+            CancelSearch();
+        bool stoppedTurnSetupSearch = stoppingSetupAtCandidate
+            || !stoppingAtCandidate && PlayerTurnSetupCoordinator.StopSearchByUser();
+        if (!stoppingAtCandidate && (controllerSearchCanceled || stoppedTurnSetupSearch))
             SearchCompletionNotifier.Notify(SearchCompletionNotificationKind.Canceled);
         _combat.PendingCompleteProjectionBaseline = null;
         _combat.PendingManualProjectionBaseline = null;
         SolverOverlay.ShowSearchStopped(host);
         Entry.Logger.Info(
             $"[CombatSolver/Test] SEARCH_STOPPED_BY_USER generation={generation?.ToString() ?? "-"} " +
-            $"turn_setup={stoppedTurnSetupSearch.ToString().ToLowerInvariant()} automatic_search_paused=true");
+            $"turn_setup={stoppedTurnSetupSearch.ToString().ToLowerInvariant()} " +
+            $"candidate_preserved={stoppingAtCandidate.ToString().ToLowerInvariant()} automatic_search_paused=true");
     }
 
-    public static void AdoptCurrentSearchResult()
+    public static void ApplyCurrentTurn()
     {
         AssertMainThread();
+        _combat.AutomaticSearchPaused = false;
+        _combat.AutomaticSearchPausedTurn = null;
+        _combat.FullAutoEnabled = false;
         if (_search is not { } search)
         {
-            PlayerTurnSetupCoordinator.AdoptCurrentSearchResult();
+            PlayerTurnSetupCoordinator.ApplyCurrentTurn();
             return;
         }
-        if (search.AdoptCurrentResultRequested
-            || Volatile.Read(ref search.Progress)?.CurrentBestResult == null)
+        if (search.Interaction.CurrentTakeoverRequest != null
+            || Volatile.Read(ref search.Interaction.Progress)?.RoutePreview == null)
+        {
             return;
+        }
 
-        search.RequestAdoptCurrentResult();
+        search.DeployWhenReady = true;
+        if (!search.Interaction.RequestApplyCurrentTurn())
+            return;
         SolverOverlay.RefreshControls();
-        Entry.Logger.Info("[CombatSolver/Test] UI_ACTION action=adopt_current_search_result");
+        Entry.Logger.Info("[CombatSolver/Test] UI_ACTION action=apply_current_turn");
+    }
+
+    public static void AdoptCurrentRoute()
+    {
+        AssertMainThread();
+        _combat.AutomaticSearchPaused = false;
+        _combat.AutomaticSearchPausedTurn = null;
+        if (_search is not { } search)
+        {
+            if (TryAdoptStoppedRoute())
+                return;
+            PlayerTurnSetupCoordinator.AdoptCurrentRoute();
+            return;
+        }
+        SolverRouteAdoptionSeed? seed = search.Interaction.RenderedRouteAdoptionSeed;
+        if (seed == null || !search.Interaction.RequestAdoptRoute(seed))
+            return;
+        SolverOverlay.RefreshControls();
+        Entry.Logger.Info(
+            $"[CombatSolver/Test] UI_ACTION action=adopt_current_route " +
+            $"candidate_version={seed.CandidateVersion}");
     }
 
     public static void SetStopFullAutoOnCombatEnd(bool enabled, bool persist = true)
@@ -1318,6 +1511,11 @@ internal static class SolverController
         Entry.Logger.Info(
             $"[CombatSolver/Test] THEFT_POLICY_CHANGED previous={previous?.ToString() ?? "-"} current={policy}");
         SolverOverlay.RefreshControls();
+        if (_combat.AutomaticSearchPaused || !AutomaticCalculationEnabled)
+        {
+            Entry.Logger.Info("[CombatSolver/Test] THEFT_POLICY_RECALCULATION_SKIPPED reason=automatic_calculation_inactive");
+            return;
+        }
         RequestSearch(host, state, SearchReason.Manual);
     }
 
@@ -1387,6 +1585,11 @@ internal static class SolverController
         Entry.Logger.Info(
             $"[CombatSolver/Test] POTION_DIRECTIVE_CHANGED slot={slot} potion={potionId} directive={directive}");
         SolverOverlay.RefreshControls();
+        if (_combat.AutomaticSearchPaused || !AutomaticCalculationEnabled)
+        {
+            Entry.Logger.Info("[CombatSolver/Test] POTION_DIRECTIVE_RECALCULATION_SKIPPED reason=automatic_calculation_inactive");
+            return;
+        }
         RequestSearch(host, state, SearchReason.Manual);
     }
 
@@ -1607,6 +1810,27 @@ internal static class SolverController
             $"managed_live_bytes={GC.GetTotalMemory(forceFullCollection: false)}");
     }
 
+    internal static void SimulateDeploymentCompletionForTesting(NGame host, CombatState state)
+    {
+        AssertMainThread();
+        if (!UnattendedTestRunner.IsActive
+            || !ReferenceEquals(_combat.State, state)
+            || _combat.LatestResult is not { } result
+            || _combat.LatestStamp != LiveCombatStamp.Capture(state))
+        {
+            throw new InvalidOperationException("无人测试无法模拟消费当前就绪路线。");
+        }
+        int actionCount = result.BestNode.Actions.Count(action =>
+            action.Turn == result.StartTurnNumber && action.IsExecutable);
+        _combat.LatestResult = null;
+        _combat.LatestStamp = null;
+        SolverOverlay.ShowDeploymentComplete(
+            host,
+            result.StartTurnNumber,
+            actionCount,
+            endedTurn: true);
+    }
+
     internal static void ReleaseUnattendedResultReferencesForTesting()
     {
         AssertMainThread();
@@ -1647,16 +1871,25 @@ internal static class SolverController
     public static void RefreshSearchProgress()
     {
         AssertMainThread();
-        if (_search is not { } search)
+        if (_search is not { } search || !SolverOverlay.IsVisible
+            || !search.Interaction.TryCreateDisplayProgress(
+                System.Environment.TickCount64,
+                out SolverProgress progress))
+        {
             return;
-        SolverProgress? progress = Volatile.Read(ref search.Progress);
-        long now = System.Environment.TickCount64;
-        if (!search.ProgressDisplay.TryCreate(progress, now, out SolverProgress displayProgress))
-            return;
+        }
+        SolverOverlaySnapshot? preview = progress.RoutePreview == null
+            ? null
+            : SolverOverlaySnapshot.CaptureRoutePreview(progress.RoutePreview);
+        search.Interaction.RenderedRouteAdoptionSeed = preview == null
+            ? null
+            : progress.RouteAdoptionSeed;
         SolverOverlay.ShowProgress(
-            displayProgress,
+            progress,
             search.DeployWhenReady,
-            _combat.ReviewedWorldlinesTotal);
+            _combat.ReviewedWorldlinesTotal,
+            preview);
+        SolverOverlay.RefreshControls();
     }
 
     public static void ObserveMainThreadFrameGap(TimeSpan gap)
@@ -1678,7 +1911,7 @@ internal static class SolverController
         search.ObserveFrame(milliseconds);
         if (milliseconds >= 100d)
         {
-            SolverProgress? progress = Volatile.Read(ref search.Progress);
+            SolverProgress? progress = Volatile.Read(ref search.Interaction.Progress);
             Entry.Logger.Info(
                 $"[CombatSolver/Test] MAIN_THREAD_LONG_FRAME gap_ms={milliseconds:F1} " +
                 $"frame={search.FrameCount} expanded={progress?.ExpandedNodes ?? -1} " +
@@ -1686,11 +1919,10 @@ internal static class SolverController
                 $"gc_pause_delta_ms={(GC.GetTotalPauseDuration() - search.ProcessGcPauseAtStart).TotalMilliseconds:F1}");
         }
     }
-
     private static void PublishSearchProgress(SolverSearchSession search, SolverProgress progress)
     {
         if (ReferenceEquals(_search, search))
-            Volatile.Write(ref search.Progress, progress);
+            search.Interaction.PublishProgress(progress);
     }
 
     private static string DescribeReplanAudit()
@@ -1763,7 +1995,7 @@ internal static class SolverController
         if (!ReferenceEquals(_search, search))
             return;
         _search = null;
-        Volatile.Write(ref search.Progress, null);
+        Volatile.Write(ref search.Interaction.Progress, null);
         int generation = search.Generation;
         Entry.Logger.Info($"[CombatSolver/Test] SEARCH_CALLBACK generation={generation} thread={System.Environment.CurrentManagedThreadId} main_thread={NGame.IsMainThread()}");
         Entry.Logger.Info(
@@ -1824,6 +2056,84 @@ internal static class SolverController
         }
 
         SolverResult result = task.Result;
+        bool stopped = search.Interaction.StopRequested;
+        bool currentTurnAdopted = result.ResultScope == SolverResultScope.CurrentTurnAdoption;
+        bool routeAdopted = result.ResultScope == SolverResultScope.RouteAdoption;
+        if (stopped || currentTurnAdopted)
+        {
+            _combat.PendingCompleteProjectionBaseline = null;
+            _combat.PendingManualProjectionBaseline = null;
+        }
+        else
+        {
+            ApplyProjectionBaselines(result);
+        }
+        ApplySearchFrameMetrics(result, search);
+        RecordReviewedWorldlines(result);
+
+        if (stopped)
+        {
+            result.ResultScope = SolverResultScope.RouteAdoption;
+            search.Interaction.PreserveStoppedResult(result, searchedStamp);
+            _combat.StoppedSearch = search.Interaction;
+            SolverOverlay.ShowResult(
+                host,
+                SolverOverlaySnapshot.CaptureWithReviewedWorldlines(
+                    result,
+                    UnexpectedReplanCount > 0,
+                    _combat.ReviewedWorldlinesTotal));
+            SolverOverlay.ShowSearchStopped(host);
+            SearchCompletionNotifier.Notify(SearchCompletionNotificationKind.Canceled);
+            Entry.Logger.Info(
+                $"[CombatSolver/Test] SEARCH_STOPPED_RESULT_PRESERVED generation={generation} " +
+                $"actions={result.BestNode.Actions.Count}");
+            return;
+        }
+
+        _combat.LatestResult = result;
+        _combat.LatestStamp = searchedStamp;
+        _combat.ContinuationSource = currentTurnAdopted ? null : result;
+        if (UnattendedTestRunner.IsActive)
+            LastCompletedResultForTesting = result;
+        BattleDamageTracker.RegisterPlan(searchedState, result);
+        CombatBugReportExporter.RecordCheckpoint(
+            searchedState,
+            currentTurnAdopted
+                ? "search_current_turn_adopted"
+                : routeAdopted
+                    ? "search_route_adopted"
+                    : "search_completed",
+            result,
+            DescribeReplanAudit());
+        SolverOverlaySnapshot completedSnapshot = SolverOverlaySnapshot.CaptureWithReviewedWorldlines(
+            result,
+            UnexpectedReplanCount > 0,
+            _combat.ReviewedWorldlinesTotal);
+        SolverOverlay.ShowResult(
+            host,
+            routeAdopted ? MarkRouteAdopted(completedSnapshot) : completedSnapshot);
+        SearchCompletionNotifier.Notify(SearchCompletionNotificationKind.Succeeded);
+        if (currentTurnAdopted)
+        {
+            Entry.Logger.Info(
+                $"[CombatSolver/Test] SEARCH_CURRENT_TURN_ADOPTED generation={generation} " +
+                $"turn={result.StartTurnNumber} actions={result.BestNode.Actions.Count}");
+        }
+        else if (routeAdopted)
+        {
+            Entry.Logger.Info(
+                $"[CombatSolver/Test] SEARCH_ROUTE_ADOPTED generation={generation} " +
+                $"actions={result.BestNode.Actions.Count} continuations={result.Continuations.Count}");
+        }
+        Entry.Logger.Info(SolverDiagnostics.DescribeResult(result));
+        if (currentTurnAdopted || search.DeployWhenReady)
+            StartDeployment(host, searchedState, result);
+        else if (_combat.FullAutoEnabled)
+            StartFullAutoDeployment(host, searchedState, result);
+    }
+
+    private static void ApplyProjectionBaselines(SolverResult result)
+    {
         CompleteProjectionBaseline? recalculationBaseline = _combat.PendingCompleteProjectionBaseline;
         ManualProjectionBaseline? manualBaseline = _combat.PendingManualProjectionBaseline;
         _combat.PendingCompleteProjectionBaseline = null;
@@ -1852,6 +2162,10 @@ internal static class SolverController
                 result.StartTurnNumber,
                 result.ProjectedBattleHpLost);
         }
+    }
+
+    private static void ApplySearchFrameMetrics(SolverResult result, SolverSearchSession search)
+    {
         result.MainThreadFrameCount = search.FrameCount;
         result.MainThreadFramesOver33Milliseconds = search.FramesOver33Milliseconds;
         result.MaxMainThreadFrameGapMilliseconds = search.MaxFrameGapMilliseconds;
@@ -1859,35 +2173,14 @@ internal static class SolverController
         result.P99MainThreadFrameGapMilliseconds = search.FramePercentile(0.99d);
         result.MainThreadFramesOver50Milliseconds = search.FramesOver50Milliseconds;
         result.MainThreadFramesOver100Milliseconds = search.FramesOver100Milliseconds;
-        RecordReviewedWorldlines(result);
-        _combat.LatestResult = result;
-        _combat.LatestStamp = searchedStamp;
-        if (UnattendedTestRunner.IsActive)
-            LastCompletedResultForTesting = result;
-        _combat.ContinuationSource = result;
-        BattleDamageTracker.RegisterPlan(searchedState, result);
-        CombatBugReportExporter.RecordCheckpoint(
-            searchedState,
-            "search_completed",
-            result,
-            DescribeReplanAudit());
-        SolverOverlay.ShowResult(
-            host,
-            SolverOverlaySnapshot.CaptureWithReviewedWorldlines(
-                result,
-                UnexpectedReplanCount > 0,
-                _combat.ReviewedWorldlinesTotal));
-        SearchCompletionNotifier.Notify(SearchCompletionNotificationKind.Succeeded);
-        Entry.Logger.Info(SolverDiagnostics.DescribeResult(result));
-        if (search.DeployWhenReady)
-        {
-            StartDeployment(host, searchedState, result);
-        }
-        else if (_combat.FullAutoEnabled)
-        {
-            StartFullAutoDeployment(host, searchedState, result);
-        }
     }
+
+    private static SolverOverlaySnapshot MarkRouteAdopted(SolverOverlaySnapshot snapshot)
+        => snapshot with
+        {
+            StatusText = "方案就绪 · 已采用当前路线",
+            StatusTone = SolverOverlayTone.Success,
+        };
 
     private static void StartFullAutoDeployment(NGame host, CombatState state, SolverResult result)
     {

--- a/src/Runtime/SolverControllerSessions.cs
+++ b/src/Runtime/SolverControllerSessions.cs
@@ -71,6 +71,7 @@ internal sealed class SolverCombatSession
     public SolverResult? LatestResult { get; set; }
     public LiveCombatStamp? LatestStamp { get; set; }
     public SolverResult? ContinuationSource { get; set; }
+    public SearchInteractionState? StoppedSearch { get; set; }
     public bool FullAutoEnabled { get; set; }
     public SolverTheftPolicy? TheftPolicy { get; set; }
     public CompleteProjectionBaseline? PendingCompleteProjectionBaseline { get; set; }
@@ -78,6 +79,7 @@ internal sealed class SolverCombatSession
     public ManualProjectionComparison? LastManualProjectionComparison { get; set; }
     public bool ManualRouteImprovementDetected { get; set; }
     public bool AutomaticSearchPaused { get; set; }
+    public int? AutomaticSearchPausedTurn { get; set; }
     public bool ManualSearchAfterTurnSetupRequested { get; set; }
     public int? DeployAfterTurnSetupTurn { get; set; }
     public CombatState? TurnSetupResumeState { get; set; }
@@ -114,20 +116,12 @@ internal sealed class SolverSearchSession(
     public int CancellationDisposeState;
     public bool DeployWhenReady { get; set; } = deployWhenReady;
     public int MaxDegreeOfParallelism { get; set; } = 1;
-    public SolverProgress? Progress;
-    public SearchProgressDisplayState ProgressDisplay { get; } = new();
-    public int AdoptCurrentResultRequestState;
+    public SearchInteractionState Interaction { get; } = new();
     public int FrameCount { get; private set; }
     public int FramesOver33Milliseconds { get; private set; }
     public int FramesOver50Milliseconds { get; private set; }
     public int FramesOver100Milliseconds { get; private set; }
     public double MaxFrameGapMilliseconds { get; private set; }
-
-    public bool AdoptCurrentResultRequested
-        => Volatile.Read(ref AdoptCurrentResultRequestState) != 0;
-
-    public void RequestAdoptCurrentResult()
-        => Interlocked.Exchange(ref AdoptCurrentResultRequestState, 1);
 
     public long ProcessAllocatedBytesAtStart { get; } = GC.GetTotalAllocatedBytes(precise: false);
     public TimeSpan ProcessGcPauseAtStart { get; } = GC.GetTotalPauseDuration();

--- a/src/Runtime/SolverProgress.cs
+++ b/src/Runtime/SolverProgress.cs
@@ -1,5 +1,138 @@
 namespace CombatSolver;
 
+internal enum SearchTakeoverKind
+{
+    ApplyCurrentTurn,
+    AdoptRoute,
+}
+
+internal sealed record SearchTakeoverRequest(
+    SearchTakeoverKind Kind,
+    SolverRouteAdoptionSeed? RouteAdoptionSeed = null,
+    bool StopAfterResult = false);
+
+internal sealed class SolverRouteAdoptionSeed(
+    int candidateVersion,
+    IReadOnlyList<PlanAction> actions,
+    Func<SolverResult> materialize)
+{
+    private readonly Lazy<SolverResult> _materialized = new(
+        materialize,
+        LazyThreadSafetyMode.ExecutionAndPublication);
+
+    public int CandidateVersion { get; } = candidateVersion;
+    public IReadOnlyList<PlanAction> Actions { get; } = actions;
+
+    public SolverResult Materialize()
+        => _materialized.Value;
+}
+
+internal sealed class SearchInteractionState
+{
+    private readonly object _gate = new();
+    private int _acceptingTakeover = 1;
+    private SearchTakeoverRequest? _takeoverRequest;
+
+    public SearchProgressDisplayState ProgressDisplay { get; } = new();
+    public SolverProgress? Progress;
+    public SolverProgress? RenderedProgress { get; private set; }
+    public SolverRouteAdoptionSeed? RenderedRouteAdoptionSeed { get; set; }
+    public SolverResult? StoppedResult { get; private set; }
+    public LiveCombatStamp? StoppedStamp { get; private set; }
+
+    public SearchTakeoverRequest? CurrentTakeoverRequest
+        => Volatile.Read(ref _takeoverRequest);
+    public bool CanAcceptTakeover
+        => Volatile.Read(ref _acceptingTakeover) != 0;
+    public bool IsApplyingCurrentTurn
+        => CurrentTakeoverRequest?.Kind == SearchTakeoverKind.ApplyCurrentTurn;
+    public bool IsAdoptingRoute
+        => CurrentTakeoverRequest?.Kind == SearchTakeoverKind.AdoptRoute;
+    public bool StopRequested
+        => CurrentTakeoverRequest?.StopAfterResult == true;
+
+    public void PublishProgress(SolverProgress progress)
+        => Volatile.Write(ref Progress, progress);
+
+    public bool TryCreateDisplayProgress(long now, out SolverProgress displayProgress)
+    {
+        SolverProgress? progress = Volatile.Read(ref Progress);
+        if (progress == null || ReferenceEquals(progress, RenderedProgress)
+            || !ProgressDisplay.TryCreate(progress, now, out displayProgress))
+        {
+            displayProgress = null!;
+            return false;
+        }
+        RenderedProgress = displayProgress;
+        return true;
+    }
+
+    public void ResetForSearch()
+    {
+        lock (_gate)
+        {
+            Volatile.Write(ref _takeoverRequest, null);
+            Volatile.Write(ref _acceptingTakeover, 1);
+        }
+        Progress = null;
+        RenderedProgress = null;
+        RenderedRouteAdoptionSeed = null;
+        StoppedResult = null;
+        StoppedStamp = null;
+        ProgressDisplay.Restart(Environment.TickCount64);
+    }
+
+    public bool RequestApplyCurrentTurn()
+        => RequestTakeover(new SearchTakeoverRequest(SearchTakeoverKind.ApplyCurrentTurn));
+
+    public bool RequestAdoptRoute(SolverRouteAdoptionSeed seed, bool stopAfterResult = false)
+        => RequestTakeover(new SearchTakeoverRequest(
+            SearchTakeoverKind.AdoptRoute,
+            seed,
+            stopAfterResult));
+
+    private bool RequestTakeover(SearchTakeoverRequest request)
+    {
+        lock (_gate)
+        {
+            if (!CanAcceptTakeover || _takeoverRequest != null)
+                return false;
+            Volatile.Write(ref _takeoverRequest, request);
+            return true;
+        }
+    }
+
+    public SolverResult FinalizeWorkerResult(SolverResult result)
+    {
+        lock (_gate)
+        {
+            Volatile.Write(ref _acceptingTakeover, 0);
+            SearchTakeoverRequest? request = CurrentTakeoverRequest;
+            if (request?.Kind == SearchTakeoverKind.AdoptRoute
+                && request.RouteAdoptionSeed != null
+                && result.ResultScope != SolverResultScope.RouteAdoption)
+            {
+                return request.RouteAdoptionSeed.Materialize();
+            }
+            return result;
+        }
+    }
+
+    public void PreserveStoppedResult(SolverResult result, LiveCombatStamp stamp)
+    {
+        StoppedResult = result;
+        StoppedStamp = stamp;
+    }
+
+    public SolverResult? TakeStoppedResult(LiveCombatStamp currentStamp)
+    {
+        SolverResult? result = StoppedStamp == currentStamp ? StoppedResult : null;
+        StoppedResult = null;
+        StoppedStamp = null;
+        return result;
+    }
+}
+
 internal sealed record SolverInterimResult(
     bool Won,
     int OutstandingStolenResource,
@@ -9,6 +142,44 @@ internal sealed record SolverInterimResult(
     int ProjectedBattlePotionCount,
     int EnemyHp,
     double Score);
+
+internal sealed record SolverFrontierTurn(
+    int Turn,
+    IReadOnlyList<PlanAction> Actions,
+    int HpLost,
+    int EnemyHpLost,
+    int EnergyLeft,
+    bool CombatEnded);
+
+internal sealed record SolverRoutePreview(
+    int CandidateVersion,
+    int StartTurnNumber,
+    int ProjectedBattlePotionCount,
+    int ProjectedBattleHpLost,
+    bool OnlyDeathRoutesFound,
+    bool HasRisk,
+    IReadOnlyList<SolverFrontierTurn> Turns)
+{
+    public static SolverRoutePreview FromResult(SolverResult result, int candidateVersion = 0)
+        => new(
+            candidateVersion,
+            result.StartTurnNumber,
+            result.ProjectedBattlePotionCount,
+            result.ProjectedBattleHpLost,
+            result.OnlyDeathRoutesFound,
+            result.Snapshot.HasRisk,
+            result.BestNode.Actions
+                .GroupBy(action => action.Turn)
+                .OrderBy(group => group.Key)
+                .Select(group => new SolverFrontierTurn(
+                    group.Key,
+                    group.ToArray(),
+                    result.HpLostByTurn.GetValueOrDefault(group.Key),
+                    result.EnemyHpLostByTurn.GetValueOrDefault(group.Key),
+                    result.EnergyLeftByTurn.GetValueOrDefault(group.Key),
+                    result.CombatEndedTurn == group.Key))
+                .ToArray());
+}
 
 internal sealed record SolverProgress(
     int StartTurnNumber,
@@ -22,4 +193,6 @@ internal sealed record SolverProgress(
     int EndedNodes,
     long ElapsedMilliseconds,
     string Phase,
-    SolverInterimResult? CurrentBestResult = null);
+    SolverInterimResult? CurrentBestResult = null,
+    SolverRoutePreview? RoutePreview = null,
+    SolverRouteAdoptionSeed? RouteAdoptionSeed = null);

--- a/src/Runtime/SolverSettings.cs
+++ b/src/Runtime/SolverSettings.cs
@@ -53,6 +53,7 @@ internal sealed record SolverPerformanceValues(
 internal sealed record SolverSettingsData
 {
     public bool SolverDisabled { get; init; }
+    public bool AutomaticCalculationEnabled { get; init; } = true;
     public bool StopFullAutoOnCombatEnd { get; init; }
     public bool StopFullAutoOnDeathTurn { get; init; } = true;
     public bool StopFullAutoOnWorseRecalculation { get; init; } = true;
@@ -90,6 +91,8 @@ internal sealed record SolverSettingsData
     public double? DeploymentInterActionDelaySeconds { get; init; }
     public float? OverlayPositionX { get; init; }
     public float? OverlayPositionY { get; init; }
+    public float? OverlayWidth { get; init; }
+    public float? OverlayHeight { get; init; }
     public string? ReporterContactQq { get; init; }
     public SolverOverlayTheme OverlayTheme { get; init; } = SolverOverlayTheme.Dark;
     public float OverlayOpacity { get; init; } = 1f;
@@ -206,6 +209,7 @@ internal static class SolverSettings
         }
         Entry.Logger.Info(
             $"[CombatSolver/Test] SETTINGS_LOADED persisted={persisted} " +
+            $"automatic_calculation={migrated.AutomaticCalculationEnabled.ToString().ToLowerInvariant()} " +
             $"performance_migration={loaded.PerformanceMigrationVersion}->{migrated.PerformanceMigrationVersion} " +
             $"solver_disabled={migrated.SolverDisabled} " +
             $"stop_on_combat_end={migrated.StopFullAutoOnCombatEnd} " +
@@ -414,6 +418,24 @@ internal static class SolverSettings
             OverlayPositionY = position.Y,
         });
 
+    public static Vector2? OverlaySize
+    {
+        get
+        {
+            SolverSettingsData data = Current;
+            return data.OverlayWidth is { } width && data.OverlayHeight is { } height
+                ? new Vector2(width, height)
+                : null;
+        }
+    }
+
+    public static void SetOverlaySize(Vector2 size)
+        => Update(Current with
+        {
+            OverlayWidth = size.X,
+            OverlayHeight = size.Y,
+        });
+
     public static string FormatSeconds(double value)
         => value.ToString("0.###", CultureInfo.InvariantCulture);
 
@@ -495,6 +517,10 @@ internal static class SolverSettings
             throw new InvalidDataException("OverlayPositionX and OverlayPositionY must both be set or both be null.");
         ValidateRange(data.OverlayPositionX, -100_000f, 100_000f, nameof(data.OverlayPositionX));
         ValidateRange(data.OverlayPositionY, -100_000f, 100_000f, nameof(data.OverlayPositionY));
+        if (data.OverlayWidth.HasValue != data.OverlayHeight.HasValue)
+            throw new InvalidDataException("OverlayWidth and OverlayHeight must both be set or both be null.");
+        ValidateRange(data.OverlayWidth, 1f, 100_000f, nameof(data.OverlayWidth));
+        ValidateRange(data.OverlayHeight, 1f, 100_000f, nameof(data.OverlayHeight));
         if (!Enum.IsDefined(data.OverlayTheme))
             throw new InvalidDataException($"Unknown overlay theme {data.OverlayTheme}.");
         ValidateRange(data.OverlayOpacity, 0.25f, 1f, nameof(data.OverlayOpacity));

--- a/src/Search/CombatBeamSolver.Models.cs
+++ b/src/Search/CombatBeamSolver.Models.cs
@@ -193,6 +193,7 @@ internal sealed partial class CombatBeamSolver
 
     private sealed record RouteAnnotations(
         IReadOnlyDictionary<int, int> HpLostByTurn,
+        IReadOnlyDictionary<int, int> EnemyHpLostByTurn,
         IReadOnlyDictionary<int, int> SoldHpByTurn,
         IReadOnlyDictionary<int, int> MaxBlockByTurn,
         IReadOnlyDictionary<int, int> ActualBlockByTurn,

--- a/src/Search/CombatBeamSolver.Phases.cs
+++ b/src/Search/CombatBeamSolver.Phases.cs
@@ -88,9 +88,85 @@ internal sealed partial class CombatBeamSolver
         long lastProgressMs = -100;
         SolverInterimResult? currentBestResult = null;
         SearchNode? currentBestNode = null;
+        SolverInterimResult? currentTurnCandidateResult = null;
+        SearchNode? currentTurnCandidateNode = null;
+        SearchNode? currentTurnPreviewNode = null;
+        SolverRoutePreview? routePreview = null;
+        SolverRouteAdoptionSeed? routeAdoptionSeed = null;
+        SolverRouteAdoptionSeed? requestedRouteAdoptionSeed = null;
+        IReadOnlyList<SearchNode>? interruptedActive = null;
+        int routePreviewVersion = 0;
         bool adoptionReached = false;
+        bool currentTurnAdoptionReached = false;
+        int initialHp = root.InitialPlayerHp;
+        int searchedTurnLayers = 0;
+        bool timeBudgetReached = false;
 
-        void ConsiderCurrentResult(SearchNode node)
+        SolverInterimResult SummarizeCandidate(SearchNode node, bool won)
+        {
+
+            int ambergrisCount = node.Actions.Count(action =>
+                action.Kind == PlanActionKind.UsePotion
+                && string.Equals(action.PotionId, "AMBERGRIS", StringComparison.Ordinal));
+            return new SolverInterimResult(
+                Won: won,
+                OutstandingStolenResource: node.Snapshot.OutstandingStolenResource,
+                ProjectedBattleHpLost: battleDamage.HpLostSoFar
+                    + node.Snapshot.CumulativePlayerHpLost,
+                StrategicHpDeficit: node.Snapshot.CumulativePlayerHpLost
+                    + Math.Max(0, root.InitialPlayerMaxHp - node.Snapshot.PlayerMaxHp),
+                PotionStrategicCost: PotionUsePolicy.EffectiveStrategicHpCost(
+                    node.PotionStrategicCost,
+                    ambergrisCount,
+                    root.InitialPlayerMaxHp),
+                ProjectedBattlePotionCount: battleDamage.PotionsUsedSoFar + node.PotionCount,
+                EnemyHp: node.Snapshot.EnemyHp,
+                Score: node.Score);
+        }
+
+        // 候选节点保留完整动作父链；每个已完成回合的边界节点各自携带 Outcome。
+        IReadOnlyList<SolverFrontierTurn>? BuildFrontierTurns(SearchNode candidate)
+        {
+            if (candidate.ActionCount == 0)
+                return null;
+            Dictionary<int, (TurnOutcome Outcome, bool CombatEnded)> outcomesByTurn = [];
+            for (SearchNode? node = candidate; node != null; node = node.Parent)
+            {
+                if (node.Outcome is { } outcome)
+                    outcomesByTurn.TryAdd(outcome.Turn, (outcome, node.Snapshot.AllEnemiesDead));
+            }
+            if (outcomesByTurn.Count == 0)
+                return null;
+
+            List<SolverFrontierTurn> turns = new(outcomesByTurn.Count);
+            foreach (IGrouping<int, PlanAction> actions in candidate.Actions.GroupBy(action => action.Turn))
+            {
+                if (!outcomesByTurn.TryGetValue(actions.Key, out var materialized))
+                    continue;
+                turns.Add(new SolverFrontierTurn(
+                    actions.Key,
+                    actions.Select(WithDisplayNames).ToArray(),
+                    materialized.Outcome.HpLost,
+                    materialized.Outcome.EnemyHpLost,
+                    materialized.Outcome.EnergyLeft,
+                    materialized.CombatEnded));
+            }
+            turns.Sort((a, b) => a.Turn.CompareTo(b.Turn));
+            return turns.Count == 0 ? null : turns;
+        }
+
+
+        SearchNode? FindCurrentTurnBoundary(SearchNode node)
+        {
+            for (SearchNode? current = node; current?.Parent != null; current = current.Parent)
+            {
+                if (current.Outcome?.Turn == _startTurnNumber)
+                    return current;
+            }
+            return null;
+        }
+
+        void ConsiderCompleteVictory(SearchNode node)
         {
             if (ExplicitPotionUseCount(node) < _minimumPotionUses
                 || _enforcePotionDirectives
@@ -107,31 +183,379 @@ internal sealed partial class CombatBeamSolver
                 return;
             }
 
-            int ambergrisCount = node.Actions.Count(action =>
-                action.Kind == PlanActionKind.UsePotion
-                && string.Equals(action.PotionId, "AMBERGRIS", StringComparison.Ordinal));
-            SolverInterimResult candidate = new(
-                Won: true,
-                OutstandingStolenResource: node.Snapshot.OutstandingStolenResource,
-                ProjectedBattleHpLost: battleDamage.HpLostSoFar
-                    + node.Snapshot.CumulativePlayerHpLost,
-                StrategicHpDeficit: node.Snapshot.CumulativePlayerHpLost
-                    + Math.Max(0, root.InitialPlayerMaxHp - node.Snapshot.PlayerMaxHp),
-                PotionStrategicCost: PotionUsePolicy.EffectiveStrategicHpCost(
-                    node.PotionStrategicCost,
-                    ambergrisCount,
-                    root.InitialPlayerMaxHp),
-                ProjectedBattlePotionCount: battleDamage.PotionsUsedSoFar + node.PotionCount,
-                EnemyHp: node.Snapshot.EnemyHp,
-                Score: node.Score);
+            SolverInterimResult candidate = SummarizeCandidate(node, won: true);
             if (currentBestResult != null
                 && !SolverInterimResultOrdering.IsBetter(candidate, currentBestResult))
             {
                 return;
             }
-
             currentBestResult = candidate;
             currentBestNode = node;
+        }
+
+        void ConsiderCurrentTurnCandidate(SearchNode node)
+        {
+            SearchNode? boundary = FindCurrentTurnBoundary(node);
+            if (boundary == null
+                || ExplicitPotionUseCount(boundary) < _minimumPotionUses
+                || _enforcePotionDirectives
+                    && !_potionStrategy.EvaluateForcedUses(
+                            boundary.Actions,
+                            root.HasRenewablePotionShapedRock)
+                        .AllForcedUsesSatisfied
+                || !IsCurrentTurnCandidate(
+                    boundary.ActionCount,
+                    turnBoundaryReached: boundary.Action is { } boundaryAction
+                        && (boundaryAction.Kind == PlanActionKind.EndTurn
+                            || boundaryAction.EndsPlayerTurn
+                            || boundary.Snapshot.AllEnemiesDead),
+                    boundary.Snapshot.PlayerDead,
+                    boundary.Snapshot.ProjectedPlayerHp))
+            {
+                return;
+            }
+
+            SolverInterimResult candidate = SummarizeCandidate(
+                boundary,
+                boundary.Snapshot.AllEnemiesDead);
+            if (currentTurnCandidateResult != null
+                && !SolverInterimResultOrdering.IsBetter(candidate, currentTurnCandidateResult))
+            {
+                if (ReferenceEquals(boundary, currentTurnCandidateNode)
+                    && node.Outcome is { } nodeOutcome
+                    && nodeOutcome.Turn > (currentTurnPreviewNode?.Outcome?.Turn ?? int.MinValue))
+                {
+                    currentTurnPreviewNode = node;
+                }
+                return;
+            }
+            currentTurnCandidateResult = candidate;
+            currentTurnCandidateNode = boundary;
+            currentTurnPreviewNode = node;
+        }
+
+
+        SolverResult MaterializeSelectedRoute(
+            FinalPlanSelection ordering,
+            bool onlyDeathRoutesFound,
+            SolverResultScope resultScope,
+            int candidateSearchedTurnLayers,
+            bool candidateTimeBudgetReached,
+            IReadOnlyList<PlanAction>? routeAdoptionActions = null)
+        {
+            SearchMeasurement finalMeasurement = _run.Performance.Begin();
+            FinalPlanCandidate publishedCandidate = ordering.Candidate;
+            SearchNode materializedNode = publishedCandidate.Node.Snapshot.HasSimulator
+                ? publishedCandidate.Node
+                : RefreshReleasedFallback(publishedCandidate.Node);
+            RouteAnnotations materializedAnnotations = BuildRouteAnnotations(materializedNode);
+            FinalPlanCandidate selectedCandidate = publishedCandidate with
+            {
+                Node = materializedNode,
+                Snapshot = materializedNode.Snapshot,
+                Features = SearchFeatures.Capture(materializedNode),
+                FutureSold = materializedNode.FutureSoldHp,
+                BattleSold = battleDamage.SoldHpCommitted + materializedNode.FutureSoldHp,
+                PotionCount = materializedNode.PotionCount,
+            };
+            int potionBranchesRejected = ordering.PotionBranchesRejected;
+            int potionHpSaved = ordering.PotionHpSaved;
+            int potionHpRequired = ordering.PotionHpRequired;
+            int sellThreshold = SoldHpThreshold();
+            int annotatedFutureSold = materializedAnnotations.SoldHpByTurn.Values.Sum();
+            if (annotatedFutureSold != selectedCandidate.FutureSold)
+            {
+                throw new InvalidOperationException(
+                    $"卖血路径状态不一致：节点累计 {selectedCandidate.FutureSold}，逐回合累计 {annotatedFutureSold}。");
+            }
+            SearchNode best = selectedCandidate.Node with { Score = selectedCandidate.Score };
+
+            SimulationSnapshot finalSnapshot = selectedCandidate.Snapshot;
+            RouteAnnotations annotations = materializedAnnotations;
+            IReadOnlyList<CachedContinuation> continuations = BuildContinuations(best);
+            int searchedTurns = Math.Max(1, best.Actions
+                .Select(action => action.Turn)
+                .DefaultIfEmpty(_startTurnNumber)
+                .Max() - _startTurnNumber + 1);
+            SearchBoundaryReason boundary = finalSnapshot.BoundaryReason;
+            if (resultScope != SolverResultScope.RouteAdoption)
+            {
+                if (boundary == SearchBoundaryReason.None && candidateTimeBudgetReached)
+                    boundary = SearchBoundaryReason.TimeLimit;
+                else if (boundary == SearchBoundaryReason.None && _run.Expanded >= _profile.MaxExpandedNodes)
+                    boundary = SearchBoundaryReason.NodeLimit;
+                else if (boundary == SearchBoundaryReason.None
+                         && policy.VerifyIncrementalSearch
+                         && candidateSearchedTurnLayers >= SolverWeights.IncrementalVerificationMaxTurns)
+                    boundary = SearchBoundaryReason.TurnLimit;
+            }
+            int futureHpLost = finalSnapshot.CumulativePlayerHpLost;
+            int futureUnavoidableHpLost = annotations.HpLostByTurn.Sum(item =>
+                Math.Max(0, item.Value - annotations.SoldHpByTurn.GetValueOrDefault(item.Key)));
+            int battleUnavoidableHpLost = Math.Max(0, battleDamage.HpLostSoFar - battleDamage.SoldHpCommitted)
+                + futureUnavoidableHpLost;
+            ActionRelicTriggerRecorder relicTriggerRecorder = new();
+            SimulationSnapshot? annotationRoot = _includeTurnSetup
+                ? ReplayTurnSetup(best.GetTurnSetupChoices())
+                : null;
+            SimulationSnapshot annotationReplay = Replay(
+                best.Actions,
+                annotationRoot,
+                _startTurnNumber,
+                priorActionCount: 0,
+                triggerRecorder: relicTriggerRecorder);
+            annotationRoot?.ReleaseSimulator();
+            if (annotationReplay.StateKey != finalSnapshot.StateKey
+                || annotationReplay.PlayerHp != finalSnapshot.PlayerHp
+                || annotationReplay.EnemyHp != finalSnapshot.EnemyHp
+                || annotationReplay.BoundaryReason != finalSnapshot.BoundaryReason)
+            {
+                ContinuationStamp expectedStamp = ContinuationStamp.CapturePredicted(
+                    _player,
+                    (CombatPredictionSimulator)finalSnapshot.Simulator,
+                    finalSnapshot.Turn,
+                    _forecast,
+                    _startTurnNumber);
+                ContinuationStamp replayStamp = ContinuationStamp.CapturePredicted(
+                    _player,
+                    (CombatPredictionSimulator)annotationReplay.Simulator,
+                    annotationReplay.Turn,
+                    _forecast,
+                    _startTurnNumber);
+                string difference = expectedStamp.DescribeFirstDifference(replayStamp);
+                annotationReplay.ReleaseSimulator();
+                throw new InvalidOperationException(
+                    $"最终路线的遗物标注回放与选中状态不一致：{difference}；" +
+                    $"hp={finalSnapshot.PlayerHp}/{annotationReplay.PlayerHp} " +
+                    $"enemy_hp={finalSnapshot.EnemyHp}/{annotationReplay.EnemyHp} " +
+                    $"boundary={finalSnapshot.BoundaryReason}/{annotationReplay.BoundaryReason}。");
+            }
+            annotationReplay.ReleaseSimulator();
+            IReadOnlyList<PlanAction> annotatedActions = resultScope == SolverResultScope.RouteAdoption
+                && routeAdoptionActions != null
+                    ? routeAdoptionActions
+                    : best.Actions
+                        .Select((action, actionIndex) => WithDisplayNames(action) with
+                        {
+                            RelicEffects = relicTriggerRecorder.ForAction(actionIndex)
+                                .Select(trigger => new PlanRelicEffect(
+                                    trigger.RelicId,
+                                    displayNames.Relic(trigger.RelicId),
+                                    trigger.Summary))
+                                .ToArray(),
+                        })
+                        .ToArray();
+            _run.Performance.End(SearchMetricPhase.FinalSelection, finalMeasurement);
+            stopwatch.Stop();
+            long workerAllocatedBytes =
+                GC.GetAllocatedBytesForCurrentThread() - allocatedBytesAtStart
+                + _run.OffThreadAllocatedBytes;
+            int gen0Collections = GC.CollectionCount(0) - gen0AtStart;
+            int gen1Collections = GC.CollectionCount(1) - gen1AtStart;
+            int gen2Collections = GC.CollectionCount(2) - gen2AtStart;
+            TimeSpan gcPauseDuration = GC.GetTotalPauseDuration() - gcPauseAtStart;
+            // 必须在返回前把节点链和模拟器图压平成运行时真正需要的数据。
+            // Coordinator 会在深化期间保留短搜结果；这里若返回 SearchNode/SimulationSnapshot，
+            // 短搜的全部父链和每步模拟器都会成为长寿命 GC 根。
+            SelectedSearchPlan selectedPlan = new(
+                annotatedActions,
+                best.ActionCount,
+                best.Score);
+            SolverSnapshot selectedSnapshot = new(
+                finalSnapshot.HasRisk,
+                finalSnapshot.PlayerDead,
+                finalSnapshot.AllEnemiesDead,
+                finalSnapshot.PlayerHp,
+                finalSnapshot.PlayerMaxHp,
+                finalSnapshot.CumulativePlayerHpLost,
+                finalSnapshot.LongTermResourceValue,
+                finalSnapshot.AngerCopiesGenerated,
+                finalSnapshot.ProjectedPlayerHp,
+                finalSnapshot.PlayerBlock,
+                finalSnapshot.EnemyHp,
+                finalSnapshot.AliveEnemyCount,
+                finalSnapshot.Energy,
+                finalSnapshot.Stars,
+                finalSnapshot.HandCount,
+                finalSnapshot.OutstandingStolenResource,
+                finalSnapshot.Turn,
+                finalSnapshot.ShufflesCrossed,
+                finalSnapshot.BoundaryReason,
+                finalSnapshot.PredictionGaps.ToArray());
+            SolverResult result = new()
+            {
+                ResultScope = resultScope,
+                SearchPhase = _profile.Phase,
+                TotalSearchElapsed = stopwatch.Elapsed,
+                TotalWorkerAllocatedBytes = workerAllocatedBytes,
+                TotalGen0Collections = gen0Collections,
+                TotalGen1Collections = gen1Collections,
+                TotalGen2Collections = gen2Collections,
+                TotalGcPauseDuration = gcPauseDuration,
+                ForkMetric = _run.Performance.Snapshot(SearchMetricPhase.Fork),
+                ActionMetric = _run.Performance.Snapshot(SearchMetricPhase.Action),
+                CardExecutionMetric = _run.Performance.Snapshot(SearchMetricPhase.CardExecution),
+                CardPostProcessingMetric = _run.Performance.Snapshot(SearchMetricPhase.CardPostProcessing),
+                PotionExecutionMetric = _run.Performance.Snapshot(SearchMetricPhase.PotionExecution),
+                RoundAdvanceMetric = _run.Performance.Snapshot(SearchMetricPhase.RoundAdvance),
+                RoundPlayerEndMetric = _run.Performance.Snapshot(SearchMetricPhase.RoundPlayerEnd),
+                RoundEndSimulationMetric = _run.Performance.Snapshot(SearchMetricPhase.RoundEndSimulation),
+                RoundFlushMetric = _run.Performance.Snapshot(SearchMetricPhase.RoundFlush),
+                RoundPlayerEndPowersMetric = _run.Performance.Snapshot(SearchMetricPhase.RoundPlayerEndPowers),
+                RoundEnemyTurnMetric = _run.Performance.Snapshot(SearchMetricPhase.RoundEnemyTurn),
+                RoundEnemyStartMetric = _run.Performance.Snapshot(SearchMetricPhase.RoundEnemyStart),
+                RoundEnemyMovesMetric = _run.Performance.Snapshot(SearchMetricPhase.RoundEnemyMoves),
+                RoundEnemyEndPowersMetric = _run.Performance.Snapshot(SearchMetricPhase.RoundEnemyEndPowers),
+                RoundPlayerStartMetric = _run.Performance.Snapshot(SearchMetricPhase.RoundPlayerStart),
+                RoundDrawMetric = _run.Performance.Snapshot(SearchMetricPhase.RoundDraw),
+                SnapshotMetric = _run.Performance.Snapshot(SearchMetricPhase.Snapshot),
+                ThreatProjectionMetric = _run.Performance.Snapshot(SearchMetricPhase.ThreatProjection),
+                FingerprintMetric = _run.Performance.Snapshot(SearchMetricPhase.Fingerprint),
+                ProjectedShuffleMetric = _run.Performance.Snapshot(SearchMetricPhase.ProjectedShuffle),
+                PileFingerprintMetric = _run.Performance.Snapshot(SearchMetricPhase.PileFingerprint),
+                PileFingerprintMissMetric = _run.Performance.Snapshot(SearchMetricPhase.PileFingerprintMiss),
+                CardFingerprintMissMetric = _run.Performance.Snapshot(SearchMetricPhase.CardFingerprintMiss),
+                CombatFingerprintMetric = _run.Performance.Snapshot(SearchMetricPhase.CombatFingerprint),
+                PruneMetric = _run.Performance.Snapshot(SearchMetricPhase.Prune),
+                FinalSelectionMetric = _run.Performance.Snapshot(SearchMetricPhase.FinalSelection),
+                StartTurnNumber = _startTurnNumber,
+                TurnSetupChoices = best.GetTurnSetupChoices().Select(WithDisplayNames).ToArray(),
+                TurnSetupPlayState = best.GetTurnSetupPlayState(),
+                BestNode = selectedPlan,
+                Snapshot = selectedSnapshot,
+                Forecast = _forecast,
+                ExpandedNodes = _run.Expanded,
+                TotalExpandedNodes = _run.Expanded,
+                DominatedActionsPruned = _run.DominatedActionsPruned,
+                TopQueueActionsDropped = _run.TopQueueActionsDropped,
+                ActionAdmissionRepresentativesProtected = _run.ActionAdmissionRepresentativesProtected,
+                DuplicateCardBranchesPruned = _run.DuplicateCardBranchesPruned,
+                ChoiceBranchesEvaluated = _run.ChoiceBranchesEvaluated,
+                TotalChoiceBranchesEvaluated = _run.ChoiceBranchesEvaluated,
+                ShuffleBranchesPruned = _run.ShuffleBranchesPruned,
+                SoldHpBranchesPruned = _run.SoldHpBranchesPruned,
+                HpInvestmentBranchesProtected = _run.HpInvestmentBranchesProtected,
+                ReplayCount = _run.ReplayCount,
+                ForkCount = _run.ForkCount,
+                TransitionCount = _run.TransitionCount,
+                TotalTransitionCount = _run.TransitionCount,
+                ReusedNodeSnapshots = _run.ReusedNodeSnapshots,
+                TranspositionBranchesPruned = _run.TranspositionBranchesPruned,
+                RepeatableNoProgressBranchesPruned = _run.RepeatableNoProgressBranchesPruned,
+                StandPatProbes = _run.StandPatProbes,
+                ParallelExpansionWaves = _run.ParallelExpansionWaves,
+                ParallelExpansionWorkItems = _run.ParallelExpansionWorkItems,
+                MaxParallelExpansionConcurrency = _run.MaxParallelExpansionConcurrency,
+                ParallelActionReplayWaves = _run.ParallelActionReplayWaves,
+                ParallelActionReplayWorkItems = _run.ParallelActionReplayWorkItems,
+                MaxParallelActionReplayConcurrency = _run.MaxParallelActionReplayConcurrency,
+                DeferredRoundChoiceActions = _run.DeferredRoundChoiceActions,
+                DeferredRoundChoiceLayerWidthTotal = _run.DeferredRoundChoiceLayerWidthTotal,
+                MaxDeferredRoundChoiceLayerWidth = _run.MaxDeferredRoundChoiceLayerWidth,
+                DeferredRoundChoiceFiniteQuotaFallbacks =
+                    _run.DeferredRoundChoiceFiniteQuotaFallbacks,
+                DeferredRoundChoiceFinitePrimaryLayers =
+                    _run.DeferredRoundChoiceFinitePrimaryLayers,
+                DeferredRoundChoiceFinitePendingFallbacks =
+                    _run.DeferredRoundChoiceFinitePendingFallbacks,
+                ParallelRoundChoiceReplayWaves = _run.ParallelRoundChoiceReplayWaves,
+                ParallelRoundChoiceReplayWorkItems = _run.ParallelRoundChoiceReplayWorkItems,
+                MaxParallelRoundChoiceReplayConcurrency =
+                    _run.MaxParallelRoundChoiceReplayConcurrency,
+                NodeLimitSnapshotsReleased = _run.NodeLimitSnapshotsReleased,
+                TransitionCacheHits = 0,
+                WorkerAllocatedBytes = workerAllocatedBytes,
+                Gen0Collections = gen0Collections,
+                Gen1Collections = gen1Collections,
+                Gen2Collections = gen2Collections,
+                GcPauseDuration = gcPauseDuration,
+                MaxObservedGcPause = _run.WorkPacer.MaxObservedGcPause,
+                WorkerYieldCount = _run.WorkPacer.YieldCount,
+                FrameRecoveryWaitCount = _run.WorkPacer.FrameRecoveryWaitCount,
+                FrameRecoveryWaitDuration = _run.WorkPacer.FrameRecoveryWaitDuration,
+                SearchedTurns = searchedTurns,
+                BoundaryReason = boundary,
+                UnavoidableHpLost = battleUnavoidableHpLost,
+                SoldHp = selectedCandidate.BattleSold,
+                FutureSoldHp = selectedCandidate.FutureSold,
+                BattleHpLostSoFar = battleDamage.HpLostSoFar,
+                ProjectedBattleHpLost = battleDamage.HpLostSoFar + futureHpLost,
+                BattlePotionsUsedSoFar = battleDamage.PotionsUsedSoFar,
+                PotionCount = selectedCandidate.PotionCount,
+                ExplicitPotionCount = annotatedActions.Count(action =>
+                    action.Kind == PlanActionKind.UsePotion),
+                PotionHpSaved = potionHpSaved,
+                PotionHpRequired = potionHpRequired,
+                PotionBranchesRejected = potionBranchesRejected,
+                TheftPolicy = _theftPolicy,
+                OutstandingStolenResource = finalSnapshot.OutstandingStolenResource,
+                SoldHpThreshold = sellThreshold,
+                SoldHpByTurn = annotations.SoldHpByTurn,
+                HpLostByTurn = annotations.HpLostByTurn,
+                EnemyHpLostByTurn = annotations.EnemyHpLostByTurn,
+                MaxBlockByTurn = annotations.MaxBlockByTurn,
+                ActualBlockByTurn = annotations.ActualBlockByTurn,
+                EnergyLeftByTurn = annotations.EnergyLeftByTurn,
+                PotionCountByTurn = annotations.PotionCountByTurn,
+                PotionStrategicCostByTurn = annotations.PotionStrategicCostByTurn,
+                KillsAfterAction = annotations.KillsAfterAction,
+                CombatEndedTurn = annotations.CombatEndedTurn,
+                DeathTurn = annotations.DeathTurn,
+                OnlyDeathRoutesFound = onlyDeathRoutesFound,
+                IsActEndingBoss = _isActEndingBoss,
+                BossHpRelief = _bossHpRelief,
+                Elapsed = stopwatch.Elapsed,
+                Continuations = resultScope == SolverResultScope.CurrentTurnAdoption ? [] : continuations,
+            };
+            finalSnapshot.ReleaseSimulator();
+            return result;
+        }
+
+        void PublishRoutePreview()
+        {
+            if (progressCallback == null)
+                return;
+            SearchNode? candidate = currentBestNode
+                ?? currentTurnPreviewNode
+                ?? currentTurnCandidateNode;
+            if (candidate == null || BuildFrontierTurns(candidate) is not { Count: > 0 } turns)
+                return;
+
+            int candidateVersion = ++routePreviewVersion;
+            bool onlyDeathRoutesFound = candidate.Snapshot.PlayerDead
+                || candidate.Snapshot.ProjectedPlayerHp <= 0;
+            routePreview = new SolverRoutePreview(
+                candidateVersion,
+                _startTurnNumber,
+                battleDamage.PotionsUsedSoFar + candidate.PotionCount,
+                battleDamage.HpLostSoFar + candidate.Snapshot.CumulativePlayerHpLost,
+                onlyDeathRoutesFound,
+                candidate.Snapshot.HasRisk,
+                turns);
+            int candidateSearchedTurnLayers = searchedTurnLayers;
+            PlanAction[] adoptionActions = turns
+                .SelectMany(turn => turn.Actions)
+                .ToArray();
+            routeAdoptionSeed = new SolverRouteAdoptionSeed(
+                candidateVersion,
+                adoptionActions,
+                () =>
+                {
+                    SearchNode materialized = candidate.Snapshot.HasSimulator
+                        ? candidate
+                        : RefreshReleasedFallback(candidate);
+                    FinalPlanSelection selection = FinalOrdering.Select(
+                        [(materialized, materialized.Snapshot)],
+                        initialHp,
+                        emitDiagnostics: false);
+                    return MaterializeSelectedRoute(
+                        selection,
+                        onlyDeathRoutesFound,
+                        SolverResultScope.RouteAdoption,
+                        candidateSearchedTurnLayers,
+                        candidateTimeBudgetReached: false,
+                        routeAdoptionActions: adoptionActions);
+                });
         }
 
         void PublishProgress(
@@ -162,7 +586,9 @@ internal sealed partial class CombatBeamSolver
                 elapsedMs,
                 _progressPhaseOverride
                 ?? $"{(checkpointPhase || _profile.Phase == SolverSearchPhase.Short ? "快速搜索" : "深化搜索")}·{phase}",
-                currentBestResult));
+                currentBestResult,
+                routePreview,
+                routeAdoptionSeed));
         }
 
         PublishProgress(_startTurnNumber, 0, 0, 1, 0, "初始化", force: true);
@@ -248,9 +674,6 @@ internal sealed partial class CombatBeamSolver
         double potionFreeBoundaryFallbackScore = double.NegativeInfinity;
         SearchNode? potionBoundaryFallback = null;
         double potionBoundaryFallbackScore = double.NegativeInfinity;
-        int initialHp = root.InitialPlayerHp;
-        int searchedTurnLayers = 0;
-        bool timeBudgetReached = false;
         // A cheap first parent is not a safe predictor for the rest of a later play depth.
         // Retain the largest observed parent for the whole search so a new depth cannot
         // immediately rematerialize a wide wave that exceeds the No-GC allocation budget.
@@ -292,12 +715,21 @@ internal sealed partial class CombatBeamSolver
                  playDepth++)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                if (_adoptCurrentResultRequested?.Invoke() == true && currentBestNode != null)
+                SearchTakeoverRequest? takeover = _interaction?.CurrentTakeoverRequest;
+                if (takeover?.Kind == SearchTakeoverKind.AdoptRoute
+                    && takeover.RouteAdoptionSeed != null)
+                {
+                    requestedRouteAdoptionSeed = takeover.RouteAdoptionSeed;
+                    interruptedActive = active;
+                    timeBudgetReached = true;
+                    break;
+                }
+                SearchNode? adoptableNode = currentBestNode ?? currentTurnCandidateNode;
+                if (takeover?.Kind == SearchTakeoverKind.ApplyCurrentTurn && adoptableNode != null)
                 {
                     adoptionReached = true;
+                    currentTurnAdoptionReached = currentBestNode == null;
                     timeBudgetReached = true;
-                    ended.AddRange(active);
-                    active = [];
                     break;
                 }
                 if (!policy.VerifyIncrementalSearch
@@ -699,6 +1131,8 @@ internal sealed partial class CombatBeamSolver
                 PublishProgress(_startTurnNumber + searchedTurnLayers, searchedTurnLayers, playDepth,
                     active.Count, ended.Count, "剪枝候选", force: true);
             }
+            if (adoptionReached || requestedRouteAdoptionSeed != null)
+                break;
 
             if (_run.Expanded >= _profile.MaxExpandedNodes)
             {
@@ -727,7 +1161,11 @@ internal sealed partial class CombatBeamSolver
             List<SearchNode> retainedAfterRound = [.. completed, .. frontier];
             ReleaseDroppedSnapshots(ended, retainedAfterRound);
             foreach (SearchNode candidate in retainedAfterRound)
-                ConsiderCurrentResult(candidate);
+            {
+                ConsiderCompleteVictory(candidate);
+                ConsiderCurrentTurnCandidate(candidate);
+            }
+            PublishRoutePreview();
             searchedTurnLayers++;
             if (_detailedDiagnostics)
             {
@@ -752,6 +1190,22 @@ internal sealed partial class CombatBeamSolver
             }
             PublishProgress(_startTurnNumber + searchedTurnLayers, searchedTurnLayers, 0,
                 frontier.Count, completed.Count, "回合层完成", force: true);
+            SearchTakeoverRequest? layerTakeover = _interaction?.CurrentTakeoverRequest;
+            if (layerTakeover?.Kind == SearchTakeoverKind.AdoptRoute
+                && layerTakeover.RouteAdoptionSeed != null)
+            {
+                requestedRouteAdoptionSeed = layerTakeover.RouteAdoptionSeed;
+                timeBudgetReached = true;
+                break;
+            }
+            if (layerTakeover?.Kind == SearchTakeoverKind.ApplyCurrentTurn
+                && (currentBestNode != null || currentTurnCandidateNode != null))
+            {
+                adoptionReached = true;
+                currentTurnAdoptionReached = currentBestNode == null;
+                timeBudgetReached = true;
+                break;
+            }
             if (completed.Any(node =>
                     node.Snapshot.AllEnemiesDead
                     && ExplicitPotionUseCount(node) == 0
@@ -766,17 +1220,38 @@ internal sealed partial class CombatBeamSolver
             }
         }
 
-        List<SearchNode> finalPool;
-        if (adoptionReached && currentBestNode != null)
+        if (requestedRouteAdoptionSeed != null)
         {
-            SearchNode adopted = RefreshReleasedFallback(currentBestNode);
+            foreach (SearchNode candidate in completed)
+                candidate.Snapshot.ReleaseSimulator();
+            foreach (SearchNode candidate in frontier)
+                candidate.Snapshot.ReleaseSimulator();
+            if (interruptedActive != null)
+            {
+                foreach (SearchNode candidate in interruptedActive)
+                    candidate.Snapshot.ReleaseSimulator();
+            }
+            policy.Diagnostics.Info(
+                $"[CombatSolver/Test] SEARCH_ROUTE_ADOPTION_CHECKPOINT " +
+                $"candidate_version={requestedRouteAdoptionSeed.CandidateVersion} " +
+                $"expanded={_run.Expanded}");
+            return requestedRouteAdoptionSeed.Materialize();
+        }
+
+        List<SearchNode> finalPool;
+        SearchNode? adoptedNode = currentBestNode ?? currentTurnCandidateNode;
+        if (adoptionReached && adoptedNode != null)
+        {
+            SearchNode adopted = RefreshReleasedFallback(adoptedNode);
             List<SearchNode> remaining = [.. completed, .. frontier];
             ReleaseDroppedSnapshots(remaining, [adopted]);
             finalPool = [adopted];
+            SolverInterimResult adoptedSummary = currentBestResult ?? currentTurnCandidateResult!;
             policy.Diagnostics.Info(
                 $"[CombatSolver/Test] SEARCH_CHECKPOINT_ADOPTED " +
-                $"potions={currentBestResult!.ProjectedBattlePotionCount} " +
-                $"projected_battle_hp_lost={currentBestResult.ProjectedBattleHpLost} " +
+                $"scope={(currentTurnAdoptionReached ? "current_turn" : "complete_victory")} " +
+                $"potions={adoptedSummary.ProjectedBattlePotionCount} " +
+                $"projected_battle_hp_lost={adoptedSummary.ProjectedBattleHpLost} " +
                 $"expanded={_run.Expanded}");
         }
         else
@@ -785,12 +1260,14 @@ internal sealed partial class CombatBeamSolver
                 ? [RefreshReleasedFallback(fallback)]
                 : [.. completed, .. frontier];
         }
-        if (!finalPool.Any(node => ExplicitPotionUseCount(node) == 0)
+        if (!adoptionReached
+            && !finalPool.Any(node => ExplicitPotionUseCount(node) == 0)
             && potionFreeBoundaryFallback != null)
         {
             finalPool.Add(RefreshReleasedFallback(potionFreeBoundaryFallback));
         }
-        if (!finalPool.Any(node => ExplicitPotionUseCount(node) > 0)
+        if (!adoptionReached
+            && !finalPool.Any(node => ExplicitPotionUseCount(node) > 0)
             && potionBoundaryFallback != null)
         {
             finalPool.Add(RefreshReleasedFallback(potionBoundaryFallback));
@@ -800,263 +1277,27 @@ internal sealed partial class CombatBeamSolver
         ValidateHistoricalSimulatorsReleased(finalCandidates);
         PublishProgress(_startTurnNumber + searchedTurnLayers, searchedTurnLayers, 0,
             finalCandidates.Count, completed.Count, "复核最终候选", force: true);
-        SearchMeasurement finalMeasurement = _run.Performance.Begin();
         List<(SearchNode Node, SimulationSnapshot Snapshot)> evaluated = finalCandidates
             .Select(node => (Node: node, Snapshot: node.Snapshot))
             .ToList();
         bool onlyDeathRoutesFound = evaluated.All(candidate =>
             candidate.Snapshot.PlayerDead || candidate.Snapshot.ProjectedPlayerHp <= 0);
         _run.ReusedNodeSnapshots += evaluated.Count;
-        int sellThreshold = SoldHpThreshold();
         FinalPlanSelection ordering = FinalOrdering.Select(
             evaluated,
             initialHp,
             emitDiagnostics: true);
-        FinalPlanCandidate selectedCandidate = ordering.Candidate;
-        int potionBranchesRejected = ordering.PotionBranchesRejected;
-        int potionHpSaved = ordering.PotionHpSaved;
-        int potionHpRequired = ordering.PotionHpRequired;
-        // Final ordering consumes scalar node features only. Walk the route once after selection
-        // instead of rebuilding the same annotation maps for every discarded finalist.
-        RouteAnnotations annotations = BuildRouteAnnotations(selectedCandidate.Node);
-        int annotatedFutureSold = annotations.SoldHpByTurn.Values.Sum();
-        if (annotatedFutureSold != selectedCandidate.FutureSold)
-        {
-            throw new InvalidOperationException(
-                $"卖血路径状态不一致：节点累计 {selectedCandidate.FutureSold}，逐回合累计 {annotatedFutureSold}。");
-        }
-        SearchNode best = selectedCandidate.Node with { Score = selectedCandidate.Score };
-
-        SimulationSnapshot finalSnapshot = selectedCandidate.Snapshot;
-        IReadOnlyList<CachedContinuation> continuations = BuildContinuations(best);
-        int searchedTurns = Math.Max(1, best.Actions
-            .Select(action => action.Turn)
-            .DefaultIfEmpty(_startTurnNumber)
-            .Max() - _startTurnNumber + 1);
-        SearchBoundaryReason boundary = finalSnapshot.BoundaryReason;
-        if (boundary == SearchBoundaryReason.None && timeBudgetReached)
-            boundary = SearchBoundaryReason.TimeLimit;
-        else if (boundary == SearchBoundaryReason.None && _run.Expanded >= _profile.MaxExpandedNodes)
-            boundary = SearchBoundaryReason.NodeLimit;
-        else if (boundary == SearchBoundaryReason.None
-                 && policy.VerifyIncrementalSearch
-                 && searchedTurnLayers >= SolverWeights.IncrementalVerificationMaxTurns)
-            boundary = SearchBoundaryReason.TurnLimit;
-        int futureHpLost = finalSnapshot.CumulativePlayerHpLost;
-        int futureUnavoidableHpLost = annotations.HpLostByTurn.Sum(item =>
-            Math.Max(0, item.Value - annotations.SoldHpByTurn.GetValueOrDefault(item.Key)));
-        int battleUnavoidableHpLost = Math.Max(0, battleDamage.HpLostSoFar - battleDamage.SoldHpCommitted)
-            + futureUnavoidableHpLost;
-        ActionRelicTriggerRecorder relicTriggerRecorder = new();
-        SimulationSnapshot? annotationRoot = _includeTurnSetup
-            ? ReplayTurnSetup(best.GetTurnSetupChoices())
-            : null;
-        SimulationSnapshot annotationReplay = Replay(
-            best.Actions,
-            annotationRoot,
-            _startTurnNumber,
-            priorActionCount: 0,
-            triggerRecorder: relicTriggerRecorder);
-        annotationRoot?.ReleaseSimulator();
-        if (annotationReplay.StateKey != finalSnapshot.StateKey
-            || annotationReplay.PlayerHp != finalSnapshot.PlayerHp
-            || annotationReplay.EnemyHp != finalSnapshot.EnemyHp
-            || annotationReplay.BoundaryReason != finalSnapshot.BoundaryReason)
-        {
-            ContinuationStamp expectedStamp = ContinuationStamp.CapturePredicted(
-                _player,
-                (CombatPredictionSimulator)finalSnapshot.Simulator,
-                finalSnapshot.Turn,
-                _forecast,
-                _startTurnNumber);
-            ContinuationStamp replayStamp = ContinuationStamp.CapturePredicted(
-                _player,
-                (CombatPredictionSimulator)annotationReplay.Simulator,
-                annotationReplay.Turn,
-                _forecast,
-                _startTurnNumber);
-            string difference = expectedStamp.DescribeFirstDifference(replayStamp);
-            annotationReplay.ReleaseSimulator();
-            throw new InvalidOperationException(
-                $"最终路线的遗物标注回放与选中状态不一致：{difference}；" +
-                $"hp={finalSnapshot.PlayerHp}/{annotationReplay.PlayerHp} " +
-                $"enemy_hp={finalSnapshot.EnemyHp}/{annotationReplay.EnemyHp} " +
-                $"boundary={finalSnapshot.BoundaryReason}/{annotationReplay.BoundaryReason}。");
-        }
-        annotationReplay.ReleaseSimulator();
-        PlanAction[] annotatedActions = best.Actions
-            .Select((action, actionIndex) => WithDisplayNames(action) with
-            {
-                RelicEffects = relicTriggerRecorder.ForAction(actionIndex)
-                    .Select(trigger => new PlanRelicEffect(
-                        trigger.RelicId,
-                        displayNames.Relic(trigger.RelicId),
-                        trigger.Summary))
-                    .ToArray(),
-            })
-            .ToArray();
-        _run.Performance.End(SearchMetricPhase.FinalSelection, finalMeasurement);
-        stopwatch.Stop();
-        long workerAllocatedBytes =
-            GC.GetAllocatedBytesForCurrentThread() - allocatedBytesAtStart
-            + _run.OffThreadAllocatedBytes;
-        int gen0Collections = GC.CollectionCount(0) - gen0AtStart;
-        int gen1Collections = GC.CollectionCount(1) - gen1AtStart;
-        int gen2Collections = GC.CollectionCount(2) - gen2AtStart;
-        TimeSpan gcPauseDuration = GC.GetTotalPauseDuration() - gcPauseAtStart;
-        // 必须在返回前把节点链和模拟器图压平成运行时真正需要的数据。
-        // Coordinator 会在深化期间保留短搜结果；这里若返回 SearchNode/SimulationSnapshot，
-        // 短搜的全部父链和每步模拟器都会成为长寿命 GC 根。
-        SelectedSearchPlan selectedPlan = new(
-            annotatedActions,
-            best.ActionCount,
-            best.Score);
-        SolverSnapshot selectedSnapshot = new(
-            finalSnapshot.HasRisk,
-            finalSnapshot.PlayerDead,
-            finalSnapshot.AllEnemiesDead,
-            finalSnapshot.PlayerHp,
-            finalSnapshot.PlayerMaxHp,
-            finalSnapshot.CumulativePlayerHpLost,
-            finalSnapshot.LongTermResourceValue,
-            finalSnapshot.AngerCopiesGenerated,
-            finalSnapshot.ProjectedPlayerHp,
-            finalSnapshot.PlayerBlock,
-            finalSnapshot.EnemyHp,
-            finalSnapshot.AliveEnemyCount,
-            finalSnapshot.Energy,
-            finalSnapshot.Stars,
-            finalSnapshot.HandCount,
-            finalSnapshot.OutstandingStolenResource,
-            finalSnapshot.Turn,
-            finalSnapshot.ShufflesCrossed,
-            finalSnapshot.BoundaryReason,
-            finalSnapshot.PredictionGaps.ToArray());
+        SolverResult result = MaterializeSelectedRoute(
+            ordering,
+            onlyDeathRoutesFound,
+            currentTurnAdoptionReached
+                ? SolverResultScope.CurrentTurnAdoption
+                : SolverResultScope.SearchCompletion,
+            searchedTurnLayers,
+            timeBudgetReached);
         foreach (SearchNode candidate in finalCandidates)
             candidate.Snapshot.ReleaseSimulator();
-        return new SolverResult
-        {
-            SearchPhase = _profile.Phase,
-            TotalSearchElapsed = stopwatch.Elapsed,
-            TotalWorkerAllocatedBytes = workerAllocatedBytes,
-            TotalGen0Collections = gen0Collections,
-            TotalGen1Collections = gen1Collections,
-            TotalGen2Collections = gen2Collections,
-            TotalGcPauseDuration = gcPauseDuration,
-            ForkMetric = _run.Performance.Snapshot(SearchMetricPhase.Fork),
-            ActionMetric = _run.Performance.Snapshot(SearchMetricPhase.Action),
-            CardExecutionMetric = _run.Performance.Snapshot(SearchMetricPhase.CardExecution),
-            CardPostProcessingMetric = _run.Performance.Snapshot(SearchMetricPhase.CardPostProcessing),
-            PotionExecutionMetric = _run.Performance.Snapshot(SearchMetricPhase.PotionExecution),
-            RoundAdvanceMetric = _run.Performance.Snapshot(SearchMetricPhase.RoundAdvance),
-            RoundPlayerEndMetric = _run.Performance.Snapshot(SearchMetricPhase.RoundPlayerEnd),
-            RoundEndSimulationMetric = _run.Performance.Snapshot(SearchMetricPhase.RoundEndSimulation),
-            RoundFlushMetric = _run.Performance.Snapshot(SearchMetricPhase.RoundFlush),
-            RoundPlayerEndPowersMetric = _run.Performance.Snapshot(SearchMetricPhase.RoundPlayerEndPowers),
-            RoundEnemyTurnMetric = _run.Performance.Snapshot(SearchMetricPhase.RoundEnemyTurn),
-            RoundEnemyStartMetric = _run.Performance.Snapshot(SearchMetricPhase.RoundEnemyStart),
-            RoundEnemyMovesMetric = _run.Performance.Snapshot(SearchMetricPhase.RoundEnemyMoves),
-            RoundEnemyEndPowersMetric = _run.Performance.Snapshot(SearchMetricPhase.RoundEnemyEndPowers),
-            RoundPlayerStartMetric = _run.Performance.Snapshot(SearchMetricPhase.RoundPlayerStart),
-            RoundDrawMetric = _run.Performance.Snapshot(SearchMetricPhase.RoundDraw),
-            SnapshotMetric = _run.Performance.Snapshot(SearchMetricPhase.Snapshot),
-            ThreatProjectionMetric = _run.Performance.Snapshot(SearchMetricPhase.ThreatProjection),
-            FingerprintMetric = _run.Performance.Snapshot(SearchMetricPhase.Fingerprint),
-            ProjectedShuffleMetric = _run.Performance.Snapshot(SearchMetricPhase.ProjectedShuffle),
-            PileFingerprintMetric = _run.Performance.Snapshot(SearchMetricPhase.PileFingerprint),
-            PileFingerprintMissMetric = _run.Performance.Snapshot(SearchMetricPhase.PileFingerprintMiss),
-            CardFingerprintMissMetric = _run.Performance.Snapshot(SearchMetricPhase.CardFingerprintMiss),
-            CombatFingerprintMetric = _run.Performance.Snapshot(SearchMetricPhase.CombatFingerprint),
-            PruneMetric = _run.Performance.Snapshot(SearchMetricPhase.Prune),
-            FinalSelectionMetric = _run.Performance.Snapshot(SearchMetricPhase.FinalSelection),
-            StartTurnNumber = _startTurnNumber,
-            TurnSetupChoices = best.GetTurnSetupChoices().Select(WithDisplayNames).ToArray(),
-            TurnSetupPlayState = best.GetTurnSetupPlayState(),
-            BestNode = selectedPlan,
-            Snapshot = selectedSnapshot,
-            Forecast = _forecast,
-            ExpandedNodes = _run.Expanded,
-            TotalExpandedNodes = _run.Expanded,
-            DominatedActionsPruned = _run.DominatedActionsPruned,
-            TopQueueActionsDropped = _run.TopQueueActionsDropped,
-            ActionAdmissionRepresentativesProtected = _run.ActionAdmissionRepresentativesProtected,
-            DuplicateCardBranchesPruned = _run.DuplicateCardBranchesPruned,
-            ChoiceBranchesEvaluated = _run.ChoiceBranchesEvaluated,
-            TotalChoiceBranchesEvaluated = _run.ChoiceBranchesEvaluated,
-            ShuffleBranchesPruned = _run.ShuffleBranchesPruned,
-            SoldHpBranchesPruned = _run.SoldHpBranchesPruned,
-            HpInvestmentBranchesProtected = _run.HpInvestmentBranchesProtected,
-            ReplayCount = _run.ReplayCount,
-            ForkCount = _run.ForkCount,
-            TransitionCount = _run.TransitionCount,
-            TotalTransitionCount = _run.TransitionCount,
-            ReusedNodeSnapshots = _run.ReusedNodeSnapshots,
-            TranspositionBranchesPruned = _run.TranspositionBranchesPruned,
-            RepeatableNoProgressBranchesPruned = _run.RepeatableNoProgressBranchesPruned,
-            StandPatProbes = _run.StandPatProbes,
-            ParallelExpansionWaves = _run.ParallelExpansionWaves,
-            ParallelExpansionWorkItems = _run.ParallelExpansionWorkItems,
-            MaxParallelExpansionConcurrency = _run.MaxParallelExpansionConcurrency,
-            ParallelActionReplayWaves = _run.ParallelActionReplayWaves,
-            ParallelActionReplayWorkItems = _run.ParallelActionReplayWorkItems,
-            MaxParallelActionReplayConcurrency = _run.MaxParallelActionReplayConcurrency,
-            DeferredRoundChoiceActions = _run.DeferredRoundChoiceActions,
-            DeferredRoundChoiceLayerWidthTotal = _run.DeferredRoundChoiceLayerWidthTotal,
-            MaxDeferredRoundChoiceLayerWidth = _run.MaxDeferredRoundChoiceLayerWidth,
-            DeferredRoundChoiceFiniteQuotaFallbacks =
-                _run.DeferredRoundChoiceFiniteQuotaFallbacks,
-            DeferredRoundChoiceFinitePrimaryLayers =
-                _run.DeferredRoundChoiceFinitePrimaryLayers,
-            DeferredRoundChoiceFinitePendingFallbacks =
-                _run.DeferredRoundChoiceFinitePendingFallbacks,
-            ParallelRoundChoiceReplayWaves = _run.ParallelRoundChoiceReplayWaves,
-            ParallelRoundChoiceReplayWorkItems = _run.ParallelRoundChoiceReplayWorkItems,
-            MaxParallelRoundChoiceReplayConcurrency =
-                _run.MaxParallelRoundChoiceReplayConcurrency,
-            NodeLimitSnapshotsReleased = _run.NodeLimitSnapshotsReleased,
-            TransitionCacheHits = 0,
-            WorkerAllocatedBytes = workerAllocatedBytes,
-            Gen0Collections = gen0Collections,
-            Gen1Collections = gen1Collections,
-            Gen2Collections = gen2Collections,
-            GcPauseDuration = gcPauseDuration,
-            MaxObservedGcPause = _run.WorkPacer.MaxObservedGcPause,
-            WorkerYieldCount = _run.WorkPacer.YieldCount,
-            FrameRecoveryWaitCount = _run.WorkPacer.FrameRecoveryWaitCount,
-            FrameRecoveryWaitDuration = _run.WorkPacer.FrameRecoveryWaitDuration,
-            SearchedTurns = searchedTurns,
-            BoundaryReason = boundary,
-            UnavoidableHpLost = battleUnavoidableHpLost,
-            SoldHp = selectedCandidate.BattleSold,
-            FutureSoldHp = selectedCandidate.FutureSold,
-            BattleHpLostSoFar = battleDamage.HpLostSoFar,
-            ProjectedBattleHpLost = battleDamage.HpLostSoFar + futureHpLost,
-            BattlePotionsUsedSoFar = battleDamage.PotionsUsedSoFar,
-            PotionCount = selectedCandidate.PotionCount,
-            ExplicitPotionCount = annotatedActions.Count(action =>
-                action.Kind == PlanActionKind.UsePotion),
-            PotionHpSaved = potionHpSaved,
-            PotionHpRequired = potionHpRequired,
-            PotionBranchesRejected = potionBranchesRejected,
-            TheftPolicy = _theftPolicy,
-            OutstandingStolenResource = finalSnapshot.OutstandingStolenResource,
-            SoldHpThreshold = sellThreshold,
-            SoldHpByTurn = annotations.SoldHpByTurn,
-            HpLostByTurn = annotations.HpLostByTurn,
-            MaxBlockByTurn = annotations.MaxBlockByTurn,
-            ActualBlockByTurn = annotations.ActualBlockByTurn,
-            EnergyLeftByTurn = annotations.EnergyLeftByTurn,
-            PotionCountByTurn = annotations.PotionCountByTurn,
-            PotionStrategicCostByTurn = annotations.PotionStrategicCostByTurn,
-            KillsAfterAction = annotations.KillsAfterAction,
-            CombatEndedTurn = annotations.CombatEndedTurn,
-            DeathTurn = annotations.DeathTurn,
-            OnlyDeathRoutesFound = onlyDeathRoutesFound,
-            IsActEndingBoss = _isActEndingBoss,
-            BossHpRelief = _bossHpRelief,
-            Elapsed = stopwatch.Elapsed,
-            Continuations = continuations,
-        };
+        return result;
     }
 
     private SearchNode? ApplyFixedPrefix(SearchNode seed)
@@ -1149,4 +1390,13 @@ internal sealed partial class CombatBeamSolver
                 .ToArray(),
         };
 
+    internal static bool IsCurrentTurnCandidate(
+        int actionCount,
+        bool turnBoundaryReached,
+        bool playerDead,
+        int projectedPlayerHp)
+        => actionCount > 0
+            && turnBoundaryReached
+            && !playerDead
+            && projectedPlayerHp > 0;
 }

--- a/src/Search/CombatBeamSolver.Terminal.cs
+++ b/src/Search/CombatBeamSolver.Terminal.cs
@@ -99,6 +99,10 @@ internal sealed partial class CombatBeamSolver
                     Outcome = new TurnOutcome(
                         outcome.Turn,
                         outcome.HpLost,
+                        Math.Max(
+                            0,
+                            outcome.TurnStart.Snapshot.EnemyHp
+                            - outcome.Node.Snapshot.EnemyHp),
                         soldThisTurn,
                         maxBlock,
                         outcome.ActualBlock,
@@ -179,6 +183,7 @@ internal sealed partial class CombatBeamSolver
         path.Reverse();
 
         Dictionary<int, int> losses = [];
+        Dictionary<int, int> enemyHpLosses = [];
         Dictionary<int, int> sold = [];
         Dictionary<int, int> maxBlock = [];
         Dictionary<int, int> actualBlock = [];
@@ -217,6 +222,7 @@ internal sealed partial class CombatBeamSolver
             if (node.Outcome is { } outcome)
             {
                 losses[outcome.Turn] = outcome.HpLost;
+                enemyHpLosses[outcome.Turn] = outcome.EnemyHpLost;
                 actualBlock[outcome.Turn] = outcome.ActualBlock;
                 maxBlock[outcome.Turn] = outcome.MaxBlock;
                 sold[outcome.Turn] = outcome.SoldHp;
@@ -233,6 +239,7 @@ internal sealed partial class CombatBeamSolver
         }
         return new RouteAnnotations(
             losses,
+            enemyHpLosses,
             sold,
             maxBlock,
             actualBlock,

--- a/src/Search/CombatBeamSolver.cs
+++ b/src/Search/CombatBeamSolver.cs
@@ -34,8 +34,7 @@ internal sealed partial class CombatBeamSolver(
     PotionFreePolicyBaseline? potionFreePolicyBaseline = null,
     int? maximumPotionUses = null,
     IReadOnlyList<PlanAction>? fixedPrefixActions = null,
-    int? minimumPotionUses = null,
-    Func<bool>? adoptCurrentResultRequested = null)
+    int? minimumPotionUses = null)
 {
     private readonly SolverSearchProfile _profile = searchProfile ?? SolverSearchProfile.Short;
     private readonly SearchRunContext _run = new(
@@ -52,7 +51,7 @@ internal sealed partial class CombatBeamSolver(
     private readonly bool _detailedDiagnostics = policy.DetailedDiagnostics;
     private readonly int? _maximumPotionUses = maximumPotionUses;
     private readonly int _minimumPotionUses = minimumPotionUses ?? 0;
-    private readonly Func<bool>? _adoptCurrentResultRequested = adoptCurrentResultRequested;
+    private readonly SearchInteractionState? _interaction = policy.Interaction;
     private readonly IReadOnlyList<PlanAction> _fixedPrefixActions = fixedPrefixActions ?? [];
     private readonly string? _progressPhaseOverride = DescribePotionProgressPhase(
         displayNames,

--- a/src/Search/CombatPlan.cs
+++ b/src/Search/CombatPlan.cs
@@ -56,6 +56,13 @@ internal enum SearchBoundaryReason
     TimeLimit,
 }
 
+internal enum SolverResultScope
+{
+    SearchCompletion,
+    CurrentTurnAdoption,
+    RouteAdoption,
+}
+
 [Flags]
 internal enum SearchRouteTraits
 {
@@ -160,6 +167,7 @@ internal sealed record PlanAction(
 internal sealed record TurnOutcome(
     int Turn,
     int HpLost,
+    int EnemyHpLost,
     int SoldHp,
     int MaxBlock,
     int ActualBlock,
@@ -476,6 +484,7 @@ internal sealed record CachedContinuation(
 
 internal sealed class SolverResult
 {
+    public SolverResultScope ResultScope { get; internal set; } = SolverResultScope.SearchCompletion;
     public SolverSearchPhase SearchPhase { get; internal set; } = SolverSearchPhase.Short;
     public bool DeepSearchTriggered { get; internal set; }
     public bool DeepSearchImprovedResult { get; internal set; }
@@ -596,6 +605,7 @@ internal sealed class SolverResult
     public required int SoldHpThreshold { get; init; }
     public required IReadOnlyDictionary<int, int> SoldHpByTurn { get; init; }
     public required IReadOnlyDictionary<int, int> HpLostByTurn { get; init; }
+    public required IReadOnlyDictionary<int, int> EnemyHpLostByTurn { get; init; }
     public required IReadOnlyDictionary<int, int> MaxBlockByTurn { get; init; }
     public required IReadOnlyDictionary<int, int> ActualBlockByTurn { get; init; }
     public required IReadOnlyDictionary<int, int> EnergyLeftByTurn { get; init; }
@@ -715,6 +725,7 @@ internal sealed class SolverResult
             SoldHpThreshold = SoldHpThreshold,
             SoldHpByTurn = soldByTurn,
             HpLostByTurn = HpLostByTurn,
+            EnemyHpLostByTurn = EnemyHpLostByTurn,
             MaxBlockByTurn = MaxBlockByTurn,
             ActualBlockByTurn = ActualBlockByTurn,
             EnergyLeftByTurn = EnergyLeftByTurn,

--- a/src/Search/CombatSearchCoordinator.cs
+++ b/src/Search/CombatSearchCoordinator.cs
@@ -11,14 +11,17 @@ internal static class CombatSearchCoordinator
         BattleDamageSnapshot battleDamage,
         SearchPolicySnapshot policy,
         CancellationToken cancellationToken,
-        Action<SolverProgress>? progressCallback,
-        Func<bool>? adoptCurrentResultRequested = null)
+        Action<SolverProgress>? progressCallback)
     {
         SearchRequestWorkTotals requestWorkTotals = new();
         policy = policy with { RequestWorkTotals = requestWorkTotals };
-        SolverResult? currentAdoptableResult = null;
+        SearchInteractionState? interaction = policy.Interaction;
+        SolverResult? currentCompleteAdoptableResult = null;
         SolverInterimResult? currentDisplayedResult = null;
         SolverProgress? lastProgress = null;
+        int routePreviewVersion = 0;
+        SolverRoutePreview? currentRoutePreview = null;
+        SolverRouteAdoptionSeed? currentRouteAdoptionSeed = null;
 
         bool TryPromoteDisplayedResult(SolverInterimResult candidate)
         {
@@ -47,16 +50,28 @@ internal static class CombatSearchCoordinator
             bool promoted = TryPromoteDisplayedResult(summary);
             if (!promoted && summary != currentDisplayedResult)
                 return;
-            currentAdoptableResult = result;
+            currentCompleteAdoptableResult = result;
+            SolverRoutePreview preview = SolverRoutePreview.FromResult(
+                result,
+                ++routePreviewVersion);
+            SolverRouteAdoptionSeed seed = new(
+                preview.CandidateVersion,
+                result.BestNode.Actions,
+                () => result);
+            currentRoutePreview = preview;
+            currentRouteAdoptionSeed = seed;
             policy.Diagnostics.Info(
                 $"[CombatSolver/Test] SEARCH_INTERIM_RESULT potions={result.ProjectedBattlePotionCount} " +
                 $"projected_battle_hp_lost={result.ProjectedBattleHpLost}");
             if (lastProgress != null && progressCallback != null)
             {
-                progressCallback(lastProgress with
+                lastProgress = lastProgress with
                 {
                     CurrentBestResult = currentDisplayedResult,
-                });
+                    RoutePreview = currentRoutePreview,
+                    RouteAdoptionSeed = currentRouteAdoptionSeed,
+                };
+                progressCallback(lastProgress);
             }
         }
 
@@ -67,9 +82,17 @@ internal static class CombatSearchCoordinator
                 lastProgress = progress;
                 if (progress.CurrentBestResult is { } candidate)
                     TryPromoteDisplayedResult(candidate);
+                if (progress.RoutePreview is { } preview)
+                {
+                    currentRoutePreview = preview;
+                    currentRouteAdoptionSeed = progress.RouteAdoptionSeed;
+                    routePreviewVersion = Math.Max(routePreviewVersion, preview.CandidateVersion);
+                }
                 progressCallback(progress with
                 {
                     CurrentBestResult = currentDisplayedResult,
+                    RoutePreview = currentRoutePreview,
+                    RouteAdoptionSeed = currentRouteAdoptionSeed,
                 });
             };
         try
@@ -81,26 +104,54 @@ internal static class CombatSearchCoordinator
                 policy,
                 cancellationToken,
                 enrichedProgressCallback,
-                adoptCurrentResultRequested == null ? null : PublishAdoptableResult,
-                adoptCurrentResultRequested);
-            SolverResult selected = adoptCurrentResultRequested?.Invoke() == true
-                && currentAdoptableResult != null
-                    ? currentAdoptableResult
-                    : result;
+                interaction == null ? null : PublishAdoptableResult);
+            SolverResult selected = ResolveTakeoverResult(result, interaction) ?? result;
+            if (interaction?.CurrentTakeoverRequest?.Kind == SearchTakeoverKind.ApplyCurrentTurn
+                && selected.ResultScope == SolverResultScope.SearchCompletion
+                && currentCompleteAdoptableResult != null)
+            {
+                selected = currentCompleteAdoptableResult;
+            }
             PopulateRequestWorkTotals(selected, requestWorkTotals);
             return selected;
         }
         catch (OperationCanceledException)
-            when (adoptCurrentResultRequested?.Invoke() == true
-                  && currentAdoptableResult != null)
+            when (interaction?.CurrentTakeoverRequest?.Kind == SearchTakeoverKind.ApplyCurrentTurn
+                  && currentCompleteAdoptableResult != null)
         {
             policy.Diagnostics.Info(
                 $"[CombatSolver/Test] SEARCH_INTERIM_ADOPTED " +
-                $"potions={currentAdoptableResult.ProjectedBattlePotionCount} " +
-                $"projected_battle_hp_lost={currentAdoptableResult.ProjectedBattleHpLost}");
-            PopulateRequestWorkTotals(currentAdoptableResult, requestWorkTotals);
-            return currentAdoptableResult;
+                $"potions={currentCompleteAdoptableResult.ProjectedBattlePotionCount} " +
+                $"projected_battle_hp_lost={currentCompleteAdoptableResult.ProjectedBattleHpLost}");
+            PopulateRequestWorkTotals(currentCompleteAdoptableResult, requestWorkTotals);
+            return currentCompleteAdoptableResult;
         }
+    }
+
+    private static bool IsAdoptionResult(SolverResult result)
+        => result.ResultScope is SolverResultScope.CurrentTurnAdoption
+            or SolverResultScope.RouteAdoption
+            || SolverInterimResultOrdering.IsCompleteVictory(
+                result.BestNode.ActionCount,
+                result.Snapshot.AllEnemiesDead,
+                result.Snapshot.PlayerDead,
+                result.Snapshot.ProjectedPlayerHp);
+
+    private static SolverResult? ResolveTakeoverResult(
+        SolverResult result,
+        SearchInteractionState? interaction)
+    {
+        SearchTakeoverRequest? request = interaction?.CurrentTakeoverRequest;
+        if (request == null)
+            return null;
+        if (result.ResultScope is SolverResultScope.CurrentTurnAdoption
+            or SolverResultScope.RouteAdoption)
+        {
+            return result;
+        }
+        if (request.Kind == SearchTakeoverKind.AdoptRoute)
+            return request.RouteAdoptionSeed?.Materialize();
+        return IsAdoptionResult(result) ? result : null;
     }
 
     private static SolverResult SolveCore(
@@ -110,8 +161,7 @@ internal static class CombatSearchCoordinator
         SearchPolicySnapshot policy,
         CancellationToken cancellationToken,
         Action<SolverProgress>? progressCallback,
-        Action<SolverResult>? interimResultCallback,
-        Func<bool>? adoptCurrentResultRequested)
+        Action<SolverResult>? interimResultCallback)
     {
         SolverSearchProfile shortProfile = policy.ShortProfile;
         if (policy.ShortBudgetOverrideMilliseconds is { } shortBudget)
@@ -155,12 +205,11 @@ internal static class CombatSearchCoordinator
                 cancellationToken,
                 progressCallback,
                 shortProfile,
-                potionPolicyOverride: initialPotionPolicyOverride,
-                adoptCurrentResultRequested: adoptCurrentResultRequested).Solve();
+                potionPolicyOverride: initialPotionPolicyOverride).Solve();
             PopulateSingleSessionTotals(shortResult, shortProfile.SoftTimeBudgetMilliseconds, deepTriggered: false);
             interimResultCallback?.Invoke(shortResult);
-            if (adoptCurrentResultRequested?.Invoke() == true)
-                return shortResult;
+            if (ResolveTakeoverResult(shortResult, policy.Interaction) is { } shortTakeoverResult)
+                return shortTakeoverResult;
             if (!policy.PotionStrategy.HasForcedDirectives)
             {
                 shortResult = RunSupplementalAudits(
@@ -174,8 +223,7 @@ internal static class CombatSearchCoordinator
                     shortCheckpointMilliseconds: null,
                     requestClock,
                     shortResult,
-                    interimResultCallback,
-                    adoptCurrentResultRequested);
+                    interimResultCallback);
             }
             if (policy.MeasurePhasePerformance)
                 policy.Diagnostics.Info(SolverDiagnostics.DescribeSearchPhasePerformance(shortResult));
@@ -204,8 +252,7 @@ internal static class CombatSearchCoordinator
             progressCallback,
             deepProfile,
             shortCheckpointMilliseconds: shortProfile.SoftTimeBudgetMilliseconds,
-            potionPolicyOverride: initialPotionPolicyOverride,
-            adoptCurrentResultRequested: adoptCurrentResultRequested).Solve();
+            potionPolicyOverride: initialPotionPolicyOverride).Solve();
         if (policy.MeasurePhasePerformance)
             policy.Diagnostics.Info(SolverDiagnostics.DescribeSearchPhasePerformance(result));
         bool deepTriggered = result.Elapsed.TotalMilliseconds > shortProfile.SoftTimeBudgetMilliseconds;
@@ -215,8 +262,8 @@ internal static class CombatSearchCoordinator
         result.SingleSessionSearch = true;
         PopulateSingleSessionTotals(result, shortProfile.SoftTimeBudgetMilliseconds, deepTriggered);
         interimResultCallback?.Invoke(result);
-        if (adoptCurrentResultRequested?.Invoke() == true)
-            return result;
+        if (ResolveTakeoverResult(result, policy.Interaction) is { } takeoverResult)
+            return takeoverResult;
         if (!policy.PotionStrategy.HasForcedDirectives)
         {
             result = RunSupplementalAudits(
@@ -230,8 +277,7 @@ internal static class CombatSearchCoordinator
                 shortProfile.SoftTimeBudgetMilliseconds,
                 requestClock,
                 result,
-                interimResultCallback,
-                adoptCurrentResultRequested);
+                interimResultCallback);
         }
         policy.Diagnostics.Info(
             $"[CombatSolver/Test] SEARCH_SESSION mode=single_anytime " +
@@ -251,8 +297,7 @@ internal static class CombatSearchCoordinator
         int? shortCheckpointMilliseconds,
         Stopwatch requestClock,
         SolverResult primary,
-        Action<SolverResult>? interimResultCallback,
-        Func<bool>? adoptCurrentResultRequested)
+        Action<SolverResult>? interimResultCallback)
     {
         long remainingMilliseconds = profile.SoftTimeBudgetMilliseconds - requestClock.ElapsedMilliseconds;
         if (remainingMilliseconds <= 0)
@@ -279,6 +324,8 @@ internal static class CombatSearchCoordinator
                 profile,
                 shortCheckpointMilliseconds,
                 selected);
+            if (ResolveTakeoverResult(selected, policy.Interaction) is { } requiredTakeoverResult)
+                return requiredTakeoverResult;
             selected = AuditSmartPotionUse(
                 root,
                 displayNames,
@@ -289,8 +336,7 @@ internal static class CombatSearchCoordinator
                 profile,
                 shortCheckpointMilliseconds,
                 selected,
-                interimResultCallback,
-                adoptCurrentResultRequested);
+                interimResultCallback);
             if (policy.PotionPolicy != SolverPotionPolicy.Smart)
             {
                 selected = AuditOpeningPowerUse(
@@ -430,6 +476,8 @@ internal static class CombatSearchCoordinator
                 profile,
                 shortCheckpointMilliseconds,
                 fixedPrefixActions: [openingPower]).Solve();
+            if (posterior.ResultScope == SolverResultScope.RouteAdoption)
+                return posterior;
             bool posteriorDeepTriggered = shortCheckpointMilliseconds is { } checkpoint
                 && posterior.Elapsed.TotalMilliseconds > checkpoint;
             posterior.SearchPhase = posteriorDeepTriggered
@@ -490,6 +538,8 @@ internal static class CombatSearchCoordinator
                 profile,
                 shortCheckpointMilliseconds,
                 fixedPrefixActions: [openingPower, offensiveFollowUp]).Solve();
+            if (linkedPosterior.ResultScope == SolverResultScope.RouteAdoption)
+                return linkedPosterior;
             bool linkedDeepTriggered = shortCheckpointMilliseconds is { } linkedCheckpoint
                 && linkedPosterior.Elapsed.TotalMilliseconds > linkedCheckpoint;
             linkedPosterior.SearchPhase = linkedDeepTriggered
@@ -554,6 +604,8 @@ internal static class CombatSearchCoordinator
                 profile,
                 shortCheckpointMilliseconds,
                 fixedPrefixActions: [openingResource, defensiveFollowUp]).Solve();
+            if (resourceDefensePosterior.ResultScope == SolverResultScope.RouteAdoption)
+                return resourceDefensePosterior;
             bool posteriorDeepTriggered = shortCheckpointMilliseconds is { } posteriorCheckpoint
                 && resourceDefensePosterior.Elapsed.TotalMilliseconds > posteriorCheckpoint;
             resourceDefensePosterior.SearchPhase = posteriorDeepTriggered
@@ -597,6 +649,8 @@ internal static class CombatSearchCoordinator
                 $"POTION_RESOURCE_POSTERIOR potion={openingPotion.PotionId}");
             if (resourcePosterior == null)
                 continue;
+            if (resourcePosterior.ResultScope == SolverResultScope.RouteAdoption)
+                return resourcePosterior;
             bool resourceDeepTriggered = shortCheckpointMilliseconds is { } resourceCheckpoint
                 && resourcePosterior.Elapsed.TotalMilliseconds > resourceCheckpoint;
             resourcePosterior.SearchPhase = resourceDeepTriggered
@@ -662,6 +716,8 @@ internal static class CombatSearchCoordinator
                 $"POTION_POWER_POSTERIOR potion={openingPotion.PotionId} power={postPotionPower.CardId}");
             if (jointPosterior == null)
                 continue;
+            if (jointPosterior.ResultScope == SolverResultScope.RouteAdoption)
+                return jointPosterior;
             bool jointDeepTriggered = shortCheckpointMilliseconds is { } jointCheckpoint
                 && jointPosterior.Elapsed.TotalMilliseconds > jointCheckpoint;
             jointPosterior.SearchPhase = jointDeepTriggered
@@ -741,6 +797,8 @@ internal static class CombatSearchCoordinator
                 $"power={postPotionPower.CardId} follow_up={defensiveFollowUp.CardId}");
             if (defensivePosterior == null)
                 continue;
+            if (defensivePosterior.ResultScope == SolverResultScope.RouteAdoption)
+                return defensivePosterior;
             bool defensiveDeepTriggered = shortCheckpointMilliseconds is { } defensiveCheckpoint
                 && defensivePosterior.Elapsed.TotalMilliseconds > defensiveCheckpoint;
             defensivePosterior.SearchPhase = defensiveDeepTriggered
@@ -818,6 +876,8 @@ internal static class CombatSearchCoordinator
             profile,
             shortCheckpointMilliseconds,
             SolverPotionPolicy.Disabled).Solve();
+        if (potionFree.ResultScope == SolverResultScope.RouteAdoption)
+            return potionFree;
         bool auditDeepTriggered = shortCheckpointMilliseconds is { } checkpoint
             && potionFree.Elapsed.TotalMilliseconds > checkpoint;
         potionFree.SearchPhase = auditDeepTriggered ? SolverSearchPhase.Deep : SolverSearchPhase.Short;
@@ -862,6 +922,8 @@ internal static class CombatSearchCoordinator
                     SolverPotionPolicy.RequireAtLeastOne,
                     maximumPotionUses: primary.PotionCount,
                     fixedPrefixActions: [openingPotion]).Solve();
+                if (posterior.ResultScope == SolverResultScope.RouteAdoption)
+                    return posterior;
                 bool posteriorDeepTriggered = shortCheckpointMilliseconds is { } posteriorCheckpoint
                     && posterior.Elapsed.TotalMilliseconds > posteriorCheckpoint;
                 posterior.SearchPhase = posteriorDeepTriggered
@@ -927,6 +989,8 @@ internal static class CombatSearchCoordinator
                         SolverPotionPolicy.RequireAtLeastOne,
                         maximumPotionUses: primary.PotionCount,
                         fixedPrefixActions: [openingPotion, secondPotion]).Solve();
+                    if (pairPosterior.ResultScope == SolverResultScope.RouteAdoption)
+                        return pairPosterior;
                     bool pairDeepTriggered = shortCheckpointMilliseconds is { } pairCheckpoint
                         && pairPosterior.Elapsed.TotalMilliseconds > pairCheckpoint;
                     pairPosterior.SearchPhase = pairDeepTriggered
@@ -996,6 +1060,8 @@ internal static class CombatSearchCoordinator
                         SolverPotionPolicy.RequireAtLeastOne,
                         maximumPotionUses: primary.PotionCount,
                         fixedPrefixActions: [openingPotion, secondPotion, defensiveFollowUp]).Solve();
+                    if (defensivePosterior.ResultScope == SolverResultScope.RouteAdoption)
+                        return defensivePosterior;
                     bool defensiveDeepTriggered = shortCheckpointMilliseconds is { } defensiveCheckpoint
                         && defensivePosterior.Elapsed.TotalMilliseconds > defensiveCheckpoint;
                     defensivePosterior.SearchPhase = defensiveDeepTriggered
@@ -1060,6 +1126,8 @@ internal static class CombatSearchCoordinator
             SolverPotionPolicy.RequireAtLeastOne,
             baseline,
             maximumPotionUses: 1).Solve();
+        if (audited.ResultScope == SolverResultScope.RouteAdoption)
+            return audited;
         bool auditedDeepTriggered = shortCheckpointMilliseconds is { } auditedCheckpoint
             && audited.Elapsed.TotalMilliseconds > auditedCheckpoint;
         audited.SearchPhase = auditedDeepTriggered ? SolverSearchPhase.Deep : SolverSearchPhase.Short;
@@ -1088,8 +1156,7 @@ internal static class CombatSearchCoordinator
         SolverSearchProfile profile,
         int? shortCheckpointMilliseconds,
         SolverResult primary,
-        Action<SolverResult>? interimResultCallback,
-        Func<bool>? adoptCurrentResultRequested)
+        Action<SolverResult>? interimResultCallback)
     {
         if (policy.PotionPolicy != SolverPotionPolicy.Smart)
             return primary;
@@ -1105,8 +1172,7 @@ internal static class CombatSearchCoordinator
                 profile,
                 shortCheckpointMilliseconds,
                 primary,
-                interimResultCallback,
-                adoptCurrentResultRequested);
+                interimResultCallback);
         }
         catch (PotionPolicyUnsatisfiedException)
             when (policy.PotionPolicy == SolverPotionPolicy.Smart
@@ -1128,8 +1194,7 @@ internal static class CombatSearchCoordinator
         SolverSearchProfile profile,
         int? shortCheckpointMilliseconds,
         SolverResult potionFree,
-        Action<SolverResult>? interimResultCallback,
-        Func<bool>? adoptCurrentResultRequested)
+        Action<SolverResult>? interimResultCallback)
     {
         if (potionFree.ExplicitPotionCount != 0)
             throw new InvalidOperationException("Smart 梯度搜索必须从无主动用药结果开始。");
@@ -1173,8 +1238,7 @@ internal static class CombatSearchCoordinator
                     SolverPotionPolicy.RequireAtLeastOne,
                     baseline,
                     maximumPotionUses: potionCount,
-                    minimumPotionUses: potionCount,
-                    adoptCurrentResultRequested: adoptCurrentResultRequested).Solve();
+                    minimumPotionUses: potionCount).Solve();
             }
             catch (PotionPolicyUnsatisfiedException)
             {
@@ -1182,6 +1246,8 @@ internal static class CombatSearchCoordinator
                     $"[CombatSolver/Test] SMART_POTION_GRADIENT layer={potionCount} route_missing=true");
                 continue;
             }
+            if (candidate.ResultScope == SolverResultScope.RouteAdoption)
+                return candidate;
 
             bool candidateDeepTriggered = shortCheckpointMilliseconds is { } checkpoint
                 && candidate.Elapsed.TotalMilliseconds > checkpoint;
@@ -1246,6 +1312,7 @@ internal static class CombatSearchCoordinator
             ProjectedBattlePotionCount: result.ProjectedBattlePotionCount,
             EnemyHp: result.Snapshot.EnemyHp,
             Score: result.BestNode.Score);
+
 
     private static bool IsBetterCompletedResult(
         CombatRootSnapshot root,

--- a/src/Search/SearchPolicySnapshot.cs
+++ b/src/Search/SearchPolicySnapshot.cs
@@ -19,4 +19,5 @@ internal sealed record SearchPolicySnapshot(
     SearchMemoryPressureSignal MemoryPressureSignal)
 {
     public SearchRequestWorkTotals? RequestWorkTotals { get; init; }
+    public SearchInteractionState? Interaction { get; init; }
 }

--- a/src/Testing/UnattendedTestRunner.ControllerSessions.cs
+++ b/src/Testing/UnattendedTestRunner.ControllerSessions.cs
@@ -57,6 +57,7 @@ internal sealed partial class UnattendedTestRunner
             try
             {
                 SolverSettingsSnapshot settings = SolverSettings.Capture();
+                SearchInteractionState interaction = new();
                 SearchPolicySnapshot forcedPolicy = SolverController.CaptureSearchPolicy(
                     settings,
                     combat,
@@ -70,6 +71,7 @@ internal sealed partial class UnattendedTestRunner
                     },
                     ForceShortOnly = true,
                     MaxDegreeOfParallelism = 4,
+                    Interaction = interaction,
                 };
                 CombatRootSnapshot forcedRoot = CombatRootSnapshot.Capture(combat);
                 SolverDisplayNames forcedDisplayNames = SolverDisplayNames.Capture(combat);
@@ -83,10 +85,13 @@ internal sealed partial class UnattendedTestRunner
                     CancellationToken.None,
                     progress =>
                     {
-                        if (progress.CurrentBestResult != null)
+                        if (progress.CurrentBestResult != null
+                            && !forcedAdoptionRequested)
+                        {
                             forcedAdoptionRequested = true;
-                    },
-                    () => forcedAdoptionRequested));
+                            interaction.RequestApplyCurrentTurn();
+                        }
+                    }));
                 if (!forcedAdoptionRequested
                     || !forcedResult.BestNode.Actions.Any(action =>
                         action.Kind == PlanActionKind.UsePotion
@@ -643,6 +648,7 @@ internal sealed partial class UnattendedTestRunner
     private static async Task AssertBoundedSmartPotionAuditAsync(CombatState combat)
     {
         SolverSettingsSnapshot settings = SolverSettings.Capture();
+        SearchInteractionState interaction = new();
         SearchPolicySnapshot policy = SolverController.CaptureSearchPolicy(
             settings,
             combat,
@@ -656,6 +662,7 @@ internal sealed partial class UnattendedTestRunner
             },
             ForceShortOnly = true,
             MaxDegreeOfParallelism = 1,
+            Interaction = interaction,
         };
         CombatRootSnapshot root = CombatRootSnapshot.Capture(combat);
         SolverDisplayNames displayNames = SolverDisplayNames.Capture(combat);
@@ -867,9 +874,8 @@ internal sealed partial class UnattendedTestRunner
                 }
                 displayedPotionCount = result.ProjectedBattlePotionCount;
                 displayedHpLost = result.ProjectedBattleHpLost;
-                adoptionRequested = true;
-            },
-            () => adoptionRequested));
+                adoptionRequested = interaction.RequestApplyCurrentTurn();
+            }));
         stopwatch.Stop();
         if (stopwatch.ElapsedMilliseconds > 4_000)
         {

--- a/src/Testing/UnattendedTestRunner.cs
+++ b/src/Testing/UnattendedTestRunner.cs
@@ -444,15 +444,15 @@ internal sealed partial class UnattendedTestRunner
                 && state != null
                 && PlayerTurnSetupCoordinator.IsInitialChoiceSearchPendingForTesting(state))
             {
-                if (!SolverController.CanAdoptCurrentSearchResult)
+                if (!SolverController.CanAdoptCurrentRoute)
                 {
                     await NextFrameAsync();
                     continue;
                 }
                 int turn = player?.PlayerCombatState?.TurnNumber
                     ?? throw new InvalidOperationException("开局搜索控件测试找不到玩家回合。");
-                SolverController.AdoptCurrentSearchResult();
-                if (!SolverController.IsAdoptingCurrentSearchResult)
+                SolverController.AdoptCurrentRoute();
+                if (!SolverController.IsAdoptingCurrentRoute)
                     throw new InvalidOperationException("开局搜索的当前完整路线没有进入采纳状态。");
                 SolverController.RequestDeploy(_host, state);
                 if (!PlayerTurnSetupCoordinator.TakeoverRequestedForTesting)

--- a/src/UI/SolverOverlay.cs
+++ b/src/UI/SolverOverlay.cs
@@ -5,9 +5,19 @@ using MegaCrit.Sts2.Core.Nodes;
 
 namespace CombatSolver;
 
+internal enum SolverOverlayPresentation
+{
+    Ready,
+    Deploying,
+    ExecutedHistory,
+    Searching,
+}
+
 internal static class SolverOverlay
 {
     private const string LayerName = "CombatSolverOverlay";
+    private const float ResizeHandleSize = 18f;
+    private const long ResizeLayoutIntervalMilliseconds = 16;
     private static Color Background => SolverUiTokens.Palette.Background;
     private static Color Surface => SolverUiTokens.Palette.Surface;
     private static Color Border => SolverUiTokens.Palette.Border;
@@ -20,6 +30,7 @@ internal static class SolverOverlay
 
     private static CanvasLayer? _layer;
     private static PanelContainer? _panel;
+    private static Control? _resizeHandle;
     private static Viewport? _viewport;
     private static ScrollContainer? _routeScroll;
     private static VBoxContainer? _body;
@@ -35,6 +46,7 @@ internal static class SolverOverlay
     private static Label? _reviewText;
     private static ProgressBar? _searchProgressBar;
     private static HBoxContainer? _routeHeadingRow;
+    private static Label? _routeHeadingLabel;
     private static readonly SolverRouteRow[] RouteRows = new SolverRouteRow[SolverWeights.UiTurnRows];
     private static PanelContainer? _detailsPanel;
     private static Label? _deathOutcomeLabel;
@@ -43,13 +55,14 @@ internal static class SolverOverlay
     private static RichTextLabel? _detailsText;
     private static SolverDetailsButton? _detailsButton;
     private static Button? _recalculateButton;
+    private static Button? _stopSearchButton;
+    private static Button? _adoptRouteButton;
     private static Button? _executeButton;
     private static Button? _fullAutoButton;
     private static Button? _collapseButton;
     private static Button? _settingsButton;
     private static Button? _potionStrategyButton;
     private static Button? _performanceHintButton;
-    private static Control? _headerPotionSpacer;
     private static SolverPotionStrategyPanel? _potionStrategyPanel;
     private static PanelContainer? _feedbackBanner;
     private static Label? _feedbackBannerLabel;
@@ -62,20 +75,32 @@ internal static class SolverOverlay
     private static bool _deployQueued;
     private static bool _detailsVisible;
     private static bool _dragging;
+    private static bool _resizing;
     private static bool _layoutQueued;
     private static bool? _renderedFullAutoStyle;
     private static SolverButtonStyle? _renderedExecuteButtonStyle;
+    private static SolverButtonStyle? _renderedAdoptRouteButtonStyle;
     private static SolverTheftPolicy? _renderedTheftPolicy;
     private static SolverOverlaySnapshot? _lastSnapshot;
+    private static SolverOverlaySnapshot? _searchBestSnapshot;
     private static string? _lastMessageText;
     private static int _lastSearchingTurn;
     private static bool _lastSearchDeployWhenReady;
     private static long _lastReviewedWorldlinesBeforeSearch;
     private static double _lastSearchProgressRatio;
+    private static SolverOverlayPresentation _presentation = SolverOverlayPresentation.Searching;
+    private static int _lastDeploymentTurn;
+    private static int _lastDeploymentActionCount;
+    private static bool _lastDeploymentEndedTurn;
+    private static bool _waitingForNextTurnPlan;
     private static bool _themeRefreshQueued;
     private static int _remainingLayoutPasses;
+    private static long _lastResizeLayoutAt;
     private static Vector2 _dragOffset;
+    private static Vector2 _resizeStartMousePosition;
+    private static Vector2 _resizeStartSize;
     private static Vector2 _panelPosition = new(SolverUiTokens.Size.PanelMargin, SolverUiTokens.Size.PanelMargin);
+    private static Vector2? _panelSize;
 
     public static bool IsVisible
         => _layer != null && GodotObject.IsInstanceValid(_layer) && _layer.Visible;
@@ -97,6 +122,11 @@ internal static class SolverOverlay
                 SolverUiTokens.BugReportUploadInstruction,
                 StringComparison.Ordinal);
     internal static string? ExecuteButtonTextForTesting => _executeButton?.Text;
+    internal static bool ExecuteButtonDisabledForTesting => _executeButton?.Disabled ?? true;
+    internal static string? AdoptRouteButtonTextForTesting => _adoptRouteButton?.Text;
+    internal static bool AdoptRouteButtonDisabledForTesting => _adoptRouteButton?.Disabled ?? true;
+    internal static SolverOverlayPresentation PresentationForTesting => _presentation;
+    internal static string? RouteHeadingForTesting => _routeHeadingLabel?.Text;
     internal static bool MessageWrappingEnabledForTesting
         => _summaryText is { FitContent: true, AutowrapMode: TextServer.AutowrapMode.WordSmart };
     internal static bool UploadProgressConfiguredForTesting
@@ -165,7 +195,7 @@ internal static class SolverOverlay
             TogglePotionStrategy();
         bool opened = _potionStrategyVisible
             && _potionStrategyPanel.Visible
-            && _headerPotionSpacer?.Visible == true;
+            && ReferenceEquals(_potionStrategyPanel.GetParent(), _layer);
         if (!original)
             TogglePotionStrategy();
         return opened && _potionStrategyVisible == original;
@@ -217,15 +247,39 @@ internal static class SolverOverlay
 
     public static void ShowSearchStopped(Node host)
     {
-        _lastSnapshot = null;
         _lastMessageText = null;
         EnsureCreated(host);
         _deployQueued = false;
         SetStatus("计算已停止", Danger);
         SetPerformanceHintVisible(false);
         SetReviewText(null);
+        if (_searchBestSnapshot == null && _lastSnapshot == null)
+        {
+            SetMessageContent(
+                $"[color={SolverUiTokens.Palette.DangerHex}]本回合计算已停止。可手动开始计算；进入下一回合后是否自动计算由设置决定。[/color]");
+        }
+        else if (_summaryText != null)
+        {
+            _summaryText.Visible = true;
+            _summaryText.Text =
+                $"[color={SolverUiTokens.Palette.WarningHex}]计算已停止；下方保留停止时已经得到的当前候选路线。[/color]";
+        }
+        ShowLayer();
+        RefreshControls();
+    }
+
+    public static void ShowManualCalculationReady(Node host, bool hasPreviousCalculation)
+    {
+        _lastSnapshot = null;
+        _searchBestSnapshot = null;
+        _lastMessageText = null;
+        EnsureCreated(host);
+        _deployQueued = false;
+        SetStatus("等待手动计算", TextMuted);
+        SetPerformanceHintVisible(false);
+        SetReviewText(null);
         SetMessageContent(
-            $"[color={SolverUiTokens.Palette.DangerHex}]本场自动计算已暂停。点击“重新计算”后恢复当前及后续回合搜索。[/color]");
+            $"[color={SolverUiTokens.Palette.TextSecondaryHex}]自动计算已关闭。点击“{(hasPreviousCalculation ? "重新计算" : "开始计算")}”生成当前回合路线。[/color]");
         ShowLayer();
         RefreshControls();
     }
@@ -233,24 +287,30 @@ internal static class SolverOverlay
     public static void ShowProgress(
         SolverProgress progress,
         bool deployWhenReady,
-        long reviewedWorldlinesBeforeSearch)
+        long reviewedWorldlinesBeforeSearch,
+        SolverOverlaySnapshot? bestSnapshot = null)
     {
+        _presentation = SolverOverlayPresentation.Searching;
+        _waitingForNextTurnPlan = false;
         if (_layer == null || !GodotObject.IsInstanceValid(_layer) || !_layer.Visible)
             return;
         _deployQueued = deployWhenReady;
-        _lastSearchingTurn = progress.CurrentTurnNumber;
         _lastSearchDeployWhenReady = deployWhenReady;
         _lastReviewedWorldlinesBeforeSearch = reviewedWorldlinesBeforeSearch;
+        if (bestSnapshot != null)
+        {
+            _searchBestSnapshot = bestSnapshot;
+            PopulateRoute(bestSnapshot, resetScroll: false);
+        }
+        string routeContext = _searchBestSnapshot is { Turns.Count: > 0 } routeSnapshot
+            ? $"已规划至第 {routeSnapshot.Turns[^1].Turn} 回合"
+            : "等待候选路线";
         SetStatus(
             "后台计算中",
             Accent,
-            deployWhenReady
-                ? $"第 {progress.CurrentTurnNumber} 回合    已排队执行"
-                : $"第 {progress.CurrentTurnNumber} 回合");
-        if (_summaryText != null)
-        {
-            _summaryText.Visible = false;
-        }
+            deployWhenReady ? $"{routeContext}    已排队执行" : routeContext);
+        if (_routeHeadingLabel != null)
+            _routeHeadingLabel.Text = "求解器当前考虑（尚未验证）";
         if (_progressText != null)
         {
             _progressText.Visible = true;
@@ -259,17 +319,16 @@ internal static class SolverOverlay
         string potionSearchPhase = progress.Phase.StartsWith("正在搜索", StringComparison.Ordinal)
             ? progress.Phase
             : string.Empty;
-        string currentBest = progress.CurrentBestResult is { } result
-            ? $"当前可采用：用 {result.ProjectedBattlePotionCount} 瓶药，" +
-              $"预计战损 {result.ProjectedBattleHpLost} · "
-            : string.Empty;
+        string reviewedWorldlinesText =
+            $"已查阅 {reviewedWorldlinesBeforeSearch + progress.ReviewedWorldlines:N0} 条世界线";
         SetReviewText(potionSearchPhase);
         if (_summaryText != null)
         {
             _summaryText.Visible = true;
-            _summaryText.Text =
-                $"{currentBest}已查阅 " +
-                $"{reviewedWorldlinesBeforeSearch + progress.ReviewedWorldlines:N0} 条世界线";
+            _summaryText.Text = _searchBestSnapshot is { } snapshot
+                ? SolverUiTokens.AdaptRichTextToActiveTheme(snapshot.SummaryText) +
+                  $"\n{reviewedWorldlinesText}"
+                : reviewedWorldlinesText;
         }
         if (_searchProgressBar != null)
         {
@@ -291,7 +350,11 @@ internal static class SolverOverlay
         bool deployWhenReady,
         long reviewedWorldlinesBeforeSearch)
     {
+        _presentation = SolverOverlayPresentation.Searching;
+        _waitingForNextTurnPlan = false;
+        SolverController.InvalidateRenderedRouteAdoptionSeed();
         _lastSnapshot = null;
+        _searchBestSnapshot = null;
         _lastMessageText = null;
         _lastSearchingTurn = turn;
         _lastSearchDeployWhenReady = deployWhenReady;
@@ -303,10 +366,12 @@ internal static class SolverOverlay
             "后台计算中",
             Accent,
             deployWhenReady ? $"第 {turn} 回合    已排队执行" : $"第 {turn} 回合");
+        if (_routeHeadingLabel != null)
+            _routeHeadingLabel.Text = "求解器当前考虑（尚未验证）";
         if (_summaryText != null)
         {
             _summaryText.Visible = true;
-            _summaryText.Text = $"[color={SolverUiTokens.Palette.TextSecondaryHex}]正在准备搜索…[/color]";
+            _summaryText.Text = $"[color={SolverUiTokens.Palette.TextSecondaryHex}]正在计算当前回合，等待可存活候选…[/color]";
         }
         if (_progressText != null)
             _progressText.Visible = false;
@@ -327,11 +392,11 @@ internal static class SolverOverlay
             _deathOutcomeLabel.Visible = false;
         for (int index = 0; index < SolverWeights.UiTurnRows; index++)
         {
-            SetRouteRowVisible(index, index < 3);
-            if (index >= 3)
+            SetRouteRowVisible(index, index == 0);
+            if (index != 0)
                 continue;
-            RouteRows[index].TurnLabel.Text = $"第 {turn + index} 回合";
-            RouteRows[index].ShowStatus("等待搜索结果…");
+            RouteRows[index].TurnLabel.Text = $"第 {turn} 回合";
+            RouteRows[index].ShowStatus("等待当前回合候选…");
             RouteRows[index].SetOutcome(string.Empty, TextMuted);
         }
         if (_routeScroll != null)
@@ -350,7 +415,10 @@ internal static class SolverOverlay
 
     public static void ShowResult(Node host, SolverOverlaySnapshot snapshot)
     {
+        _presentation = SolverOverlayPresentation.Ready;
+        _waitingForNextTurnPlan = false;
         _lastSnapshot = snapshot;
+        _searchBestSnapshot = null;
         _lastMessageText = null;
         EnsureCreated(host);
         _deployQueued = false;
@@ -360,10 +428,10 @@ internal static class SolverOverlay
             SolverOverlayTone.Success => Success,
             _ => Accent,
         };
-        SetStatus(
-            snapshot.StatusText,
-            statusColor,
-            $"第 {snapshot.StartTurnNumber} 回合");
+        string routeContext = snapshot.Turns.Count > 0
+            ? $"已规划至第 {snapshot.Turns[^1].Turn} 回合"
+            : $"第 {snapshot.StartTurnNumber} 回合";
+        SetStatus(snapshot.StatusText, statusColor, routeContext);
         if (_summaryPanel != null)
             _summaryPanel.Visible = true;
         if (_summaryText != null)
@@ -374,10 +442,28 @@ internal static class SolverOverlay
         if (_progressText != null)
             _progressText.Visible = false;
         SetReviewText(snapshot.ReviewSummaryText);
-        SetPerformanceHintVisible(snapshot.ProjectedBattleHpLost > 0);
+        bool hasRouteDetails = !string.IsNullOrEmpty(snapshot.DetailsText);
+        SetPerformanceHintVisible(hasRouteDetails && snapshot.ProjectedBattleHpLost > 0);
         if (_searchProgressBar != null)
             _searchProgressBar.Visible = false;
 
+        if (_routeHeadingLabel != null)
+            _routeHeadingLabel.Text = "推荐路线";
+        PopulateRoute(snapshot, resetScroll: true);
+        if (_detailsButton != null)
+            _detailsButton.Visible = hasRouteDetails;
+        if (_detailsText != null)
+            _detailsText.Text = SolverUiTokens.AdaptRichTextToActiveTheme(snapshot.DetailsText);
+        SetDetailsVisible(false);
+        ShowLayer();
+        RefreshControls();
+        Entry.Logger.Info(
+            $"[CombatSolver/Test] UI_STATE state=ready turn={snapshot.StartTurnNumber} " +
+            $"risk={snapshot.HasRisk} only_death_routes={snapshot.OnlyDeathRoutesFound}");
+    }
+
+    private static void PopulateRoute(SolverOverlaySnapshot snapshot, bool resetScroll)
+    {
         SetRouteVisibility(true);
         if (_potionOutcomeLabel != null)
         {
@@ -404,33 +490,35 @@ internal static class SolverOverlay
             RouteRows[index].SetOutcome(
                 outcome,
                 turn.CombatEnded ? Success : turn.HpLoss > 0 ? Danger : TextMuted,
-                $"余 {turn.EnergyLeft} 费");
+                energyText: $"余 {turn.EnergyLeft} 费",
+                enemyDamageText: turn.EnemyHpDamageLost is { } damage
+                    ? $"对敌伤害 {damage}"
+                    : string.Empty);
         }
-        if (_routeScroll != null)
+        if (resetScroll && _routeScroll != null)
             _routeScroll.ScrollVertical = 0;
 
         if (_hpOutcomeLabel != null)
         {
             _hpOutcomeLabel.Text = snapshot.HpOutcomeText;
-            _hpOutcomeLabel.AddThemeColorOverride("font_color", snapshot.ProjectedBattleHpLost > 0 ? Danger : Success);
+            _hpOutcomeLabel.AddThemeColorOverride(
+                "font_color",
+                snapshot.ProjectedBattleHpLost > 0 ? Danger : Success);
         }
-        if (_detailsButton != null)
-            _detailsButton.Visible = true;
-        if (_detailsText != null)
-            _detailsText.Text = SolverUiTokens.AdaptRichTextToActiveTheme(snapshot.DetailsText);
-        SetDetailsVisible(false);
-        ShowLayer();
-        RefreshControls();
-        Entry.Logger.Info(
-            $"[CombatSolver/Test] UI_STATE state=ready turn={snapshot.StartTurnNumber} " +
-            $"risk={snapshot.HasRisk} only_death_routes={snapshot.OnlyDeathRoutesFound}");
     }
 
     public static void ShowDeploying(Node host, int turn, int actionCount)
     {
+        _presentation = SolverOverlayPresentation.Deploying;
+        _waitingForNextTurnPlan = false;
+        _lastDeploymentTurn = turn;
+        _lastDeploymentActionCount = actionCount;
+        _lastDeploymentEndedTurn = false;
         EnsureCreated(host);
         _deployQueued = false;
         SetStatus("正在执行", Warning, $"第 {turn} 回合");
+        if (_routeHeadingLabel != null)
+            _routeHeadingLabel.Text = "正在执行的路线";
         if (_summaryPanel != null)
             _summaryPanel.Visible = true;
         if (_summaryText != null)
@@ -489,11 +577,18 @@ internal static class SolverOverlay
 
     public static void ShowDeploymentComplete(Node host, int turn, int actionCount, bool endedTurn)
     {
+        _presentation = SolverOverlayPresentation.ExecutedHistory;
+        _waitingForNextTurnPlan = false;
+        _lastDeploymentTurn = turn;
+        _lastDeploymentActionCount = actionCount;
+        _lastDeploymentEndedTurn = endedTurn;
         EnsureCreated(host);
         ShowDeploymentStep(actionCount, actionCount, null);
         RouteRows[0].SetEndTurnDeploymentState(active: false, completed: endedTurn);
         _deployQueued = false;
         SetStatus("执行完成", Accent, $"第 {turn} 回合");
+        if (_routeHeadingLabel != null)
+            _routeHeadingLabel.Text = "已执行路线（后续回合待校验）";
         if (_summaryPanel != null)
             _summaryPanel.Visible = true;
         if (_summaryText != null)
@@ -508,6 +603,30 @@ internal static class SolverOverlay
         ShowLayer();
         RefreshControls();
         Entry.Logger.Info($"[CombatSolver/Test] UI_STATE state=deployment_complete turn={turn} card_count={actionCount} end_turn={endedTurn}");
+    }
+
+    public static void ShowWaitingForNextTurnPlan(Node host)
+    {
+        _presentation = SolverOverlayPresentation.ExecutedHistory;
+        _waitingForNextTurnPlan = true;
+        if (_lastSnapshot == null)
+        {
+            Show(host, "[b]战斗路线求解器[/b]\n等待下一回合方案。");
+            return;
+        }
+
+        EnsureCreated(host);
+        SetStatus("等待下一回合方案", TextMuted, $"第 {_lastDeploymentTurn} 回合已执行");
+        if (_routeHeadingLabel != null)
+            _routeHeadingLabel.Text = "已执行路线（后续回合待校验）";
+        if (_summaryText != null)
+        {
+            _summaryText.Visible = true;
+            _summaryText.Text =
+                $"[color={SolverUiTokens.Palette.TextSecondaryHex}]当前路线已经执行；等待下一回合方案就绪。[/color]";
+        }
+        ShowLayer();
+        RefreshControls();
     }
 
     public static void ShowFullAutoStoppedAtCombatEnd(int turn)
@@ -570,33 +689,57 @@ internal static class SolverOverlay
 
     public static void RefreshControls()
     {
-        if (_recalculateButton == null || _executeButton == null || _fullAutoButton == null)
+        if (_recalculateButton == null || _stopSearchButton == null || _adoptRouteButton == null
+            || _executeButton == null || _fullAutoButton == null)
             return;
 
         RefreshFeedbackBanner();
 
         bool solverDisabled = SolverController.SolverDisabled;
-        _recalculateButton.Disabled = solverDisabled || SolverController.IsSearching || SolverController.IsDeploying;
+        bool searching = SolverController.IsSearching;
+        bool adoptingRoute = SolverController.IsAdoptingCurrentRoute;
+        bool canAdoptRoute = SolverController.CanAdoptCurrentRoute;
+        bool canApplyCurrentTurn = SolverController.CanApplyCurrentTurn;
+        bool canExecuteCurrentTurn = SolverController.CanExecuteCurrentTurn;
+        _recalculateButton.Text = !SolverController.AutomaticCalculationEnabled
+            && !SolverController.HasCalculatedThisCombat
+                ? "开始计算"
+                : "重新计算";
+        _recalculateButton.Disabled = solverDisabled || searching
+            || SolverController.IsDeploying || adoptingRoute;
+        _stopSearchButton.Disabled = solverDisabled || !searching || SolverController.IsStoppingSearch;
+        _adoptRouteButton.Disabled = solverDisabled || !canAdoptRoute || adoptingRoute;
+        _adoptRouteButton.Text = adoptingRoute ? "正在采用…" : "采用当前路线";
+        SolverButtonStyle adoptRouteStyle = canAdoptRoute && !adoptingRoute
+            ? SolverButtonStyle.Positive
+            : SolverButtonStyle.Secondary;
+        if (_renderedAdoptRouteButtonStyle != adoptRouteStyle)
+        {
+            SolverUiTokens.ApplyButtonStyle(_adoptRouteButton, adoptRouteStyle);
+            _renderedAdoptRouteButtonStyle = adoptRouteStyle;
+        }
         _executeButton.Disabled = solverDisabled
             || SolverController.IsDeploying
-            || SolverController.IsAdoptingCurrentSearchResult;
+            || SolverController.IsApplyingCurrentTurn
+            || adoptingRoute
+            || searching && !canApplyCurrentTurn
+            || !searching && !canExecuteCurrentTurn;
         if (SolverController.IsDeploying)
             _executeButton.Text = "执行中…";
-        else if (SolverController.IsAdoptingCurrentSearchResult)
-            _executeButton.Text = "正在采用…";
-        else if (SolverController.CanAdoptCurrentSearchResult)
-            _executeButton.Text = "采用当前路线";
-        else if (SolverController.IsSearching)
-            _executeButton.Text = "停止计算";
+        else if (SolverController.IsApplyingCurrentTurn)
+            _executeButton.Text = "正在应用…";
+        else if (searching)
+            _executeButton.Text = "应用当前回合";
         else if (_deployQueued)
             _executeButton.Text = "已排队执行";
+        else if (_presentation == SolverOverlayPresentation.ExecutedHistory
+                 && !canExecuteCurrentTurn)
+            _executeButton.Text = "等待下一回合";
         else
             _executeButton.Text = "执行本回合";
-        SolverButtonStyle executeStyle = SolverController.CanAdoptCurrentSearchResult
+        SolverButtonStyle executeStyle = canApplyCurrentTurn
             ? SolverButtonStyle.Positive
-            : SolverController.IsSearching
-                ? SolverButtonStyle.Danger
-                : SolverButtonStyle.Primary;
+            : SolverButtonStyle.Primary;
         if (_renderedExecuteButtonStyle != executeStyle)
         {
             SolverUiTokens.ApplyButtonStyle(_executeButton, executeStyle);
@@ -604,7 +747,7 @@ internal static class SolverOverlay
         }
 
         _fullAutoButton.Text = SolverController.FullAutoEnabled ? "全自动：开" : "全自动：关";
-        _fullAutoButton.Disabled = solverDisabled;
+        _fullAutoButton.Disabled = solverDisabled || adoptingRoute;
         if (_renderedFullAutoStyle != SolverController.FullAutoEnabled)
         {
             SolverUiTokens.ApplyButtonStyle(
@@ -643,22 +786,23 @@ internal static class SolverOverlay
             return;
         }
 
-        SolverTheftPolicy policy = SolverController.TheftPolicy ?? SolverTheftPolicy.PreserveResources;
+        SolverTheftPolicy activePolicy = SolverController.TheftPolicy
+            ?? SolverTheftPolicy.PreserveResources;
         _preserveResourcesButton.Disabled = solverDisabled || SolverController.IsDeploying;
         _letEscapeButton.Disabled = solverDisabled || SolverController.IsDeploying;
-        if (_renderedTheftPolicy != policy)
+        if (_renderedTheftPolicy != activePolicy)
         {
             SolverUiTokens.ApplyButtonStyle(
                 _preserveResourcesButton,
-                policy == SolverTheftPolicy.PreserveResources
+                activePolicy == SolverTheftPolicy.PreserveResources
                     ? SolverButtonStyle.Positive
                     : SolverButtonStyle.Secondary);
             SolverUiTokens.ApplyButtonStyle(
                 _letEscapeButton,
-                policy == SolverTheftPolicy.LetEscape
+                activePolicy == SolverTheftPolicy.LetEscape
                     ? SolverButtonStyle.Primary
                     : SolverButtonStyle.Secondary);
-            _renderedTheftPolicy = policy;
+            _renderedTheftPolicy = activePolicy;
         }
     }
 
@@ -673,7 +817,12 @@ internal static class SolverOverlay
         if (_panel == null || !GodotObject.IsInstanceValid(_panel))
             return;
         float opacity = Math.Clamp(SolverSettings.Current.OverlayOpacity, 0.25f, 1f);
-        _panel.Modulate = new Color(1f, 1f, 1f, opacity);
+        Color modulate = new(1f, 1f, 1f, opacity);
+        _panel.Modulate = modulate;
+        if (_resizeHandle != null)
+            _resizeHandle.Modulate = modulate;
+        if (_potionStrategyPanel != null)
+            _potionStrategyPanel.Modulate = modulate;
     }
 
     public static void ApplyConfiguredTheme()
@@ -697,6 +846,8 @@ internal static class SolverOverlay
         bool wasPotionStrategyVisible = _potionStrategyVisible;
         bool wasCollapsed = _collapsed;
         bool wereDetailsVisible = _detailsVisible;
+        SolverOverlayPresentation presentation = _presentation;
+        bool wasWaitingForNextTurnPlan = _waitingForNextTurnPlan;
         CanvasLayer oldLayer = _layer;
         oldLayer.Visible = false;
         oldLayer.QueueFree();
@@ -704,16 +855,33 @@ internal static class SolverOverlay
             _viewport.SizeChanged -= ApplyResponsiveLayout;
         _layer = null;
         _panel = null;
+        _resizeHandle = null;
         _viewport = null;
+        _resizing = false;
         _layoutQueued = false;
         _remainingLayoutPasses = 0;
         _renderedFullAutoStyle = null;
         _renderedExecuteButtonStyle = null;
+        _renderedAdoptRouteButtonStyle = null;
         _renderedTheftPolicy = null;
 
         if (_lastSnapshot is { } snapshot)
         {
             ShowResult(host, snapshot);
+            if (presentation == SolverOverlayPresentation.Deploying)
+                ShowDeploying(host, _lastDeploymentTurn, _lastDeploymentActionCount);
+            else if (presentation == SolverOverlayPresentation.ExecutedHistory)
+            {
+                ShowDeploymentComplete(
+                    host,
+                    _lastDeploymentTurn,
+                    _lastDeploymentActionCount,
+                    _lastDeploymentEndedTurn);
+                if (wasWaitingForNextTurnPlan)
+                    ShowWaitingForNextTurnPlan(host);
+            }
+            if (SolverController.AutomaticSearchPaused)
+                ShowSearchStopped(host);
         }
         else if (SolverController.SolverDisabled)
         {
@@ -730,6 +898,10 @@ internal static class SolverOverlay
                 _lastSearchingTurn,
                 _lastSearchDeployWhenReady,
                 _lastReviewedWorldlinesBeforeSearch);
+        }
+        else if (!SolverController.AutomaticCalculationEnabled)
+        {
+            ShowManualCalculationReady(host, SolverController.HasCalculatedThisCombat);
         }
         else
         {
@@ -779,6 +951,17 @@ internal static class SolverOverlay
             SolverUiTokens.Spacing.Md,
             shadow: true));
 
+        PanelContainer resizeHandle = new()
+        {
+            Name = "ResizeHandle",
+            CustomMinimumSize = new Vector2(ResizeHandleSize, ResizeHandleSize),
+            MouseFilter = Control.MouseFilterEnum.Stop,
+            MouseDefaultCursorShape = Control.CursorShape.Fdiagsize,
+        };
+        resizeHandle.AddThemeStyleboxOverride("panel", SolverUiTokens.CreateBox(
+            Surface, Accent, SolverUiTokens.Radius.Small, 0, 0));
+        resizeHandle.GuiInput += OnResizeHandleGuiInput;
+
         VBoxContainer root = new()
         {
             Name = "Layout",
@@ -795,6 +978,7 @@ internal static class SolverOverlay
             Name = "ContentColumns",
             MouseFilter = Control.MouseFilterEnum.Pass,
             SizeFlagsHorizontal = Control.SizeFlags.ExpandFill,
+            SizeFlagsVertical = Control.SizeFlags.ExpandFill,
         };
         contentColumns.AddThemeConstantOverride("separation", SolverUiTokens.Spacing.Md);
         root.AddChild(contentColumns);
@@ -804,6 +988,7 @@ internal static class SolverOverlay
             Name = "PrimaryColumn",
             MouseFilter = Control.MouseFilterEnum.Pass,
             SizeFlagsHorizontal = Control.SizeFlags.ExpandFill,
+            SizeFlagsVertical = Control.SizeFlags.ExpandFill,
         };
         primaryColumn.AddThemeConstantOverride("separation", SolverUiTokens.Spacing.Sm);
         contentColumns.AddChild(primaryColumn);
@@ -814,6 +999,7 @@ internal static class SolverOverlay
         {
             Name = "ContentAndActions",
             MouseFilter = Control.MouseFilterEnum.Pass,
+            SizeFlagsVertical = Control.SizeFlags.ExpandFill,
         };
         lowerStack.AddThemeConstantOverride("separation", 0);
         primaryColumn.AddChild(lowerStack);
@@ -828,12 +1014,11 @@ internal static class SolverOverlay
 
         _potionStrategyPanel = new SolverPotionStrategyPanel();
         _potionStrategyPanel.DirectiveChanged += OnPotionDirectiveChanged;
-        contentColumns.AddChild(_potionStrategyPanel);
 
         _body = new VBoxContainer
         {
             Name = "Body",
-            SizeFlagsVertical = Control.SizeFlags.ShrinkBegin,
+            SizeFlagsVertical = Control.SizeFlags.ExpandFill,
             MouseFilter = Control.MouseFilterEnum.Ignore,
         };
         _body.AddThemeConstantOverride("separation", SolverUiTokens.Spacing.Sm);
@@ -845,13 +1030,13 @@ internal static class SolverOverlay
             MouseFilter = Control.MouseFilterEnum.Ignore,
             SizeFlagsHorizontal = Control.SizeFlags.ExpandFill,
         };
-        Label routeHeading = CreateTextLabel(
+        _routeHeadingLabel = CreateTextLabel(
             "推荐路线",
             SolverUiTokens.Type.Body,
             TextPrimary,
             FontType.Bold);
-        routeHeading.SizeFlagsHorizontal = Control.SizeFlags.ExpandFill;
-        _routeHeadingRow.AddChild(routeHeading);
+        _routeHeadingLabel.SizeFlagsHorizontal = Control.SizeFlags.ExpandFill;
+        _routeHeadingRow.AddChild(_routeHeadingLabel);
         _deathOutcomeLabel = CreateTextLabel(
             "未找到生还路线",
             SolverUiTokens.Type.Body,
@@ -888,7 +1073,7 @@ internal static class SolverOverlay
             Name = "RouteScroll",
             CustomMinimumSize = new Vector2(0, SolverUiTokens.Size.RouteViewportHeight),
             SizeFlagsHorizontal = Control.SizeFlags.ExpandFill,
-            SizeFlagsVertical = Control.SizeFlags.ShrinkBegin,
+            SizeFlagsVertical = Control.SizeFlags.ExpandFill,
             HorizontalScrollMode = ScrollContainer.ScrollMode.Disabled,
             VerticalScrollMode = ScrollContainer.ScrollMode.Auto,
             MouseFilter = Control.MouseFilterEnum.Pass,
@@ -916,9 +1101,12 @@ internal static class SolverOverlay
         lowerStack.AddChild(footerArea);
 
         layer.AddChild(panel);
+        layer.AddChild(_potionStrategyPanel);
+        layer.AddChild(resizeHandle);
         host.AddChild(layer);
         _layer = layer;
         _panel = panel;
+        _resizeHandle = resizeHandle;
         ApplyOverlayOpacity();
         if (_viewport != null && GodotObject.IsInstanceValid(_viewport))
             _viewport.SizeChanged -= ApplyResponsiveLayout;
@@ -927,10 +1115,15 @@ internal static class SolverOverlay
         panel.MinimumSizeChanged += QueueResponsiveLayout;
         _panelPosition = SolverSettings.OverlayPosition
             ?? new Vector2(SolverUiTokens.Size.PanelMargin, SolverUiTokens.Size.PanelMargin);
+        _panelSize = SolverSettings.OverlaySize;
         Entry.Logger.Info(
             $"[CombatSolver/Test] UI_POSITION_LOADED persisted={SolverSettings.OverlayPosition.HasValue} " +
             $"x={_panelPosition.X:F1} y={_panelPosition.Y:F1}");
+        Entry.Logger.Info(
+            $"[CombatSolver/Test] UI_SIZE_LOADED persisted={_panelSize.HasValue} " +
+            $"width={_panelSize?.X:F1} height={_panelSize?.Y:F1}");
         _dragging = false;
+        _resizing = false;
         _settingsVisible = false;
         _potionStrategyVisible = false;
         SetCollapsed(false);
@@ -1016,13 +1209,6 @@ internal static class SolverOverlay
         }
         header.AddChild(_collapseButton);
 
-        _headerPotionSpacer = new Control
-        {
-            Name = "PotionHeaderAnchorSpacer",
-            Visible = false,
-            MouseFilter = Control.MouseFilterEnum.Ignore,
-        };
-        header.AddChild(_headerPotionSpacer);
         return header;
     }
 
@@ -1216,6 +1402,17 @@ internal static class SolverOverlay
         _recalculateButton.CustomMinimumSize = new Vector2(112, SolverUiTokens.Size.ButtonHeight);
         _recalculateButton.Pressed += OnRecalculatePressed;
         footer.AddChild(_recalculateButton);
+
+        _stopSearchButton = CreateButton("停止计算", false);
+        SolverUiTokens.ApplyButtonStyle(_stopSearchButton, SolverButtonStyle.Danger);
+        _stopSearchButton.CustomMinimumSize = new Vector2(112, SolverUiTokens.Size.ButtonHeight);
+        _stopSearchButton.Pressed += OnStopSearchPressed;
+        footer.AddChild(_stopSearchButton);
+
+        _adoptRouteButton = CreateButton("采用当前路线", false);
+        _adoptRouteButton.CustomMinimumSize = new Vector2(132, SolverUiTokens.Size.ButtonHeight);
+        _adoptRouteButton.Pressed += OnAdoptRoutePressed;
+        footer.AddChild(_adoptRouteButton);
 
         _executeButton = CreateButton("执行本回合", true);
         _renderedExecuteButtonStyle = SolverButtonStyle.Primary;
@@ -1515,24 +1712,14 @@ internal static class SolverOverlay
             _mainStack.Visible = !_settingsVisible || _collapsed;
         if (_body != null)
             _body.Visible = !_collapsed && !_settingsVisible;
+        if (_resizeHandle != null)
+            _resizeHandle.Visible = !_collapsed;
         if (_footerDivider != null)
             _footerDivider.Visible = !_collapsed && !_settingsVisible;
         if (_settingsPanel != null)
             _settingsPanel.Visible = !_collapsed && _settingsVisible;
         if (_potionStrategyPanel != null)
             _potionStrategyPanel.Visible = !_collapsed && !_settingsVisible && _potionStrategyVisible;
-        if (_headerPotionSpacer != null)
-        {
-            bool reservePotionSidebar = !_collapsed && !_settingsVisible && _potionStrategyVisible;
-            _headerPotionSpacer.Visible = reservePotionSidebar;
-            _headerPotionSpacer.CustomMinimumSize = reservePotionSidebar
-                ? new Vector2(
-                    SolverPotionStrategyPanel.PreferredWidth
-                    + SolverUiTokens.Spacing.Md
-                    - SolverUiTokens.Spacing.Sm,
-                    0)
-                : Vector2.Zero;
-        }
         if (_settingsButton != null)
         {
             _settingsButton.Text = _settingsVisible ? "返回" : "设置";
@@ -1567,20 +1754,23 @@ internal static class SolverOverlay
         float primaryWidth = Math.Min(
             SolverUiTokens.Size.ExpandedMaxWidth,
             Math.Max(SolverUiTokens.Size.ExpandedMinWidth, viewportSize.X * 0.58f));
-        float potionSidebarWidth = _potionStrategyVisible
-            ? SolverPotionStrategyPanel.PreferredWidth + SolverUiTokens.Spacing.Md
-            : 0f;
+        float minimumWidth = Math.Min(SolverUiTokens.Size.ExpandedMinWidth, availableWidth);
         float width = _collapsed
             ? Math.Min(SolverUiTokens.Size.CollapsedWidth, availableWidth)
-            : primaryWidth + potionSidebarWidth;
-        width = Math.Min(width, availableWidth);
+            : Math.Clamp(_panelSize?.X ?? primaryWidth, minimumWidth, availableWidth);
         float desiredHeight = _collapsed
             ? SolverUiTokens.Size.CollapsedHeight
-            : _panel.GetCombinedMinimumSize().Y;
-        float maximumHeight = _settingsVisible || _potionStrategyVisible
+            : _panelSize?.Y ?? _panel.GetCombinedMinimumSize().Y;
+        float defaultMaximumHeight = _settingsVisible
             ? 540f
             : SolverUiTokens.Size.ExpandedMaxHeight;
-        float height = Math.Min(desiredHeight, Math.Min(maximumHeight, availableHeight));
+        float maximumHeight = Math.Min(
+            _panelSize.HasValue ? availableHeight : defaultMaximumHeight,
+            availableHeight);
+        float minimumHeight = Math.Min(_panel.GetCombinedMinimumSize().Y, maximumHeight);
+        float height = _collapsed
+            ? Math.Min(desiredHeight, availableHeight)
+            : Math.Clamp(desiredHeight, minimumHeight, maximumHeight);
 
         ApplyPanelBounds(viewportSize, width, height);
     }
@@ -1599,6 +1789,38 @@ internal static class SolverOverlay
         _panel.OffsetTop = _panelPosition.Y;
         _panel.OffsetRight = _panelPosition.X + width;
         _panel.OffsetBottom = _panelPosition.Y + height;
+        if (_resizeHandle != null && GodotObject.IsInstanceValid(_resizeHandle))
+        {
+            _resizeHandle.Position = _panelPosition + new Vector2(
+                width - ResizeHandleSize,
+                height - ResizeHandleSize);
+            _resizeHandle.Size = new Vector2(ResizeHandleSize, ResizeHandleSize);
+        }
+        ApplyPotionStrategyBounds(viewportSize, width, height);
+    }
+
+    private static void ApplyPotionStrategyBounds(Vector2 viewportSize, float panelWidth, float panelHeight)
+    {
+        if (_potionStrategyPanel == null || !GodotObject.IsInstanceValid(_potionStrategyPanel))
+            return;
+        const float edge = 8f;
+        float width = Math.Min(
+            SolverPotionStrategyPanel.PreferredWidth,
+            Math.Max(0f, viewportSize.X - edge * 2f));
+        float height = Math.Min(panelHeight, Math.Max(0f, viewportSize.Y - edge * 2f));
+        float maximumX = Math.Max(edge, viewportSize.X - width - edge);
+        float rightOfPanelX = _panelPosition.X + panelWidth + SolverUiTokens.Spacing.Md;
+        float x = rightOfPanelX <= maximumX
+            ? rightOfPanelX
+            : Math.Clamp(_panelPosition.X + panelWidth - width, edge, maximumX);
+        float y = Math.Clamp(
+            _panelPosition.Y,
+            edge,
+            Math.Max(edge, viewportSize.Y - height - edge));
+        _potionStrategyPanel.OffsetLeft = x;
+        _potionStrategyPanel.OffsetTop = y;
+        _potionStrategyPanel.OffsetRight = x + width;
+        _potionStrategyPanel.OffsetBottom = y + height;
     }
 
     private static void OnHeaderGuiInput(InputEvent inputEvent)
@@ -1628,9 +1850,66 @@ internal static class SolverOverlay
         ApplyPanelBounds(_viewport.GetVisibleRect().Size, _panel.Size.X, _panel.Size.Y);
     }
 
+    private static void OnResizeHandleGuiInput(InputEvent inputEvent)
+    {
+        if (_panel == null || _viewport == null || _collapsed)
+            return;
+        if (inputEvent is InputEventMouseButton { ButtonIndex: MouseButton.Left } button)
+        {
+            if (button.Pressed)
+            {
+                _resizing = true;
+                _resizeStartMousePosition = _viewport.GetMousePosition();
+                _resizeStartSize = _panel.Size;
+                _lastResizeLayoutAt = System.Environment.TickCount64 - ResizeLayoutIntervalMilliseconds;
+            }
+            else if (_resizing)
+            {
+                ResizeToMousePosition();
+                _resizing = false;
+                Vector2 size = _panel.Size;
+                _panelSize = size;
+                SolverSettings.SetOverlaySize(size);
+                Entry.Logger.Info(
+                    $"[CombatSolver/Test] UI_SIZE_SAVED width={size.X:F1} height={size.Y:F1}");
+            }
+            return;
+        }
+        if (!_resizing || inputEvent is not InputEventMouseMotion)
+            return;
+        long now = System.Environment.TickCount64;
+        if (now - _lastResizeLayoutAt < ResizeLayoutIntervalMilliseconds)
+            return;
+        _lastResizeLayoutAt = now;
+        ResizeToMousePosition();
+    }
+
+    private static void ResizeToMousePosition()
+    {
+        if (_panel == null || _viewport == null)
+            return;
+        const float edge = 8f;
+        Vector2 viewportSize = _viewport.GetVisibleRect().Size;
+        Vector2 requestedSize = _resizeStartSize
+            + _viewport.GetMousePosition() - _resizeStartMousePosition;
+        float availableWidth = Math.Max(360f, viewportSize.X - SolverUiTokens.Size.PanelMargin * 2f);
+        float maximumWidth = Math.Min(availableWidth, viewportSize.X - _panelPosition.X - edge);
+        float minimumWidth = Math.Min(SolverUiTokens.Size.ExpandedMinWidth, maximumWidth);
+        float availableHeight = Math.Max(
+            SolverUiTokens.Size.CollapsedHeight,
+            viewportSize.Y - SolverUiTokens.Size.PanelMargin * 2f);
+        float maximumHeight = Math.Min(availableHeight, viewportSize.Y - _panelPosition.Y - edge);
+        float minimumHeight = Math.Min(_panel.GetCombinedMinimumSize().Y, maximumHeight);
+        _panelSize = new Vector2(
+            Math.Clamp(requestedSize.X, minimumWidth, maximumWidth),
+            Math.Clamp(requestedSize.Y, minimumHeight, maximumHeight));
+        ApplyResponsiveLayout();
+    }
+
     private static void ResetOverlayPosition()
     {
         _panelPosition = new Vector2(SolverUiTokens.Size.PanelMargin, SolverUiTokens.Size.PanelMargin);
+        _panelSize = SolverSettings.OverlaySize;
         ApplyResponsiveLayout();
     }
 
@@ -1648,18 +1927,27 @@ internal static class SolverOverlay
         SolverController.RequestSearch(host, state, SearchReason.Manual);
     }
 
+    private static void OnStopSearchPressed()
+    {
+        Entry.Logger.Info("[CombatSolver/Test] UI_ACTION action=stop_search");
+        if (NGame.Instance is { } host)
+            SolverController.StopSearchByUser(host);
+        RefreshControls();
+    }
+
+    private static void OnAdoptRoutePressed()
+    {
+        SolverController.AdoptCurrentRoute();
+        RefreshControls();
+    }
+
     private static void OnExecutePressed()
     {
         NGame? host = NGame.Instance;
         if (host != null && SolverController.IsSearching)
         {
-            if (SolverController.CanAdoptCurrentSearchResult)
-            {
-                SolverController.AdoptCurrentSearchResult();
-                return;
-            }
-            Entry.Logger.Info("[CombatSolver/Test] UI_ACTION action=stop_search");
-            SolverController.StopSearchByUser(host);
+            if (SolverController.CanApplyCurrentTurn)
+                SolverController.ApplyCurrentTurn();
             return;
         }
 

--- a/src/UI/SolverOverlaySnapshot.cs
+++ b/src/UI/SolverOverlaySnapshot.cs
@@ -34,6 +34,7 @@ internal sealed record SolverOverlayTurnSnapshot(
     IReadOnlyList<string> TurnStartChoices,
     IReadOnlyList<SolverOverlayActionSnapshot> Actions,
     SolverOverlayActionSnapshot? EndTurnAction,
+    int? EnemyHpDamageLost,
     int HpLoss,
     int EnergyLeft,
     bool CombatEnded);
@@ -72,6 +73,54 @@ internal sealed record SolverOverlaySnapshot(
         bool unexpectedReplan,
         long reviewedWorldlinesTotal = 0)
         => Capture(result, turn, unexpectedReplan, pendingTurnSetup: true, reviewedWorldlinesTotal);
+
+
+    public static SolverOverlaySnapshot CaptureRoutePreview(
+        SolverRoutePreview preview)
+    {
+        if (preview.Turns.Count == 0)
+            throw new InvalidOperationException("动态候选路线没有可展示回合。");
+        SolverOverlayTurnSnapshot[] turns = preview.Turns
+            .Select(BuildOverlayTurn)
+            .ToArray();
+        int furthestTurn = turns[^1].Turn;
+        string hpOutcomeText = preview.ProjectedBattleHpLost > 0
+            ? $"当前候选累计预计掉血 {preview.ProjectedBattleHpLost} HP（尚未验证）"
+            : "当前候选累计预计掉血 0 HP（尚未验证）";
+        return new SolverOverlaySnapshot(
+            preview.StartTurnNumber,
+            $"求解器当前考虑 · 已演化至第 {furthestTurn} 回合",
+            SolverOverlayTone.Accent,
+            $"[color={SolverUiTokens.Palette.WarningHex}]求解器当前考虑，尚未验证  │  " +
+            $"路线可能继续变化或回跳[/color]",
+            string.Empty,
+            preview.ProjectedBattlePotionCount,
+            preview.ProjectedBattleHpLost,
+            hpOutcomeText,
+            preview.OnlyDeathRoutesFound,
+            turns,
+            DetailsText: string.Empty,
+            HasRisk: preview.HasRisk);
+    }
+
+    private static SolverOverlayTurnSnapshot BuildOverlayTurn(SolverFrontierTurn frontier)
+    {
+        SolverOverlayActionSnapshot[] frontierActions = frontier.Actions
+            .Where(action => action.IsExecutable)
+            .Select(action => CaptureAction(action, []))
+            .ToArray();
+        PlanAction? frontierEndTurn = frontier.Actions
+            .LastOrDefault(action => action.Kind == PlanActionKind.EndTurn);
+        return new SolverOverlayTurnSnapshot(
+            frontier.Turn,
+            TurnStartChoices: [],
+            frontierActions,
+            frontierEndTurn == null ? null : CaptureAction(frontierEndTurn, []),
+            EnemyHpDamageLost: frontier.EnemyHpLost,
+            frontier.HpLost,
+            frontier.EnergyLeft,
+            frontier.CombatEnded);
+    }
 
     private static SolverOverlaySnapshot Capture(
         SolverResult result,
@@ -161,11 +210,15 @@ internal sealed record SolverOverlaySnapshot(
             .ToArray();
         PlanAction? endTurn = result.BestNode.Actions
             .LastOrDefault(action => action.Turn == turn && action.Kind == PlanActionKind.EndTurn);
+        int? enemyHpLost = result.EnemyHpLostByTurn.TryGetValue(turn, out int materializedEnemyHpLost)
+            ? materializedEnemyHpLost
+            : null;
         return new SolverOverlayTurnSnapshot(
             turn,
             turnStartChoices,
             actions,
             endTurn == null ? null : CaptureAction(endTurn, []),
+            enemyHpLost,
             result.HpLostByTurn.GetValueOrDefault(turn),
             result.EnergyLeftByTurn.GetValueOrDefault(turn),
             result.CombatEndedTurn == turn);

--- a/src/UI/SolverPotionStrategyPanel.cs
+++ b/src/UI/SolverPotionStrategyPanel.cs
@@ -146,7 +146,7 @@ internal sealed partial class SolverPotionStrategyPanel : PanelContainer
         PanelContainer card = new()
         {
             Name = $"PotionStrategyCard{slot}",
-            CustomMinimumSize = new Vector2(CardMinimumWidth, 170),
+            CustomMinimumSize = new Vector2(CardMinimumWidth, 64),
             MouseFilter = MouseFilterEnum.Pass,
             SizeFlagsHorizontal = SizeFlags.ExpandFill,
         };
@@ -155,20 +155,22 @@ internal sealed partial class SolverPotionStrategyPanel : PanelContainer
             SolverUiTokens.Palette.BorderSubtle,
             SolverUiTokens.Radius.Medium,
             SolverUiTokens.Spacing.Sm,
-            SolverUiTokens.Spacing.Sm));
-        VBoxContainer layout = new()
+            SolverUiTokens.Spacing.Xs));
+        HBoxContainer layout = new()
         {
             MouseFilter = MouseFilterEnum.Pass,
             SizeFlagsHorizontal = SizeFlags.ExpandFill,
+            Alignment = BoxContainer.AlignmentMode.Begin,
         };
-        layout.AddThemeConstantOverride("separation", SolverUiTokens.Spacing.Xs);
+        layout.AddThemeConstantOverride("separation", SolverUiTokens.Spacing.Sm);
 
         TextureRect icon = new()
         {
             Name = "PotionIcon",
             Texture = potion.Image,
-            CustomMinimumSize = new Vector2(56, 56),
-            SizeFlagsHorizontal = SizeFlags.ShrinkCenter,
+            CustomMinimumSize = new Vector2(44, 44),
+            SizeFlagsHorizontal = SizeFlags.ShrinkBegin,
+            SizeFlagsVertical = SizeFlags.ShrinkCenter,
             ExpandMode = TextureRect.ExpandModeEnum.IgnoreSize,
             StretchMode = TextureRect.StretchModeEnum.KeepAspectCentered,
             MouseFilter = MouseFilterEnum.Ignore,
@@ -176,40 +178,35 @@ internal sealed partial class SolverPotionStrategyPanel : PanelContainer
         layout.AddChild(icon);
 
         Label title = SolverUiTokens.CreateLabel(
-            $"#{slot + 1}  {potion.Title.GetFormattedText()}",
+            $"#{slot + 1} {potion.Title.GetFormattedText()}",
             SolverUiTokens.Type.Caption,
             SolverUiTokens.Palette.TextPrimary,
             FontType.Bold);
         title.Name = "PotionTitle";
         title.SizeFlagsHorizontal = SizeFlags.ExpandFill;
-        title.HorizontalAlignment = HorizontalAlignment.Center;
+        title.HorizontalAlignment = HorizontalAlignment.Left;
         title.AutowrapMode = TextServer.AutowrapMode.WordSmart;
-        title.CustomMinimumSize = new Vector2(0, 38);
+        title.CustomMinimumSize = new Vector2(0, 44);
+        title.TooltipText = potion.Title.GetFormattedText();
         layout.AddChild(title);
 
-        OptionButton input = CreateDirectiveInput();
-        input.Name = "PotionDirective";
+        Button input = CreateDirectiveToggle(directive);
+        input.Name = "PotionDirectiveToggle";
+        input.Disabled = controlsDisabled || !searchable;
         if (!searchable)
         {
-            input.AddItem("不可指定");
-            input.Disabled = true;
+            input.TooltipText = "该药水不可指定使用策略";
         }
         else
         {
-            input.AddItem("智能使用", (int)SolverPotionDirective.Smart);
-            input.AddItem("强制使用", (int)SolverPotionDirective.Force);
-            input.AddItem("禁用 / 保护", (int)SolverPotionDirective.Disabled);
-            input.Selected = input.GetItemIndex((int)directive);
-            input.Disabled = controlsDisabled;
             string potionId = potion.Id.Entry;
-            input.ItemSelected += index =>
+            input.Pressed += () =>
             {
-                SolverPotionDirective selected =
-                    (SolverPotionDirective)input.GetItemId((int)index);
-                DirectiveChanged?.Invoke(slot, potionId, selected);
+                directive = NextDirective(directive);
+                ApplyDirectiveToggle(input, directive);
+                DirectiveChanged?.Invoke(slot, potionId, directive);
             };
         }
-        input.SizeFlagsHorizontal = SizeFlags.ExpandFill;
         layout.AddChild(input);
         card.AddChild(layout);
         return card;
@@ -218,40 +215,71 @@ internal sealed partial class SolverPotionStrategyPanel : PanelContainer
     private void UpdateGridColumns()
         => _cards.Columns = 1;
 
-    private static OptionButton CreateDirectiveInput()
+    private static Button CreateDirectiveToggle(SolverPotionDirective directive)
     {
-        OptionButton input = new()
+        Button input = new()
         {
             FocusMode = FocusModeEnum.None,
-            CustomMinimumSize = new Vector2(148, 32),
+            CustomMinimumSize = new Vector2(40, 40),
             SizeFlagsHorizontal = SizeFlags.ShrinkEnd,
+            SizeFlagsVertical = SizeFlags.ShrinkCenter,
             MouseDefaultCursorShape = CursorShape.PointingHand,
         };
-        input.AddThemeFontSizeOverride("font_size", SolverUiTokens.Type.Body);
-        input.AddThemeColorOverride("font_color", SolverUiTokens.Palette.TextPrimary);
+        input.AddThemeFontSizeOverride("font_size", 18);
+        input.ApplyLocaleFontSubstitution(FontType.Bold, "font");
+        SolverUiTokens.ApplyTextOutline(input);
+        ApplyDirectiveToggle(input, directive);
+        return input;
+    }
+
+    private static SolverPotionDirective NextDirective(SolverPotionDirective directive)
+        => directive switch
+        {
+            SolverPotionDirective.Smart => SolverPotionDirective.Disabled,
+            SolverPotionDirective.Disabled => SolverPotionDirective.Force,
+            _ => SolverPotionDirective.Smart,
+        };
+
+    private static void ApplyDirectiveToggle(Button input, SolverPotionDirective directive)
+    {
+        (string text, string description, Color color) = directive switch
+        {
+            SolverPotionDirective.Disabled => ("x", "禁用 / 保护", SolverUiTokens.Palette.Danger),
+            SolverPotionDirective.Force => ("✓", "强制使用", SolverUiTokens.Palette.Success),
+            _ => ("-", "智能使用", SolverUiTokens.Palette.TextSecondary),
+        };
+        Color background = SolverUiTokens.IsLightTheme
+            ? SolverUiTokens.Palette.Surface
+            : SolverUiTokens.Palette.Background;
+        input.Text = text;
+        input.TooltipText = $"{description}（点击切换）";
+        input.AddThemeColorOverride("font_color", color);
+        input.AddThemeColorOverride("font_hover_color", color);
+        input.AddThemeColorOverride("font_pressed_color", color);
         input.AddThemeColorOverride("font_disabled_color", SolverUiTokens.Palette.TextMuted);
         input.AddThemeStyleboxOverride("normal", SolverUiTokens.CreateBox(
-            SolverUiTokens.IsLightTheme
-                ? SolverUiTokens.Palette.Surface
-                : SolverUiTokens.Palette.Background,
-            SolverUiTokens.Palette.BorderSubtle,
+            background,
+            color,
             SolverUiTokens.Radius.Small,
-            SolverUiTokens.Spacing.Sm,
+            SolverUiTokens.Spacing.Xs,
             SolverUiTokens.Spacing.Xs));
         input.AddThemeStyleboxOverride("hover", SolverUiTokens.CreateBox(
-            SolverUiTokens.Palette.SurfaceRaised,
-            SolverUiTokens.Palette.Accent,
+            SolverUiTokens.Palette.SurfaceHover,
+            color.Lightened(0.12f),
             SolverUiTokens.Radius.Small,
-            SolverUiTokens.Spacing.Sm,
+            SolverUiTokens.Spacing.Xs,
             SolverUiTokens.Spacing.Xs));
-        if (SolverUiTokens.IsLightTheme)
-        {
-            input.AddThemeIconOverride(
-                "arrow",
-                SolverUiTokens.CreateChevronTexture(SolverUiTokens.Palette.TextSecondary));
-        }
-        SolverUiTokens.ApplyTextOutline(input);
-        input.ApplyLocaleFontSubstitution(FontType.Bold, "font");
-        return input;
+        input.AddThemeStyleboxOverride("pressed", SolverUiTokens.CreateBox(
+            background.Darkened(0.12f),
+            color,
+            SolverUiTokens.Radius.Small,
+            SolverUiTokens.Spacing.Xs,
+            SolverUiTokens.Spacing.Xs));
+        input.AddThemeStyleboxOverride("disabled", SolverUiTokens.CreateBox(
+            SolverUiTokens.Palette.Background,
+            SolverUiTokens.Palette.BorderSubtle,
+            SolverUiTokens.Radius.Small,
+            SolverUiTokens.Spacing.Xs,
+            SolverUiTokens.Spacing.Xs));
     }
 }

--- a/src/UI/SolverRouteRow.cs
+++ b/src/UI/SolverRouteRow.cs
@@ -10,6 +10,7 @@ internal sealed partial class SolverRouteRow : PanelContainer
 
     public Label TurnLabel { get; }
     public HFlowContainer ActionFlow { get; }
+    public Label EnemyDamageLabel { get; }
     public Label OutcomeLabel { get; }
     public Label EnergyLabel { get; }
     public int DeploymentActionCount => _deploymentActions.Count;
@@ -78,6 +79,16 @@ internal sealed partial class SolverRouteRow : PanelContainer
             MouseFilter = MouseFilterEnum.Ignore,
         };
         outcomeLayout.AddThemeConstantOverride("separation", SolverUiTokens.Spacing.Sm);
+        EnemyDamageLabel = SolverUiTokens.CreateLabel(
+            string.Empty,
+            SolverUiTokens.Type.Body,
+            SolverUiTokens.Palette.Warning,
+            FontType.Bold);
+        EnemyDamageLabel.HorizontalAlignment = HorizontalAlignment.Right;
+        EnemyDamageLabel.AutowrapMode = TextServer.AutowrapMode.Off;
+        EnemyDamageLabel.CustomMinimumSize = new Vector2(92, SolverUiTokens.Size.ActionPillHeight);
+        EnemyDamageLabel.SizeFlagsVertical = SizeFlags.ShrinkCenter;
+        outcomeLayout.AddChild(EnemyDamageLabel);
         OutcomeLabel = SolverUiTokens.CreateLabel(
             string.Empty,
             SolverUiTokens.Type.Metric,
@@ -175,8 +186,13 @@ internal sealed partial class SolverRouteRow : PanelContainer
         ActionFlow.AddChild(SolverActionPill.CreateStatus(text, SolverUiTokens.Palette.TextMuted));
     }
 
-    public void SetOutcome(string text, Color color, string energyText = "")
+    public void SetOutcome(
+        string text,
+        Color color,
+        string energyText = "",
+        string enemyDamageText = "")
     {
+        EnemyDamageLabel.Text = enemyDamageText;
         OutcomeLabel.Text = text;
         OutcomeLabel.AddThemeColorOverride("font_color", color);
         EnergyLabel.Text = energyText;

--- a/src/UI/SolverSettingsPanel.General.cs
+++ b/src/UI/SolverSettingsPanel.General.cs
@@ -6,6 +6,7 @@ namespace CombatSolver;
 internal sealed partial class SolverSettingsPanel
 {
     private CheckButton _solverEnabled = null!;
+    private CheckButton _automaticCalculation = null!;
     private CheckButton _stopOnCombatEnd = null!;
     private CheckButton _stopOnDeathTurn = null!;
     private CheckButton _stopOnWorseRecalculation = null!;
@@ -97,6 +98,13 @@ internal sealed partial class SolverSettingsPanel
         _solverEnabled = CreateToggle();
         _solverEnabled.Toggled += OnSolverEnabledToggled;
         AddBasicRow(solverGrid, "启用求解器", _solverEnabled);
+        _automaticCalculation = CreateToggle();
+        _automaticCalculation.Toggled += OnAutomaticCalculationToggled;
+        AddBasicRow(
+            solverGrid,
+            "自动计算",
+            _automaticCalculation,
+            "开启后会在进入战斗局面和每个玩家回合自动开始后台计算；关闭后由主面板手动开始计算。");
         _searchCompletionNotificationPolicy = CreateSearchCompletionNotificationPolicyInput();
         AddBasicRow(
             solverGrid,
@@ -145,6 +153,7 @@ internal sealed partial class SolverSettingsPanel
     private void ReloadGeneralPage(SolverSettingsData data)
     {
         _solverEnabled.ButtonPressed = !data.SolverDisabled;
+        _automaticCalculation.ButtonPressed = data.AutomaticCalculationEnabled;
         _stopOnCombatEnd.ButtonPressed = data.StopFullAutoOnCombatEnd;
         _stopOnDeathTurn.ButtonPressed = data.StopFullAutoOnDeathTurn;
         _stopOnWorseRecalculation.ButtonPressed = data.StopFullAutoOnWorseRecalculation;
@@ -264,6 +273,16 @@ internal sealed partial class SolverSettingsPanel
             return;
         SolverController.SetSolverDisabled(!enabled);
         SetStatus(enabled ? "求解器已启用" : "求解器已暂停", SolverUiTokens.Palette.Success);
+    }
+
+    private void OnAutomaticCalculationToggled(bool enabled)
+    {
+        if (_loading)
+            return;
+        SolverController.SetAutomaticCalculationEnabled(enabled);
+        SetStatus(
+            enabled ? "自动计算已开启" : "自动计算已关闭",
+            SolverUiTokens.Palette.Success);
     }
 
     private void OnStopOnCombatEndToggled(bool enabled)

--- a/src/UI/SolverUiTokens.cs
+++ b/src/UI/SolverUiTokens.cs
@@ -86,7 +86,7 @@ internal static class SolverUiTokens
         public const float RouteRowHeight = 44f;
         public const float ActionPillHeight = 28f;
         public const float TurnColumnWidth = 88f;
-        public const float OutcomeColumnWidth = 146f;
+        public const float OutcomeColumnWidth = 238f;
         public const float ButtonHeight = 34f;
     }
 


### PR DESCRIPTION
- 每一回合，路线列表都会显示对敌人造成了多少伤害。
- 计算时，它会一边算一边显示当前正在考虑的几种走法；还没算定的，就标注"可能还会变"。
- 主界面右下多了一个拖拽把手，可以拉伸窗口大小；窗口大小和位置会记住，下次打开还是原来的。药水那块改成能拖动的悬浮面板，屏幕放不下会自动贴边，不会跑出屏幕。
- 每瓶药水改成三档：智能、禁用保护、强制使用，点一下换一档。
- "采纳这套走法"和"执行本回合"拆成两个按钮。操作区会根据当前进度显示"正在算 / 已采纳 / 正在执行 / 等下一步"；窗口收起再打开，显示的还是当前状态。
- 新增一个一直显示的"停止计算"按钮：按下就停掉本次计算，已算好的走法原样保留，用不用由你决定；停止后再改药水、偷窃等设置，不会立即重新计算。
- 设置里加了一个"自动计算"开关，默认开启、会保存。关掉后，进战斗和新回合都不再自动计算，主按钮变成"开始计算"或"重新计算"，需要你自己点。