### PR TITLE
恢复搜索路线的动态演化预览与优先更早结束路线（PR#31 后续）

### DIFF
--- a/src/Runtime/PlayerTurnSetupPatches.cs
+++ b/src/Runtime/PlayerTurnSetupPatches.cs
@@ -203,10 +203,12 @@ internal static class PlayerTurnSetupCoordinator
         {
             return;
         }
-        SolverOverlaySnapshot? preview = progress.RoutePreview == null
-            ? null
-            : SolverOverlaySnapshot.CaptureRoutePreview(progress.RoutePreview);
-        active.Interaction.RenderedRouteAdoptionSeed = preview == null
+        SolverOverlaySnapshot? preview = progress.SpeculativeRoutePreview is { } speculative
+            ? SolverOverlaySnapshot.CaptureSpeculativeRoute(speculative)
+            : progress.CurrentTurnPreview is { } currentTurn
+                ? SolverOverlaySnapshot.CaptureCurrentTurn(currentTurn)
+                : null;
+        active.Interaction.RenderedRouteAdoptionSeed = progress.SpeculativeRoutePreview == null
             ? null
             : progress.RouteAdoptionSeed;
         SolverOverlay.ShowProgress(
@@ -316,7 +318,7 @@ internal static class PlayerTurnSetupCoordinator
            && active.Interaction.CurrentTakeoverRequest == null
            && active.Interaction.CanAcceptTakeover
            && (active.SearchState == 1 || active.ManualSearchState == 1)
-           && Volatile.Read(ref active.Interaction.Progress)?.RoutePreview != null;
+           && Volatile.Read(ref active.Interaction.Progress)?.CurrentTurnPreview != null;
 
     public static bool IsApplyingCurrentTurn
         => _active?.Interaction.IsApplyingCurrentTurn == true;

--- a/src/Runtime/SolverController.cs
+++ b/src/Runtime/SolverController.cs
@@ -79,7 +79,7 @@ internal static class SolverController
         => _search is { } search
                && search.Interaction.CurrentTakeoverRequest == null
                && search.Interaction.CanAcceptTakeover
-               && Volatile.Read(ref search.Interaction.Progress)?.RoutePreview != null
+               && Volatile.Read(ref search.Interaction.Progress)?.CurrentTurnPreview != null
            || PlayerTurnSetupCoordinator.CanApplyCurrentTurn;
     public static bool IsApplyingCurrentTurn
         => _search?.Interaction.IsApplyingCurrentTurn == true
@@ -512,10 +512,12 @@ internal static class SolverController
             },
             result,
             DescribeReplanAudit());
-        SolverOverlaySnapshot snapshot = SolverOverlaySnapshot.CaptureWithReviewedWorldlines(
-            result,
-            UnexpectedReplanCount > 0,
-            _combat.ReviewedWorldlinesTotal);
+        SolverOverlaySnapshot snapshot = result.ResultScope == SolverResultScope.CurrentTurnAdoption
+            ? SolverOverlaySnapshot.CaptureCurrentTurn(SolverCurrentTurnPreview.FromResult(result))
+            : SolverOverlaySnapshot.CaptureWithReviewedWorldlines(
+                result,
+                UnexpectedReplanCount > 0,
+                _combat.ReviewedWorldlinesTotal);
         if (result.ResultScope == SolverResultScope.RouteAdoption)
             snapshot = MarkRouteAdopted(snapshot);
         SolverOverlay.ShowResult(host, snapshot);
@@ -539,10 +541,12 @@ internal static class SolverController
     {
         AssertMainThread();
         RecordReviewedWorldlines(result);
-        SolverOverlaySnapshot snapshot = SolverOverlaySnapshot.CaptureWithReviewedWorldlines(
-            result,
-            UnexpectedReplanCount > 0,
-            _combat.ReviewedWorldlinesTotal);
+        SolverOverlaySnapshot snapshot = result.ResultScope == SolverResultScope.CurrentTurnAdoption
+            ? SolverOverlaySnapshot.CaptureCurrentTurn(SolverCurrentTurnPreview.FromResult(result))
+            : SolverOverlaySnapshot.CaptureWithReviewedWorldlines(
+                result,
+                UnexpectedReplanCount > 0,
+                _combat.ReviewedWorldlinesTotal);
         if (result.ResultScope == SolverResultScope.RouteAdoption)
             snapshot = MarkRouteAdopted(snapshot);
         SolverOverlay.ShowResult(host, snapshot);
@@ -1423,7 +1427,7 @@ internal static class SolverController
             return;
         }
         if (search.Interaction.CurrentTakeoverRequest != null
-            || Volatile.Read(ref search.Interaction.Progress)?.RoutePreview == null)
+            || Volatile.Read(ref search.Interaction.Progress)?.CurrentTurnPreview == null)
         {
             return;
         }
