### PR TITLE
修复对敌伤害显示口径与药水补查阶段路线污染（PR#32 后续）

### DIFF
--- a/src/Search/CombatBeamSolver.Expansion.cs
+++ b/src/Search/CombatBeamSolver.Expansion.cs
@@ -320,7 +320,10 @@ internal sealed partial class CombatBeamSolver
                 false,
                 seed,
                 powerSnapshot,
-                CombatProgressState.Capture(powerSnapshot));
+                CombatProgressState.Capture(powerSnapshot))
+            {
+                CumulativeEnemyHpLost = AccumulateEnemyHpLost(seed, powerSnapshot),
+            };
             followUps.AddRange(Expand(powerNode).Where(node =>
                 node.Action is { Kind: PlanActionKind.PlayCard, Turn: var turn }
                 && turn == _startTurnNumber));
@@ -700,7 +703,10 @@ internal sealed partial class CombatBeamSolver
                             ? node.CombatProgress.Advance(finalSnapshot)
                             : node.CombatProgress,
                         RepeatableNoProgressCardId: repeatableCardId,
-                        RepeatableNoProgressCount: repeatableCount);
+                        RepeatableNoProgressCount: repeatableCount)
+                    {
+                        CumulativeEnemyHpLost = AccumulateEnemyHpLost(node, finalSnapshot),
+                    };
                     if (ShouldPruneRepeatableNoProgress(child)
                         || ShouldPruneCrossTurnNoProgress(child))
                     {
@@ -860,7 +866,10 @@ internal sealed partial class CombatBeamSolver
                             terminal,
                             node,
                             finalSnapshot,
-                            node.CombatProgress);
+                            node.CombatProgress)
+                        {
+                            CumulativeEnemyHpLost = AccumulateEnemyHpLost(node, finalSnapshot),
+                        };
                         bool accepted = TryAcceptTransposition(child);
                         if (_detailedDiagnostics && node.ActionCount == 0)
                         {
@@ -997,7 +1006,10 @@ internal sealed partial class CombatBeamSolver
                 combatEnded || endSnapshot.BoundaryReason != SearchBoundaryReason.None,
                 node,
                 endSnapshot,
-                node.CombatProgress.Advance(endSnapshot));
+                node.CombatProgress.Advance(endSnapshot))
+            {
+                CumulativeEnemyHpLost = AccumulateEnemyHpLost(node, endSnapshot),
+            };
             if (ShouldPruneCrossTurnNoProgress(endNode))
             {
                 _run.RepeatableNoProgressBranchesPruned++;

--- a/src/Search/CombatBeamSolver.ParallelExpansion.cs
+++ b/src/Search/CombatBeamSolver.ParallelExpansion.cs
@@ -1517,7 +1517,10 @@ internal sealed partial class CombatBeamSolver
                     ? node.CombatProgress.Advance(finalSnapshot)
                     : node.CombatProgress,
                 RepeatableNoProgressCardId: repeatableCardId,
-                RepeatableNoProgressCount: repeatableCount);
+                RepeatableNoProgressCount: repeatableCount)
+            {
+                CumulativeEnemyHpLost = AccumulateEnemyHpLost(node, finalSnapshot),
+            };
             if (ShouldPruneRepeatableNoProgress(child)
                 || ShouldPruneCrossTurnNoProgress(child))
             {
@@ -1913,7 +1916,10 @@ internal sealed partial class CombatBeamSolver
                             terminal,
                             node,
                             finalSnapshot,
-                            node.CombatProgress);
+                            node.CombatProgress)
+                        {
+                            CumulativeEnemyHpLost = AccumulateEnemyHpLost(node, finalSnapshot),
+                        };
                         batch.AddPotion(child);
                     }
                 }
@@ -1947,7 +1953,10 @@ internal sealed partial class CombatBeamSolver
                 endTerminal,
                 node,
                 endSnapshot,
-                node.CombatProgress.Advance(endSnapshot));
+                node.CombatProgress.Advance(endSnapshot))
+            {
+                CumulativeEnemyHpLost = AccumulateEnemyHpLost(node, endSnapshot),
+            };
             if (ShouldPruneCrossTurnNoProgress(endNode))
             {
                 _run.RepeatableNoProgressBranchesPruned++;

--- a/src/Search/CombatBeamSolver.Phases.cs
+++ b/src/Search/CombatBeamSolver.Phases.cs
@@ -609,7 +609,7 @@ internal sealed partial class CombatBeamSolver
                         group.Key,
                         out int annotatedEnemyHpLost)
                             ? annotatedEnemyHpLost
-                            : Math.Max(0, first.Parent!.Snapshot.EnemyHp - last.Snapshot.EnemyHp);
+                            : last.CumulativeEnemyHpLost - first.Parent!.CumulativeEnemyHpLost;
                     int energyLeft = annotations.EnergyLeftByTurn.TryGetValue(
                         group.Key,
                         out int annotatedEnergyLeft)
@@ -1500,7 +1500,10 @@ internal sealed partial class CombatBeamSolver
                 terminal,
                 node,
                 snapshot,
-                node.CombatProgress);
+                node.CombatProgress)
+            {
+                CumulativeEnemyHpLost = AccumulateEnemyHpLost(node, snapshot),
+            };
             node.Parent!.Snapshot.ReleaseSimulator();
         }
         return node;