@@ -1878,10 +1882,12 @@ internal static class SolverController
         {
             return;
         }
-        SolverOverlaySnapshot? preview = progress.RoutePreview == null
-            ? null
-            : SolverOverlaySnapshot.CaptureRoutePreview(progress.RoutePreview);
-        search.Interaction.RenderedRouteAdoptionSeed = preview == null
+        SolverOverlaySnapshot? preview = progress.SpeculativeRoutePreview is { } speculative
+            ? SolverOverlaySnapshot.CaptureSpeculativeRoute(speculative)
+            : progress.CurrentTurnPreview is { } currentTurn
+                ? SolverOverlaySnapshot.CaptureCurrentTurn(currentTurn)
+                : null;
+        search.Interaction.RenderedRouteAdoptionSeed = progress.SpeculativeRoutePreview == null
             ? null
             : progress.RouteAdoptionSeed;
         SolverOverlay.ShowProgress(
@@ -2105,10 +2111,12 @@ internal static class SolverController
                     : "search_completed",
             result,
             DescribeReplanAudit());
-        SolverOverlaySnapshot completedSnapshot = SolverOverlaySnapshot.CaptureWithReviewedWorldlines(
-            result,
-            UnexpectedReplanCount > 0,
-            _combat.ReviewedWorldlinesTotal);
+        SolverOverlaySnapshot completedSnapshot = currentTurnAdopted
+            ? SolverOverlaySnapshot.CaptureCurrentTurn(SolverCurrentTurnPreview.FromResult(result))
+            : SolverOverlaySnapshot.CaptureWithReviewedWorldlines(
+                result,
+                UnexpectedReplanCount > 0,
+                _combat.ReviewedWorldlinesTotal);
         SolverOverlay.ShowResult(
             host,
             routeAdopted ? MarkRouteAdopted(completedSnapshot) : completedSnapshot);

--- a/src/Runtime/SolverProgress.cs
+++ b/src/Runtime/SolverProgress.cs
@@ -141,7 +141,8 @@ internal sealed record SolverInterimResult(
     int PotionStrategicCost,
     int ProjectedBattlePotionCount,
     int EnemyHp,
-    double Score);
+    double Score,
+    int? CombatEndedTurn = null);
 
 internal sealed record SolverFrontierTurn(
     int Turn,

--- a/src/Runtime/SolverProgress.cs
+++ b/src/Runtime/SolverProgress.cs
@@ -149,9 +149,49 @@ internal sealed record SolverFrontierTurn(
     int HpLost,
     int EnemyHpLost,
     int EnergyLeft,
-    bool CombatEnded);
+    bool CombatEnded)
+{
+    public static IReadOnlyList<SolverFrontierTurn> FromResult(SolverResult result)
+        => result.BestNode.Actions
+            .GroupBy(action => action.Turn)
+            .OrderBy(group => group.Key)
+            .Select(group => new SolverFrontierTurn(
+                group.Key,
+                group.ToArray(),
+                result.HpLostByTurn.GetValueOrDefault(group.Key),
+                result.EnemyHpLostByTurn.GetValueOrDefault(group.Key),
+                result.EnergyLeftByTurn.GetValueOrDefault(group.Key),
+                result.CombatEndedTurn == group.Key))
+            .ToArray();
+}
 
-internal sealed record SolverRoutePreview(
+internal sealed record SolverCurrentTurnPreview(
+    int CandidateVersion,
+    int Turn,
+    IReadOnlyList<PlanAction> Actions,
+    int HpLost,
+    int EnemyHpLost,
+    int EnergyLeft,
+    bool CombatEnded,
+    IReadOnlyList<SolverFrontierTurn>? FrontierTurns = null)
+{
+    public static SolverCurrentTurnPreview FromResult(
+        SolverResult result,
+        int candidateVersion = 0)
+        => new(
+            candidateVersion,
+            result.StartTurnNumber,
+            result.BestNode.Actions
+                .Where(action => action.Turn == result.StartTurnNumber)
+                .ToArray(),
+            result.HpLostByTurn.GetValueOrDefault(result.StartTurnNumber),
+            result.EnemyHpLostByTurn.GetValueOrDefault(result.StartTurnNumber),
+            result.EnergyLeftByTurn.GetValueOrDefault(result.StartTurnNumber),
+            result.CombatEndedTurn == result.StartTurnNumber,
+            SolverFrontierTurn.FromResult(result));
+}
+
+internal sealed record SolverSpeculativeRoutePreview(
     int CandidateVersion,
     int StartTurnNumber,
     int ProjectedBattlePotionCount,
@@ -160,7 +200,9 @@ internal sealed record SolverRoutePreview(
     bool HasRisk,
     IReadOnlyList<SolverFrontierTurn> Turns)
 {
-    public static SolverRoutePreview FromResult(SolverResult result, int candidateVersion = 0)
+    public static SolverSpeculativeRoutePreview FromResult(
+        SolverResult result,
+        int candidateVersion = 0)
         => new(
             candidateVersion,
             result.StartTurnNumber,
@@ -168,17 +210,7 @@ internal sealed record SolverRoutePreview(
             result.ProjectedBattleHpLost,
             result.OnlyDeathRoutesFound,
             result.Snapshot.HasRisk,
-            result.BestNode.Actions
-                .GroupBy(action => action.Turn)
-                .OrderBy(group => group.Key)
-                .Select(group => new SolverFrontierTurn(
-                    group.Key,
-                    group.ToArray(),
-                    result.HpLostByTurn.GetValueOrDefault(group.Key),
-                    result.EnemyHpLostByTurn.GetValueOrDefault(group.Key),
-                    result.EnergyLeftByTurn.GetValueOrDefault(group.Key),
-                    result.CombatEndedTurn == group.Key))
-                .ToArray());
+            SolverFrontierTurn.FromResult(result));
 }
 
 internal sealed record SolverProgress(
@@ -194,5 +226,6 @@ internal sealed record SolverProgress(
     long ElapsedMilliseconds,
     string Phase,
     SolverInterimResult? CurrentBestResult = null,
-    SolverRoutePreview? RoutePreview = null,
+    SolverCurrentTurnPreview? CurrentTurnPreview = null,
+    SolverSpeculativeRoutePreview? SpeculativeRoutePreview = null,
     SolverRouteAdoptionSeed? RouteAdoptionSeed = null);

--- a/src/Search/CombatBeamSolver.FinalPlanOrdering.cs
+++ b/src/Search/CombatBeamSolver.FinalPlanOrdering.cs
@@ -50,6 +50,10 @@ internal sealed partial class CombatBeamSolver
                     int explicitPotionCount = PotionUsePolicy.ExplicitUseCount(
                         potionCount,
                         candidate.Snapshot.AutomaticPotionUseCount);
+                    int? combatEndedTurn = features.AllEnemiesDead
+                        && features.BoundaryReason != SearchBoundaryReason.UnsupportedEffect
+                            ? candidate.Node.Action?.Turn
+                            : null;
                     int ambergrisCount = candidate.Node.Actions.Count(action =>
                         action.Kind == PlanActionKind.UsePotion
                         && string.Equals(action.PotionId, "AMBERGRIS", StringComparison.Ordinal));
@@ -91,6 +95,7 @@ internal sealed partial class CombatBeamSolver
                             : 0);
                     return (candidate.Node, candidate.Snapshot, Features: features,
                         FutureSold: sold, BattleSold: battleSold, PotionCount: potionCount,
+                        CombatEndedTurn: combatEndedTurn,
                         ExplicitPotionCount: explicitPotionCount, HpDeficit: hpDeficit,
                         StrategicHpDeficit: strategicHpDeficit, PolicyHpDeficit: policyHpDeficit,
                         MaxHpDeficit: maxHpDeficit, HealthResourceCost: healthResourceCost,
@@ -136,6 +141,7 @@ internal sealed partial class CombatBeamSolver
                 .ThenBy(item => item.Candidate.Features.AngerCopiesGenerated)
                 .ThenBy(item => CombatBeamSolver.PolicyBoundaryRank(item.Candidate.Features.BoundaryReason))
                 .ThenBy(item => item.Candidate.Features.EnemyHp)
+                .ThenBy(item => item.Candidate.CombatEndedTurn ?? int.MaxValue)
                 .ThenByDescending(item => item.Candidate.Score)
                 .ThenBy(item => item.Candidate.StrategicSold)
                 .ThenBy(item => item.Candidate.Features.ActionCount)
@@ -229,6 +235,7 @@ internal sealed partial class CombatBeamSolver
                 .ThenBy(candidate => candidate.OptionalPotionCount)
                 .ThenBy(candidate => candidate.StrategicSold)
                 .ThenBy(candidate => candidate.Features.EnemyHp)
+                .ThenBy(candidate => candidate.CombatEndedTurn ?? int.MaxValue)
                 .ThenByDescending(candidate => candidate.Score)
                 .ThenBy(candidate => candidate.Features.ActionCount)
                 .ToList();

--- a/src/Search/CombatBeamSolver.Phases.cs
+++ b/src/Search/CombatBeamSolver.Phases.cs
@@ -125,7 +125,8 @@ internal sealed partial class CombatBeamSolver
                     root.InitialPlayerMaxHp),
                 ProjectedBattlePotionCount: battleDamage.PotionsUsedSoFar + node.PotionCount,
                 EnemyHp: node.Snapshot.EnemyHp,
-                Score: node.Score);
+                Score: node.Score,
+                CombatEndedTurn: won ? node.Action?.Turn : null);
         }
 
 