--- a/src/Search/CombatBeamSolver.Terminal.cs
+++ b/src/Search/CombatBeamSolver.Terminal.cs
@@ -24,6 +24,12 @@ namespace CombatSolver;
 
 internal sealed partial class CombatBeamSolver
 {
+    private static int AccumulateEnemyHpLost(
+        SearchNode parent,
+        SimulationSnapshot childSnapshot)
+        => checked(parent.CumulativeEnemyHpLost
+            + Math.Max(0, parent.Snapshot.RawEnemyHp - childSnapshot.RawEnemyHp));
+
     private List<SearchNode> AnnotateTurnOutcomes(List<SearchNode> ended)
     {
         if (ended.Count == 0)
@@ -99,10 +105,8 @@ internal sealed partial class CombatBeamSolver
                     Outcome = new TurnOutcome(
                         outcome.Turn,
                         outcome.HpLost,
-                        Math.Max(
-                            0,
-                            outcome.TurnStart.Snapshot.EnemyHp
-                            - outcome.Node.Snapshot.EnemyHp),
+                        outcome.Node.CumulativeEnemyHpLost
+                            - outcome.TurnStart.CumulativeEnemyHpLost,
                         soldThisTurn,
                         maxBlock,
                         outcome.ActualBlock,

--- a/src/Search/CombatPlan.cs
+++ b/src/Search/CombatPlan.cs
@@ -245,6 +245,7 @@ internal sealed record SearchNode(
 
     public int RetentionRank { get; set; } = int.MaxValue;
     public int LongTermResourceRetentionRank { get; set; } = int.MaxValue;
+    public int CumulativeEnemyHpLost { get; init; }
     public IReadOnlyList<PlanAction> Actions => _actions ??= MaterializeActions();
 
     public IReadOnlyList<PlanCardChoice> GetTurnSetupChoices()

--- a/src/Search/CombatSearchCoordinator.cs
+++ b/src/Search/CombatSearchCoordinator.cs
@@ -27,10 +27,12 @@ internal static class CombatSearchCoordinator
 
         bool TryPromoteDisplayedResult(SolverInterimResult candidate)
         {
-            if (currentDisplayedResult != null
-                && !SolverInterimResultOrdering.IsBetter(candidate, currentDisplayedResult))
+            if (currentDisplayedResult != null)
             {
-                return false;
+                if (candidate == currentDisplayedResult)
+                    return true;
+                if (!SolverInterimResultOrdering.IsBetter(candidate, currentDisplayedResult))
+                    return false;
             }
             currentDisplayedResult = candidate;
             return true;
@@ -85,22 +87,35 @@ internal static class CombatSearchCoordinator
             : progress =>
             {
                 lastProgress = progress;
+                // Supplemental searches publish their own local previews. Once a global best exists,
+                // keep those previews and their adoption seed together unless that local result wins globally.
+                bool acceptsRouteUpdate = currentDisplayedResult == null;
                 if (progress.CurrentBestResult is { } candidate)
-                    TryPromoteDisplayedResult(candidate);
-                if (progress.CurrentTurnPreview is { } current)
                 {
-                    currentTurnPreview = current;
-                    currentTurnPreviewVersion = Math.Max(
-                        currentTurnPreviewVersion,
-                        current.CandidateVersion);
+                    acceptsRouteUpdate = TryPromoteDisplayedResult(candidate);
                 }
-                if (progress.SpeculativeRoutePreview is { } speculative)
+                else if (currentDisplayedResult != null)
                 {
-                    speculativeRoutePreview = speculative;
-                    currentRouteAdoptionSeed = progress.RouteAdoptionSeed;
-                    speculativeRouteVersion = Math.Max(
-                        speculativeRouteVersion,
-                        speculative.CandidateVersion);
+                    acceptsRouteUpdate = false;
+                }
+
+                if (acceptsRouteUpdate)
+                {
+                    if (progress.CurrentTurnPreview is { } current)
+                    {
+                        currentTurnPreview = current;
+                        currentTurnPreviewVersion = Math.Max(
+                            currentTurnPreviewVersion,
+                            current.CandidateVersion);
+                    }
+                    if (progress.SpeculativeRoutePreview is { } speculative)
+                    {
+                        speculativeRoutePreview = speculative;
+                        currentRouteAdoptionSeed = progress.RouteAdoptionSeed;
+                        speculativeRouteVersion = Math.Max(
+                            speculativeRouteVersion,
+                            speculative.CandidateVersion);
+                    }
                 }
                 progressCallback(progress with
                 {


### PR DESCRIPTION
本 PR 是 #32（恢复动态演化预览与优先更早结束路线）的后续，修两个问题。

**对敌伤害显示口径**
- 之前界面的"对敌伤害"数字比怪物实际掉的血少，现在改成按怪物真实掉的血来统计，显示的是实际造成的伤害。

**药水补查阶段路线污染**
- 之前搜"要不要用药水"时，一条更差（费药又不省血）的用药水路线会错误顶掉不用药水的好路线；现在改成候选真正比现在好才替换，差的用药水路线不再顶掉好路线。