--- a/src/Search/CombatBeamSolver.Phases.cs
+++ b/src/Search/CombatBeamSolver.Phases.cs
@@ -91,11 +91,15 @@ internal sealed partial class CombatBeamSolver
         SolverInterimResult? currentTurnCandidateResult = null;
         SearchNode? currentTurnCandidateNode = null;
         SearchNode? currentTurnPreviewNode = null;
-        SolverRoutePreview? routePreview = null;
+        SolverCurrentTurnPreview? currentTurnPreview = null;
+        IReadOnlyList<PlanAction>? publishedCurrentTurnActions = null;
+        int currentTurnPreviewVersion = 0;
+        SolverSpeculativeRoutePreview? speculativeRoutePreview = null;
         SolverRouteAdoptionSeed? routeAdoptionSeed = null;
         SolverRouteAdoptionSeed? requestedRouteAdoptionSeed = null;
         IReadOnlyList<SearchNode>? interruptedActive = null;
         int routePreviewVersion = 0;
+        long lastRoutePreviewAt = System.Environment.TickCount64 - 100;
         bool adoptionReached = false;
         bool currentTurnAdoptionReached = false;
         int initialHp = root.InitialPlayerHp;
@@ -124,7 +128,8 @@ internal sealed partial class CombatBeamSolver
                 Score: node.Score);
         }
 
-        // 候选节点保留完整动作父链；每个已完成回合的边界节点各自携带 Outcome。
+
+
         IReadOnlyList<SolverFrontierTurn>? BuildFrontierTurns(SearchNode candidate)
         {
             if (candidate.ActionCount == 0)
@@ -155,6 +160,27 @@ internal sealed partial class CombatBeamSolver
             return turns.Count == 0 ? null : turns;
         }
 
+        static bool FrontierTurnsEqual(
+            IReadOnlyList<SolverFrontierTurn>? current,
+            IReadOnlyList<SolverFrontierTurn>? next)
+        {
+            if (ReferenceEquals(current, next))
+                return true;
+            if (current == null || next == null || current.Count != next.Count)
+                return false;
+            for (int i = 0; i < current.Count; i++)
+            {
+                SolverFrontierTurn a = current[i];
+                SolverFrontierTurn b = next[i];
+                if (a.Turn != b.Turn || a.HpLost != b.HpLost || a.EnemyHpLost != b.EnemyHpLost
+                    || a.EnergyLeft != b.EnergyLeft || a.CombatEnded != b.CombatEnded
+                    || !a.Actions.SequenceEqual(b.Actions))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
 
         SearchNode? FindCurrentTurnBoundary(SearchNode node)
         {
@@ -233,6 +259,45 @@ internal sealed partial class CombatBeamSolver
             currentTurnCandidateNode = boundary;
             currentTurnPreviewNode = node;
         }
+        void RefreshCurrentTurnPreview()
+        {
+            SearchNode? candidate = currentBestNode
+                ?? currentTurnPreviewNode
+                ?? currentTurnCandidateNode;
+            SearchNode? boundary = candidate == null
+                ? null
+                : FindCurrentTurnBoundary(candidate);
+            if (candidate == null || boundary?.Outcome is not { } outcome)
+                return;
+            PlanAction[] actions = candidate.Actions
+                .Where(action => action.Turn == _startTurnNumber)
+                .ToArray();
+            bool combatEnded = boundary.Snapshot.AllEnemiesDead;
+            IReadOnlyList<SolverFrontierTurn>? frontierTurns = BuildFrontierTurns(candidate);
+            if (publishedCurrentTurnActions != null
+                && publishedCurrentTurnActions.SequenceEqual(actions)
+                && currentTurnPreview is { } published
+                && published.HpLost == outcome.HpLost
+                && published.EnemyHpLost == outcome.EnemyHpLost
+                && published.EnergyLeft == outcome.EnergyLeft
+                && published.CombatEnded == combatEnded
+                && FrontierTurnsEqual(published.FrontierTurns, frontierTurns))
+            {
+                return;
+            }
+
+            publishedCurrentTurnActions = actions;
+            currentTurnPreview = new SolverCurrentTurnPreview(
+                ++currentTurnPreviewVersion,
+                _startTurnNumber,
+                actions.Select(WithDisplayNames).ToArray(),
+                outcome.HpLost,
+                outcome.EnemyHpLost,
+                outcome.EnergyLeft,
+                combatEnded,
+                frontierTurns);
+        }
+
 
 
         SolverResult MaterializeSelectedRoute(
@@ -511,51 +576,134 @@ internal sealed partial class CombatBeamSolver
             return result;
         }
 
-        void PublishRoutePreview()
+        SolverSpeculativeRoutePreview BuildRoutePreview(
+            FinalPlanSelection selection,
+            bool onlyDeathRoutesFound,
+            int candidateVersion)
+        {
+            FinalPlanCandidate selected = selection.Candidate;
+            RouteAnnotations annotations = BuildRouteAnnotations(selected.Node);
+            List<SearchNode> path = [];
+            for (SearchNode? node = selected.Node; node?.Parent != null; node = node.Parent)
+                path.Add(node);
+            path.Reverse();
+
+            SolverFrontierTurn[] turns = path
+                .GroupBy(node => node.Action!.Turn)
+                .OrderBy(group => group.Key)
+                .Select(group =>
+                {
+                    SearchNode[] nodes = group.ToArray();
+                    SearchNode first = nodes[0];
+                    SearchNode last = nodes[^1];
+                    int hpLost = annotations.HpLostByTurn.TryGetValue(
+                        group.Key,
+                        out int annotatedHpLost)
+                            ? annotatedHpLost
+                            : Math.Max(
+                                0,
+                                last.Snapshot.CumulativePlayerHpLost
+                                - first.Parent!.Snapshot.CumulativePlayerHpLost);
+                    int enemyHpLost = annotations.EnemyHpLostByTurn.TryGetValue(
+                        group.Key,
+                        out int annotatedEnemyHpLost)
+                            ? annotatedEnemyHpLost
+                            : Math.Max(0, first.Parent!.Snapshot.EnemyHp - last.Snapshot.EnemyHp);
+                    int energyLeft = annotations.EnergyLeftByTurn.TryGetValue(
+                        group.Key,
+                        out int annotatedEnergyLeft)
+                            ? annotatedEnergyLeft
+                            : last.Snapshot.Energy;
+                    return new SolverFrontierTurn(
+                        group.Key,
+                        nodes.Select(node => WithDisplayNames(node.Action!)).ToArray(),
+                        hpLost,
+                        enemyHpLost,
+                        energyLeft,
+                        annotations.CombatEndedTurn == group.Key);
+                })
+                .ToArray();
+            return new SolverSpeculativeRoutePreview(
+                candidateVersion,
+                _startTurnNumber,
+                battleDamage.PotionsUsedSoFar + selected.Node.PotionCount,
+                battleDamage.HpLostSoFar + selected.Snapshot.CumulativePlayerHpLost,
+                onlyDeathRoutesFound,
+                selected.Snapshot.HasRisk,
+                turns);
+        }
+
+        void PublishRoutePreview(
+            IReadOnlyList<SearchNode> retained,
+            IReadOnlyList<SearchNode>? additional = null,
+            bool force = false)
         {
             if (progressCallback == null)
                 return;
-            SearchNode? candidate = currentBestNode
-                ?? currentTurnPreviewNode
-                ?? currentTurnCandidateNode;
-            if (candidate == null || BuildFrontierTurns(candidate) is not { Count: > 0 } turns)
+            long now = System.Environment.TickCount64;
+            if (!force && now - lastRoutePreviewAt < 100)
                 return;
-
+            IEnumerable<SearchNode> pool = additional == null
+                ? retained
+                : retained.Concat(additional);
+            List<SearchNode> viable = pool
+                .Where(node => node.ActionCount > 0 && node.Snapshot.HasSimulator)
+                .DistinctBy(node => node.Snapshot)
+                .ToList();
+            if (viable.Count == 0)
+                return;
+            (SearchNode Node, int RetentionRank)[] savedRanks = viable
+                .Select(node => (node, node.RetentionRank))
+                .ToArray();
+            List<SearchNode> candidates;
+            try
+            {
+                candidates = Retention.RankBest(
+                    viable,
+                    _profile.BeamWidth * 4);
+            }
+            finally
+            {
+                foreach ((SearchNode node, int retentionRank) in savedRanks)
+                    node.RetentionRank = retentionRank;
+            }
+            List<(SearchNode Node, SimulationSnapshot Snapshot)> evaluated = candidates
+                .Select(node => (Node: node, Snapshot: node.Snapshot))
+                .ToList();
+            FinalPlanSelection ordering;
+            try
+            {
+                ordering = FinalOrdering.Select(
+                    evaluated,
+                    root.InitialPlayerHp,
+                    emitDiagnostics: false);
+            }
+            catch (PotionPolicyUnsatisfiedException)
+            {
+                return;
+            }
+            bool onlyDeathRoutesFound = evaluated.All(candidate =>
+                candidate.Snapshot.PlayerDead || candidate.Snapshot.ProjectedPlayerHp <= 0);
             int candidateVersion = ++routePreviewVersion;
-            bool onlyDeathRoutesFound = candidate.Snapshot.PlayerDead
-                || candidate.Snapshot.ProjectedPlayerHp <= 0;
-            routePreview = new SolverRoutePreview(
-                candidateVersion,
-                _startTurnNumber,
-                battleDamage.PotionsUsedSoFar + candidate.PotionCount,
-                battleDamage.HpLostSoFar + candidate.Snapshot.CumulativePlayerHpLost,
+            speculativeRoutePreview = BuildRoutePreview(
+                ordering,
                 onlyDeathRoutesFound,
-                candidate.Snapshot.HasRisk,
-                turns);
+                candidateVersion);
             int candidateSearchedTurnLayers = searchedTurnLayers;
-            PlanAction[] adoptionActions = turns
+            PlanAction[] adoptionActions = speculativeRoutePreview.Turns
                 .SelectMany(turn => turn.Actions)
                 .ToArray();
             routeAdoptionSeed = new SolverRouteAdoptionSeed(
                 candidateVersion,
                 adoptionActions,
-                () =>
-                {
-                    SearchNode materialized = candidate.Snapshot.HasSimulator
-                        ? candidate
-                        : RefreshReleasedFallback(candidate);
-                    FinalPlanSelection selection = FinalOrdering.Select(
-                        [(materialized, materialized.Snapshot)],
-                        initialHp,
-                        emitDiagnostics: false);
-                    return MaterializeSelectedRoute(
-                        selection,
-                        onlyDeathRoutesFound,
-                        SolverResultScope.RouteAdoption,
-                        candidateSearchedTurnLayers,
-                        candidateTimeBudgetReached: false,
-                        routeAdoptionActions: adoptionActions);
-                });
+                () => MaterializeSelectedRoute(
+                    ordering,
+                    onlyDeathRoutesFound,
+                    SolverResultScope.RouteAdoption,
+                    candidateSearchedTurnLayers,
+                    candidateTimeBudgetReached: false,
+                    routeAdoptionActions: adoptionActions));
+            lastRoutePreviewAt = System.Environment.TickCount64;
         }
 
         void PublishProgress(
@@ -587,7 +735,8 @@ internal sealed partial class CombatBeamSolver
                 _progressPhaseOverride
                 ?? $"{(checkpointPhase || _profile.Phase == SolverSearchPhase.Short ? "快速搜索" : "深化搜索")}·{phase}",
                 currentBestResult,
-                routePreview,
+                currentTurnPreview,
+                speculativeRoutePreview,
                 routeAdoptionSeed));
         }
 
@@ -1121,6 +1270,7 @@ internal sealed partial class CombatBeamSolver
                 List<SearchNode> prunedPlays = Prune(nextPlays);
                 ReleaseDroppedSnapshots(nextPlays, prunedPlays);
                 active = prunedPlays;
+                PublishRoutePreview(completed, active);
                 if (_detailedDiagnostics && searchedTurnLayers == 0)
                 {
                     policy.Diagnostics.Info(
@@ -1165,7 +1315,8 @@ internal sealed partial class CombatBeamSolver
                 ConsiderCompleteVictory(candidate);
                 ConsiderCurrentTurnCandidate(candidate);
             }
-            PublishRoutePreview();
+            RefreshCurrentTurnPreview();
+            PublishRoutePreview(retainedAfterRound, force: true);
             searchedTurnLayers++;
             if (_detailedDiagnostics)
             {

--- a/src/Search/CombatSearchCoordinator.cs
+++ b/src/Search/CombatSearchCoordinator.cs
@@ -19,8 +19,10 @@ internal static class CombatSearchCoordinator
         SolverResult? currentCompleteAdoptableResult = null;
         SolverInterimResult? currentDisplayedResult = null;
         SolverProgress? lastProgress = null;
-        int routePreviewVersion = 0;
-        SolverRoutePreview? currentRoutePreview = null;
+        int currentTurnPreviewVersion = 0;
+        int speculativeRouteVersion = 0;
+        SolverCurrentTurnPreview? currentTurnPreview = null;
+        SolverSpeculativeRoutePreview? speculativeRoutePreview = null;
         SolverRouteAdoptionSeed? currentRouteAdoptionSeed = null;
 
         bool TryPromoteDisplayedResult(SolverInterimResult candidate)
@@ -51,14 +53,16 @@ internal static class CombatSearchCoordinator
             if (!promoted && summary != currentDisplayedResult)
                 return;
             currentCompleteAdoptableResult = result;
-            SolverRoutePreview preview = SolverRoutePreview.FromResult(
+            currentTurnPreview = SolverCurrentTurnPreview.FromResult(
                 result,
-                ++routePreviewVersion);
+                ++currentTurnPreviewVersion);
+            speculativeRoutePreview = SolverSpeculativeRoutePreview.FromResult(
+                result,
+                ++speculativeRouteVersion);
             SolverRouteAdoptionSeed seed = new(
-                preview.CandidateVersion,
+                speculativeRoutePreview.CandidateVersion,
                 result.BestNode.Actions,
                 () => result);
-            currentRoutePreview = preview;
             currentRouteAdoptionSeed = seed;
             policy.Diagnostics.Info(
                 $"[CombatSolver/Test] SEARCH_INTERIM_RESULT potions={result.ProjectedBattlePotionCount} " +
@@ -68,7 +72,8 @@ internal static class CombatSearchCoordinator
                 lastProgress = lastProgress with
                 {
                     CurrentBestResult = currentDisplayedResult,
-                    RoutePreview = currentRoutePreview,
+                    CurrentTurnPreview = currentTurnPreview,
+                    SpeculativeRoutePreview = speculativeRoutePreview,
                     RouteAdoptionSeed = currentRouteAdoptionSeed,
                 };
                 progressCallback(lastProgress);
@@ -82,16 +87,26 @@ internal static class CombatSearchCoordinator
                 lastProgress = progress;
                 if (progress.CurrentBestResult is { } candidate)
                     TryPromoteDisplayedResult(candidate);
-                if (progress.RoutePreview is { } preview)
+                if (progress.CurrentTurnPreview is { } current)
                 {
-                    currentRoutePreview = preview;
+                    currentTurnPreview = current;
+                    currentTurnPreviewVersion = Math.Max(
+                        currentTurnPreviewVersion,
+                        current.CandidateVersion);
+                }
+                if (progress.SpeculativeRoutePreview is { } speculative)
+                {
+                    speculativeRoutePreview = speculative;
                     currentRouteAdoptionSeed = progress.RouteAdoptionSeed;
-                    routePreviewVersion = Math.Max(routePreviewVersion, preview.CandidateVersion);
+                    speculativeRouteVersion = Math.Max(
+                        speculativeRouteVersion,
+                        speculative.CandidateVersion);
                 }
                 progressCallback(progress with
                 {
                     CurrentBestResult = currentDisplayedResult,
-                    RoutePreview = currentRoutePreview,
+                    CurrentTurnPreview = currentTurnPreview,
+                    SpeculativeRoutePreview = speculativeRoutePreview,
                     RouteAdoptionSeed = currentRouteAdoptionSeed,
                 });
             };

--- a/src/Search/SolverInterimResultOrdering.cs
+++ b/src/Search/SolverInterimResultOrdering.cs
@@ -26,6 +26,11 @@ internal static class SolverInterimResultOrdering
             return candidate.ProjectedBattlePotionCount < current.ProjectedBattlePotionCount;
         if (candidate.EnemyHp != current.EnemyHp)
             return candidate.EnemyHp < current.EnemyHp;
+        if (candidate.Won && candidate.CombatEndedTurn != current.CombatEndedTurn)
+        {
+            return (candidate.CombatEndedTurn ?? int.MaxValue)
+                < (current.CombatEndedTurn ?? int.MaxValue);
+        }
         return candidate.Score > current.Score;
     }
 

--- a/src/Testing/UnattendedTestRunner.ControllerSessions.cs
+++ b/src/Testing/UnattendedTestRunner.ControllerSessions.cs
@@ -119,7 +119,7 @@ internal sealed partial class UnattendedTestRunner
         if (!SolverController.IsSearching)
             throw new InvalidOperationException("控制器没有建立搜索会话。");
         int progressTurn = player.PlayerCombatState!.TurnNumber;
-        SolverRoutePreview progressPreview = new(
+        SolverSpeculativeRoutePreview progressPreview = new(
             CandidateVersion: 1,
             StartTurnNumber: progressTurn,
             ProjectedBattlePotionCount: 0,
@@ -176,10 +176,10 @@ internal sealed partial class UnattendedTestRunner
                     ProjectedBattlePotionCount: 0,
                     EnemyHp: 1,
                     Score: 0d),
-                RoutePreview: progressPreview),
+                SpeculativeRoutePreview: progressPreview),
             deployWhenReady: false,
             reviewedWorldlinesBeforeSearch: 5,
-            bestSnapshot: SolverOverlaySnapshot.CaptureRoutePreview(progressPreview));
+            bestSnapshot: SolverOverlaySnapshot.CaptureSpeculativeRoute(progressPreview));
         if (SolverOverlay.SearchProgressRatioForTesting < progressRatio
             || SolverOverlay.ReviewSummaryTextForTesting?.Contains(
                 "正在搜索无药路线",

--- a/src/UI/SolverOverlaySnapshot.cs
+++ b/src/UI/SolverOverlaySnapshot.cs
@@ -75,8 +75,51 @@ internal sealed record SolverOverlaySnapshot(
         => Capture(result, turn, unexpectedReplan, pendingTurnSetup: true, reviewedWorldlinesTotal);
 
 
-    public static SolverOverlaySnapshot CaptureRoutePreview(
-        SolverRoutePreview preview)
+    public static SolverOverlaySnapshot CaptureCurrentTurn(SolverCurrentTurnPreview preview)
+    {
+        SolverOverlayActionSnapshot[] actions = preview.Actions
+            .Where(action => action.IsExecutable)
+            .Select(action => CaptureAction(action, []))
+            .ToArray();
+        PlanAction? endTurn = preview.Actions
+            .LastOrDefault(action => action.Kind == PlanActionKind.EndTurn);
+        SolverOverlayTurnSnapshot currentTurn = new(
+            preview.Turn,
+            TurnStartChoices: [],
+            actions,
+            endTurn == null ? null : CaptureAction(endTurn, []),
+            EnemyHpDamageLost: preview.EnemyHpLost,
+            preview.HpLost,
+            preview.EnergyLeft,
+            preview.CombatEnded);
+        SolverOverlayTurnSnapshot[] turns = preview.FrontierTurns is { Count: > 0 } frontier
+            ? frontier.Select(BuildOverlayTurn).ToArray()
+            : [currentTurn];
+        int furthestTurn = preview.FrontierTurns is { Count: > 0 } frontierTurns
+            ? frontierTurns[^1].Turn
+            : preview.Turn;
+        string outcome = preview.CombatEnded
+            ? "本回合结束战斗"
+            : preview.HpLost > 0
+                ? $"本回合预计掉血 {preview.HpLost} HP"
+                : "本回合预计掉血 0 HP";
+        return new SolverOverlaySnapshot(
+            preview.Turn,
+            $"搜索前沿预览 · 已规划至第 {furthestTurn} 回合",
+            SolverOverlayTone.Accent,
+            $"[color={SolverUiTokens.Palette.TextSecondaryHex}]搜索前沿预览，尚未验证完整胜利  │  {outcome}[/color]",
+            string.Empty,
+            preview.Actions.Count(action => action.Kind == PlanActionKind.UsePotion),
+            preview.HpLost,
+            outcome,
+            OnlyDeathRoutesFound: false,
+            turns,
+            DetailsText: string.Empty,
+            HasRisk: false);
+    }
+
+    public static SolverOverlaySnapshot CaptureSpeculativeRoute(
+        SolverSpeculativeRoutePreview preview)
     {
         if (preview.Turns.Count == 0)
             throw new InvalidOperationException("动态候选路线没有可展示回合。");


### PR DESCRIPTION
本 PR 是 #31（完善求解器路线交互与界面控制）的后续，主要补两项。

**策略更新（重点）**
- 选路时，若两条路线都获胜、且战损/用药/长线资源等更高优先级维度相同，优先选择更早结束战斗的路线（回合数越少越好）。
- 该维度排在敌血等资源之后、总评分之前，不会为了快一回合而多掉血、多用资源。

**动态预览恢复**
- 恢复搜索时"边算边逐条变动"的动态演化预览：每 ~100ms 从当前候选里重新选最优展示，未完成的当前回合动作也实时可见。
- 界面区分"已规划至第 N 回合"（当前回合可应用）和"已演化至第 N 回合、可能变化或回跳"（fork 演化）。
- "采用当前路线"/"停止计算"对应屏幕当前显示的那条。
- 纯展示，不影响最终选路。