### PR TITLE
perf: 缓存 ModelDb 泛型查询并消除搜索热路径上的枚举器与数组分配

### DIFF
--- a/src/Engine/Common/CanonicalModels.cs
+++ b/src/Engine/Common/CanonicalModels.cs
@@ -1,0 +1,84 @@
+using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Models.Afflictions;
+using MegaCrit.Sts2.Core.Models.Cards;
+using MegaCrit.Sts2.Core.Models.Enchantments;
+using MegaCrit.Sts2.Core.Models.Monsters;
+using MegaCrit.Sts2.Core.Models.Orbs;
+using MegaCrit.Sts2.Core.Models.Potions;
+using MegaCrit.Sts2.Core.Models.Powers;
+using MegaCrit.Sts2.Core.Models.Relics;
+
+namespace CombatSolver.Engine.Common;
+
+/// <summary>
+/// <see cref="ModelDb"/> 的泛型查询每次都用正则把类型名 slug 化成 <c>ModelId</c> 再查字典
+/// （<c>StringHelper.Slugify</c> 三次 <c>Regex.Replace</c>）。规范实例在 <c>ModelDb.Init</c>
+/// 之后不会变化，搜索热路径（<c>SetAmount</c>、<c>Tick</c>、生成牌）按封闭泛型类型缓存即可。
+/// 缓存只在首次访问时填充，不在类型初始化器里查询，避免 ModelDb 尚未就绪时把失败固化。
+/// </summary>
+internal static class CanonicalModels
+{
+    public static T Power<T>() where T : PowerModel => PowerCache<T>.Value;
+
+    public static T Card<T>() where T : CardModel => CardCache<T>.Value;
+
+    public static T Relic<T>() where T : RelicModel => RelicCache<T>.Value;
+
+    public static T Potion<T>() where T : PotionModel => PotionCache<T>.Value;
+
+    public static T Monster<T>() where T : MonsterModel => MonsterCache<T>.Value;
+
+    public static T Affliction<T>() where T : AfflictionModel => AfflictionCache<T>.Value;
+
+    public static T Enchantment<T>() where T : EnchantmentModel => EnchantmentCache<T>.Value;
+
+    public static T Orb<T>() where T : OrbModel => OrbCache<T>.Value;
+
+    private static class PowerCache<T> where T : PowerModel
+    {
+        private static T? _value;
+        public static T Value => _value ??= ModelDb.Power<T>();
+    }
+
+    private static class CardCache<T> where T : CardModel
+    {
+        private static T? _value;
+        public static T Value => _value ??= ModelDb.Card<T>();
+    }
+
+    private static class RelicCache<T> where T : RelicModel
+    {
+        private static T? _value;
+        public static T Value => _value ??= ModelDb.Relic<T>();
+    }
+
+    private static class PotionCache<T> where T : PotionModel
+    {
+        private static T? _value;
+        public static T Value => _value ??= ModelDb.Potion<T>();
+    }
+
+    private static class MonsterCache<T> where T : MonsterModel
+    {
+        private static T? _value;
+        public static T Value => _value ??= ModelDb.Monster<T>();
+    }
+
+    private static class AfflictionCache<T> where T : AfflictionModel
+    {
+        private static T? _value;
+        public static T Value => _value ??= ModelDb.Affliction<T>();
+    }
+
+    private static class EnchantmentCache<T> where T : EnchantmentModel
+    {
+        private static T? _value;
+        public static T Value => _value ??= ModelDb.Enchantment<T>();
+    }
+
+    private static class OrbCache<T> where T : OrbModel
+    {
+        private static T? _value;
+        public static T Value => _value ??= ModelDb.Orb<T>();
+    }
+}

--- a/src/Engine/Common/Mirrors/MethodMirrorRegistry.cs
+++ b/src/Engine/Common/Mirrors/MethodMirrorRegistry.cs
@@ -59,6 +59,9 @@ internal sealed class MethodMirrorRegistry<TBase, TContext>(MirrorMethodSpec met
     private readonly Dictionary<Type, LookupResult> _registrations = [];
     private readonly ConcurrentDictionary<Type, Lazy<LookupResult>> _lookupCache = new();
     private readonly object _lookupResolutionGate = new();
+    // 热路径上每个 listener × 每个 hook 都要 Lookup 一次。已解析结果放进一张写时复制的普通字典，
+    // 读取无锁且只查一次哈希；ConcurrentDictionary + Lazy 只留给首次解析。
+    private Dictionary<Type, LookupResult> _resolvedSnapshot = [];
 
     private MethodMirrorInferrer<TBase, TContext>? _inferrer;
     private MethodMirrorInferrer<TBase, TContext>? _strictInferrer;
@@ -80,6 +83,8 @@ internal sealed class MethodMirrorRegistry<TBase, TContext>(MirrorMethodSpec met
             {
                 _allowInference = value;
                 _lookupCache.Clear();
+                lock (_lookupResolutionGate)
+                    Volatile.Write(ref _resolvedSnapshot, []);
             }
         }
     }
@@ -224,15 +229,31 @@ internal sealed class MethodMirrorRegistry<TBase, TContext>(MirrorMethodSpec met
 
     private LookupResult Lookup(Type type)
     {
-        if (_registrations.TryGetValue(type, out var result))
-            return result;
+        if (Volatile.Read(ref _resolvedSnapshot).TryGetValue(type, out var cached))
+            return cached;
+        if (!_registrations.TryGetValue(type, out var result))
+        {
+            result = _lookupCache.GetOrAdd(
+                type,
+                static (runtimeType, registry) => new Lazy<LookupResult>(
+                    () => registry.ResolveLookup(runtimeType),
+                    LazyThreadSafetyMode.ExecutionAndPublication),
+                this).Value;
+        }
+        PublishResolvedLookup(type, result);
+        return result;
+    }
 
-        return _lookupCache.GetOrAdd(
-            type,
-            static (runtimeType, registry) => new Lazy<LookupResult>(
-                () => registry.ResolveLookup(runtimeType),
-                LazyThreadSafetyMode.ExecutionAndPublication),
-            this).Value;
+    private void PublishResolvedLookup(Type type, LookupResult result)
+    {
+        lock (_lookupResolutionGate)
+        {
+            Dictionary<Type, LookupResult> current = _resolvedSnapshot;
+            if (current.ContainsKey(type))
+                return;
+            Dictionary<Type, LookupResult> next = new(current) { [type] = result };
+            Volatile.Write(ref _resolvedSnapshot, next);
+        }
     }
 
     private LookupResult ResolveLookup(Type type)
@@ -319,6 +340,9 @@ internal sealed class MethodMirrorRegistry<TBase, TContext, TResult>(MirrorMetho
     private readonly Dictionary<Type, LookupResult> _registrations = [];
     private readonly ConcurrentDictionary<Type, Lazy<LookupResult>> _lookupCache = new();
     private readonly object _lookupResolutionGate = new();
+    // 热路径上每个 listener × 每个 hook 都要 Lookup 一次。已解析结果放进一张写时复制的普通字典，
+    // 读取无锁且只查一次哈希；ConcurrentDictionary + Lazy 只留给首次解析。
+    private Dictionary<Type, LookupResult> _resolvedSnapshot = [];
 
     public void Register<TModel>(Func<TModel, TContext, TResult> handler)
         where TModel : TBase
@@ -404,15 +428,31 @@ internal sealed class MethodMirrorRegistry<TBase, TContext, TResult>(MirrorMetho
 
     private LookupResult Lookup(Type type)
     {
-        if (_registrations.TryGetValue(type, out var result))
-            return result;
+        if (Volatile.Read(ref _resolvedSnapshot).TryGetValue(type, out var cached))
+            return cached;
+        if (!_registrations.TryGetValue(type, out var result))
+        {
+            result = _lookupCache.GetOrAdd(
+                type,
+                static (runtimeType, registry) => new Lazy<LookupResult>(
+                    () => registry.ResolveLookup(runtimeType),
+                    LazyThreadSafetyMode.ExecutionAndPublication),
+                this).Value;
+        }
+        PublishResolvedLookup(type, result);
+        return result;
+    }
 
-        return _lookupCache.GetOrAdd(
-            type,
-            static (runtimeType, registry) => new Lazy<LookupResult>(
-                () => registry.ResolveLookup(runtimeType),
-                LazyThreadSafetyMode.ExecutionAndPublication),
-            this).Value;
+    private void PublishResolvedLookup(Type type, LookupResult result)
+    {
+        lock (_lookupResolutionGate)
+        {
+            Dictionary<Type, LookupResult> current = _resolvedSnapshot;
+            if (current.ContainsKey(type))
+                return;
+            Dictionary<Type, LookupResult> next = new(current) { [type] = result };
+            Volatile.Write(ref _resolvedSnapshot, next);
+        }
     }
 
     private LookupResult ResolveLookup(Type type)

--- a/src/Engine/Common/PredictionStateStore.cs
+++ b/src/Engine/Common/PredictionStateStore.cs
@@ -6,6 +6,9 @@ internal sealed class PredictionStateStore
 {
     private readonly Dictionary<(AbstractModel Model, Type StateType), StateEntry> _states;
     private readonly Dictionary<AbstractModel, AbstractModel> _modelAliases;
+    // 每种状态类型当前的条目数。ReadEntries<TState> 是热路径（每次动作后都要同步 Power 数量），
+    // 绝大多数调用时该类型根本没有条目，用计数直接短路，避免整表扫描。
+    private readonly Dictionary<Type, int> _countByType = new();
 
     public PredictionStateStore()
         : this(0, 0)
@@ -61,6 +64,7 @@ internal sealed class PredictionStateStore
                 ?? throw new InvalidOperationException("Prediction state factory returned null.");
             entry = new OwnedStateEntry(state);
             _states[key] = entry;
+            IncrementCount(typeof(TState));
         }
 
         return (TState)entry.Materialize();
@@ -88,6 +92,7 @@ internal sealed class PredictionStateStore
                 ?? throw new InvalidOperationException("Prediction state factory returned null.");
             entry = new OwnedStateEntry(state);
             _states[key] = entry;
+            IncrementCount(typeof(TState));
         }
         return (TState)entry.Read();
     }
@@ -132,6 +137,8 @@ internal sealed class PredictionStateStore
     public IEnumerable<(AbstractModel Model, TState State)> ReadEntries<TState>()
         where TState : class, IPredictionStateForkable
     {
+        if (!_countByType.TryGetValue(typeof(TState), out int count) || count == 0)
+            yield break;
         foreach (((AbstractModel model, Type stateType), StateEntry entry) in _states)
         {
             if (stateType == typeof(TState))
@@ -141,7 +148,15 @@ internal sealed class PredictionStateStore
 
     public bool Remove<TState>(AbstractModel model)
         where TState : class, IPredictionStateForkable
-        => _states.Remove((ResolveModel(model), typeof(TState)));
+    {
+        if (!_states.Remove((ResolveModel(model), typeof(TState))))
+            return false;
+        _countByType[typeof(TState)]--;
+        return true;
+    }
+
+    private void IncrementCount(Type stateType)
+        => _countByType[stateType] = _countByType.GetValueOrDefault(stateType) + 1;
 
     public void RemapModel(AbstractModel source, AbstractModel replacement)
     {
@@ -196,6 +211,11 @@ internal sealed class PredictionStateStore
                 context.Register(state, forkedState);
             }
             fork._states.Add((forkedModel, stateType), new OwnedStateEntry(forkedState));
+        }
+        foreach ((Type stateType, int count) in _countByType)
+        {
+            if (count != 0)
+                fork._countByType[stateType] = count;
         }
         foreach ((AbstractModel source, AbstractModel replacement) in _modelAliases)
         {

--- a/src/Engine/InCombat/Mirrors/Hooks/Card/AfterCardDrawnMirrors.cs
+++ b/src/Engine/InCombat/Mirrors/Hooks/Card/AfterCardDrawnMirrors.cs
@@ -157,7 +157,7 @@ internal static class AfterCardDrawnMirrors
             context.CombatState.CurrentSide == power.Owner.Side &&
             // CanAfflict only checks card type, existing affliction, and Unplayable.
             // Vanilla currently has no global hook that adds Unplayable, so preview keywords are sufficient here.
-            ModelDb.Affliction<Bound>().CanAfflict(context.PreviewCard))
+            CanonicalModels.Affliction<Bound>().CanAfflict(context.PreviewCard))
         {
             ChainsOfBindingPredictionState state = context.StateStore.Get(
                 power,

--- a/src/Engine/InCombat/Simulation/CombatPredictionSimulator.Attack.cs
+++ b/src/Engine/InCombat/Simulation/CombatPredictionSimulator.Attack.cs
@@ -35,13 +35,31 @@ internal sealed partial class CombatPredictionSimulator
         attackContext.AddResultsInternal(results);
     }
 
+    /// <summary>把多次命中的结果展平成一个列表；热路径上避免 SelectMany/ToArray 的迭代器与两次拷贝。</summary>
+    private static DamageResult[] FlattenAttackResults(AttackCommand attackCommand)
+    {
+        int total = 0;
+        foreach (List<DamageResult> hit in attackCommand.Results)
+            total += hit.Count;
+        if (total == 0)
+            return [];
+        DamageResult[] flattened = new DamageResult[total];
+        int index = 0;
+        foreach (List<DamageResult> hit in attackCommand.Results)
+        {
+            hit.CopyTo(flattened, index);
+            index += hit.Count;
+        }
+        return flattened;
+    }
+
     public void EndAttackContext(AttackCommand attackContext)
     {
         Creature attacker = attackContext.Attacker
             ?? throw new InvalidOperationException("Attack context must have an attacker.");
         History.CreatureAttacked(
             attacker,
-            attackContext.Results.SelectMany(results => results).ToArray());
+            FlattenAttackResults(attackContext));
         if (State.CombatState is ICombatPredictionCardEventSink eventSink)
             eventSink.RecordCreatureAttacked(attacker);
         HookMirrors.AfterAttack(this, attackContext);
@@ -125,7 +143,7 @@ internal sealed partial class CombatPredictionSimulator
 
         History.CreatureAttacked(
             attacker,
-            attackCommand.Results.SelectMany(results => results).ToArray());
+            FlattenAttackResults(attackCommand));
         if (State.CombatState is ICombatPredictionCardEventSink eventSink)
             eventSink.RecordCreatureAttacked(attacker);
 

--- a/src/Engine/InCombat/Simulation/CombatPredictionSimulator.Card.cs
+++ b/src/Engine/InCombat/Simulation/CombatPredictionSimulator.Card.cs
@@ -482,7 +482,7 @@ internal sealed partial class CombatPredictionSimulator
     // Mirrors CardModel.Afflict<T>.
     public T? Afflict<T>(PredictedCard card, decimal amount) where T : AfflictionModel
     {
-        return Afflict(ModelDb.Affliction<T>().ToMutable(), card, amount) as T;
+        return Afflict(CanonicalModels.Affliction<T>().ToMutable(), card, amount) as T;
     }
 
     /// <summary>

--- a/src/Engine/InCombat/Simulation/CombatPredictionSimulator.CardPile.cs
+++ b/src/Engine/InCombat/Simulation/CombatPredictionSimulator.CardPile.cs
@@ -167,7 +167,7 @@ internal sealed partial class CombatPredictionSimulator
         List<PredictedCard> cards = [];
         for (var i = 0; i < count; i++)
         {
-            cards.Add(PredictedCard.Create(ModelDb.Card<TCard>(), player));
+            cards.Add(PredictedCard.Create(CanonicalModels.Card<TCard>(), player));
         }
 
         return AddGeneratedCardsToCombat(cards, pileType, creator, position, CardGenerationResultKind.Fixed);

--- a/src/Engine/InCombat/Simulation/CombatPredictionSimulator.Orb.cs
+++ b/src/Engine/InCombat/Simulation/CombatPredictionSimulator.Orb.cs
@@ -43,7 +43,7 @@ internal sealed partial class CombatPredictionSimulator
     {
         for (var i = 0; i < count; i++)
         {
-            if (!OrbChannel(player, ModelDb.Orb<T>().ToMutable()))
+            if (!OrbChannel(player, CanonicalModels.Orb<T>().ToMutable()))
             {
                 break;
             }

--- a/src/Prediction/CardEffectSpecRegistry.cs
+++ b/src/Prediction/CardEffectSpecRegistry.cs
@@ -267,7 +267,7 @@ internal static class CardEffectSpecRegistry
                 CardChoiceSupport.TransformCards(
                     simulator,
                     statuses,
-                    ModelDb.Card<Fuel>(),
+                    CanonicalModels.Card<Fuel>(),
                     card.IsUpgraded);
                 applied = true;
                 break;
@@ -425,7 +425,7 @@ internal static class CardEffectSpecRegistry
                 List<PredictedCard> souls = new(count);
                 for (int index = 0; index < count; index++)
                 {
-                    PredictedCard soul = PredictedCard.Create(ModelDb.Card<Soul>(), card.Owner);
+                    PredictedCard soul = PredictedCard.Create(CanonicalModels.Card<Soul>(), card.Owner);
                     if (card.IsUpgraded)
                         soul.Upgrade();
                     souls.Add(soul);

--- a/src/Prediction/CardOnPlaySupport.Batch042.cs
+++ b/src/Prediction/CardOnPlaySupport.Batch042.cs
@@ -97,7 +97,7 @@ internal static partial class CardOnPlaySupport
                 CardChoiceSupport.TransformCards(
                     simulator,
                     attacks,
-                    ModelDb.Card<GiantRock>(),
+                    CanonicalModels.Card<GiantRock>(),
                     card.IsUpgraded);
                 break;
             }
@@ -146,7 +146,7 @@ internal static partial class CardOnPlaySupport
 
         List<PredictedCard> souls = new(card.DynamicVars.Cards.IntValue);
         for (int index = 0; index < card.DynamicVars.Cards.IntValue; index++)
-            souls.Add(PredictedCard.Create(ModelDb.Card<Soul>(), card.Owner));
+            souls.Add(PredictedCard.Create(CanonicalModels.Card<Soul>(), card.Owner));
         simulator.AddGeneratedCardsToCombat(
             souls,
             PileType.Draw,

--- a/src/Prediction/CardOnPlaySupport.Batch043.cs
+++ b/src/Prediction/CardOnPlaySupport.Batch043.cs
@@ -91,7 +91,7 @@ internal static partial class CardOnPlaySupport
         List<PredictedCard> souls = new(xValue);
         for (int index = 0; index < xValue; index++)
         {
-            PredictedCard soul = PredictedCard.Create(ModelDb.Card<Soul>(), card.Owner);
+            PredictedCard soul = PredictedCard.Create(CanonicalModels.Card<Soul>(), card.Owner);
             if (card.IsUpgraded)
                 soul.Upgrade();
             souls.Add(soul);

--- a/src/Prediction/CardOnPlaySupport.cs
+++ b/src/Prediction/CardOnPlaySupport.cs
@@ -183,7 +183,7 @@ internal static partial class CardOnPlaySupport
             {
                 simulator.State.GetPlayerCombatState(card.Owner).GainEnergy(card.DynamicVars.Energy.IntValue);
                 PredictedCard generated = PredictedCard.Create(
-                    ModelDb.Card<MegaCrit.Sts2.Core.Models.Cards.Void>(),
+                    CanonicalModels.Card<MegaCrit.Sts2.Core.Models.Cards.Void>(),
                     card.Owner);
                 simulator.AddGeneratedCardToCombat(
                     generated,

--- a/src/Prediction/CardPileOnPlaySupport.cs
+++ b/src/Prediction/CardPileOnPlaySupport.cs
@@ -98,7 +98,7 @@ internal static class CardPileOnPlaySupport
     {
         IReadOnlyList<PredictedCard> shivs = GenerateShivs(simulator, owner, count, upgraded: false);
         foreach (PredictedCard shiv in shivs)
-            shiv.Enchant(ModelDb.Enchantment<Inky>().ToMutable(), 1m);
+            shiv.Enchant(CanonicalModels.Enchantment<Inky>().ToMutable(), 1m);
     }
 
     internal static IReadOnlyList<PredictedCard> GenerateShivs(
@@ -110,7 +110,7 @@ internal static class CardPileOnPlaySupport
         List<PredictedCard> shivs = new(count);
         for (int index = 0; index < count; index++)
         {
-            PredictedCard shiv = PredictedCard.Create(ModelDb.Card<Shiv>(), owner);
+            PredictedCard shiv = PredictedCard.Create(CanonicalModels.Card<Shiv>(), owner);
             if (upgraded)
                 shiv.Upgrade();
             shivs.Add(shiv);

--- a/src/Prediction/CorePowerSupport.cs
+++ b/src/Prediction/CorePowerSupport.cs
@@ -425,9 +425,12 @@ internal static class CorePowerSupport
             int poison = combat.GetAmount<PoisonPower>(creature);
             if (poison <= 0 || simulator.State.GetCreature(creature).IsDead)
                 continue;
-            int accelerant = combat.GetOpponentsOf(creature)
-                .Where(opponent => simulator.State.GetCreature(opponent).IsAlive)
-                .Sum(opponent => combat.GetAmount<AccelerantPower>(opponent));
+            int accelerant = 0;
+            foreach (Creature opponent in combat.GetOpponentsOf(creature))
+            {
+                if (simulator.State.GetCreature(opponent).IsAlive)
+                    accelerant += combat.GetAmount<AccelerantPower>(opponent);
+            }
             int triggerCount = Math.Min(poison, 1 + accelerant);
             for (int trigger = 0; trigger < triggerCount; trigger++)
             {

--- a/src/Prediction/KnowledgeDemonChoiceSupport.cs
+++ b/src/Prediction/KnowledgeDemonChoiceSupport.cs
@@ -1,3 +1,4 @@
+using CombatSolver.Engine.Common;
 using MegaCrit.Sts2.Core.Entities.Cards;
 using MegaCrit.Sts2.Core.Entities.Creatures;
 using MegaCrit.Sts2.Core.Models;
@@ -16,9 +17,9 @@ internal static class KnowledgeDemonChoiceSupport
 {
     private static readonly string[][] OptionsByCounter =
     [
-        [ModelDb.Card<Disintegration>().Id.Entry, ModelDb.Card<MindRot>().Id.Entry],
-        [ModelDb.Card<Disintegration>().Id.Entry, ModelDb.Card<Sloth>().Id.Entry],
-        [ModelDb.Card<Disintegration>().Id.Entry, ModelDb.Card<WasteAway>().Id.Entry],
+        [CanonicalModels.Card<Disintegration>().Id.Entry, CanonicalModels.Card<MindRot>().Id.Entry],
+        [CanonicalModels.Card<Disintegration>().Id.Entry, CanonicalModels.Card<Sloth>().Id.Entry],
+        [CanonicalModels.Card<Disintegration>().Id.Entry, CanonicalModels.Card<WasteAway>().Id.Entry],
     ];
 
     public static void Resolve(
@@ -52,13 +53,13 @@ internal static class KnowledgeDemonChoiceSupport
         if (!optionIds.Contains(selectedId, StringComparer.Ordinal))
             throw new InvalidOperationException($"知识恶魔当前不能选择 {selectedId}。");
 
-        if (selectedId == ModelDb.Card<Disintegration>().Id.Entry)
+        if (selectedId == CanonicalModels.Card<Disintegration>().Id.Entry)
             combat.Apply<DisintegrationPower>(player, 6 + counter, player);
-        else if (selectedId == ModelDb.Card<MindRot>().Id.Entry)
+        else if (selectedId == CanonicalModels.Card<MindRot>().Id.Entry)
             combat.Apply<MindRotPower>(player, 1, player);
-        else if (selectedId == ModelDb.Card<Sloth>().Id.Entry)
+        else if (selectedId == CanonicalModels.Card<Sloth>().Id.Entry)
             combat.Apply<SlothPower>(player, 3, player);
-        else if (selectedId == ModelDb.Card<WasteAway>().Id.Entry)
+        else if (selectedId == CanonicalModels.Card<WasteAway>().Id.Entry)
             combat.Apply<WasteAwayPower>(player, 1, player);
         else
             throw new InvalidOperationException($"知识恶魔诅咒 {selectedId} 没有模拟效果。");

--- a/src/Prediction/MonsterSpawnSupport.cs
+++ b/src/Prediction/MonsterSpawnSupport.cs
@@ -1,3 +1,4 @@
+using CombatSolver.Engine.Common;
 using MegaCrit.Sts2.Core.Combat;
 using MegaCrit.Sts2.Core.Entities.Creatures;
 using MegaCrit.Sts2.Core.Models;
@@ -32,7 +33,7 @@ internal static class MonsterSpawnSupport
         Action<T>? configure = null)
         where T : MonsterModel
     {
-        T monster = (T)ModelDb.Monster<T>().ToMutable();
+        T monster = (T)CanonicalModels.Monster<T>().ToMutable();
         configure?.Invoke(monster);
         return combat.CreatePredictedMonster(simulator, monster, CombatSide.Enemy, slot);
     }

--- a/src/Prediction/PersistentPowerSupport.cs
+++ b/src/Prediction/PersistentPowerSupport.cs
@@ -274,7 +274,7 @@ internal static class PersistentPowerSupport
             && !state.ExhaustPile.Cards.Contains(card));
         if (!hasUnexhaustedBlade)
         {
-            PredictedCard created = PredictedCard.Create(ModelDb.Card<SovereignBlade>(), player);
+            PredictedCard created = PredictedCard.Create(CanonicalModels.Card<SovereignBlade>(), player);
             ((SovereignBlade)created.MutablePreview).CreatedThroughForge = true;
             simulator.AddGeneratedCardToCombat(
                 created,

--- a/src/Prediction/PotionOnUseSupport.cs
+++ b/src/Prediction/PotionOnUseSupport.cs
@@ -236,7 +236,7 @@ internal static class PotionOnUseSupport
             {
                 List<PredictedCard> souls = new(value.DynamicVars.Cards.IntValue);
                 for (int index = 0; index < value.DynamicVars.Cards.IntValue; index++)
-                    souls.Add(PredictedCard.Create(ModelDb.Card<Soul>(), PlayerTarget()));
+                    souls.Add(PredictedCard.Create(CanonicalModels.Card<Soul>(), PlayerTarget()));
                 simulator.AddGeneratedCardsToCombat(
                     souls,
                     PileType.Hand,

--- a/src/Prediction/RelicPredictionStateSupport.cs
+++ b/src/Prediction/RelicPredictionStateSupport.cs
@@ -142,7 +142,7 @@ internal static class RelicPredictionStateSupport
         {
             case BeatingRemnant value:
                 simulator.StateStore
-                    .Get((AbstractModel)value, () => new BeatingRemnantPredictionState(value))
+                    .Get(value, static model => new BeatingRemnantPredictionState(model))
                     .DamageReceivedThisTurn = 0m;
                 break;
             case BrilliantScarf value:
@@ -150,7 +150,7 @@ internal static class RelicPredictionStateSupport
                 break;
             case DemonTongue value:
                 simulator.StateStore
-                    .Get((AbstractModel)value, () => new DemonTonguePredictionState(value))
+                    .Get(value, static model => new DemonTonguePredictionState(model))
                     .TriggeredThisTurn = false;
                 break;
             case Kunai value:
@@ -159,7 +159,7 @@ internal static class RelicPredictionStateSupport
             case MusicBox value:
                 {
                     MusicBoxPredictionState state = simulator.StateStore
-                        .Get((AbstractModel)value, () => new MusicBoxPredictionState(value));
+                        .Get(value, static model => new MusicBoxPredictionState(model));
                     state.WasUsedThisTurn = false;
                     state.CardBeingPlayed = null;
                     break;
@@ -170,7 +170,7 @@ internal static class RelicPredictionStateSupport
             case RainbowRing value:
                 {
                     RainbowRingPredictionState state = simulator.StateStore
-                        .Get((AbstractModel)value, () => new RainbowRingPredictionState(value));
+                        .Get(value, static model => new RainbowRingPredictionState(model));
                     state.AttacksPlayedThisTurn = 0;
                     state.SkillsPlayedThisTurn = 0;
                     state.PowersPlayedThisTurn = 0;
@@ -179,7 +179,7 @@ internal static class RelicPredictionStateSupport
                 }
             case Regalite value:
                 simulator.StateStore
-                    .Get((AbstractModel)value, () => new RegalitePredictionState(value))
+                    .Get(value, static model => new RegalitePredictionState(model))
                     .UsedThisTurn = false;
                 break;
             case Shuriken value:
@@ -204,7 +204,7 @@ internal static class RelicPredictionStateSupport
             case PaelsLegion value:
                 {
                     PaelsLegionPredictionState state = simulator.StateStore
-                        .Get((AbstractModel)value, () => new PaelsLegionPredictionState(value));
+                        .Get(value, static model => new PaelsLegionPredictionState(model));
                     state.Cooldown--;
                     state.TriggeredBlockLastTurn = false;
                     break;

--- a/src/Search/CardChoiceResolution.cs
+++ b/src/Search/CardChoiceResolution.cs
@@ -138,10 +138,10 @@ internal static partial class CardChoiceSupport
     {
         CardModel replacement = source switch
         {
-            Begone => ModelDb.Card<MinionStrike>(),
-            Charge => ModelDb.Card<MinionDiveBomb>(),
-            Guards => ModelDb.Card<MinionSacrifice>(),
-            Seance => ModelDb.Card<Soul>(),
+            Begone => CanonicalModels.Card<MinionStrike>(),
+            Charge => CanonicalModels.Card<MinionDiveBomb>(),
+            Guards => CanonicalModels.Card<MinionSacrifice>(),
+            Seance => CanonicalModels.Card<Soul>(),
             _ => throw new InvalidOperationException($"卡牌 {source.Id.Entry} 没有选牌变换定义。"),
         };
         bool upgrade = source.IsUpgraded && source is Begone or Charge or Guards;

--- a/src/Search/SimulatedCombatState.AutoPlay.cs
+++ b/src/Search/SimulatedCombatState.AutoPlay.cs
@@ -50,7 +50,7 @@ internal sealed partial class SimulatedCombatState
             if (!AutoPlayWithChoice(
                     simulator,
                     card,
-                    MegaCrit.Sts2.Core.Models.ModelDb.Power<MegaCrit.Sts2.Core.Models.Powers.MayhemPower>().Id.Entry,
+                    CanonicalModels.Power<MegaCrit.Sts2.Core.Models.Powers.MayhemPower>().Id.Entry,
                     $"{card.Preview.Id.Entry}+{card.Preview.CurrentUpgradeLevel}#{index}",
                     choices,
                     processedEnemyDeaths))

--- a/src/Search/SimulatedCombatState.CardLifecycle.cs
+++ b/src/Search/SimulatedCombatState.CardLifecycle.cs
@@ -43,7 +43,7 @@ internal sealed partial class SimulatedCombatState
     public T AddPowerInstance<T>(Creature owner, int amount, Creature? applier = null)
         where T : PowerModel
     {
-        T power = (T)ModelDb.Power<T>().ToMutable();
+        T power = (T)CanonicalModels.Power<T>().ToMutable();
         power._owner = owner;
         power._applier = applier;
         power._target = owner;
@@ -65,7 +65,7 @@ internal sealed partial class SimulatedCombatState
         Creature osty;
         if (created)
         {
-            Osty model = (Osty)ModelDb.Monster<Osty>().ToMutable();
+            Osty model = (Osty)CanonicalModels.Monster<Osty>().ToMutable();
             osty = CreatePredictedMonster(simulator, model, player.Creature.Side, slot: null);
             osty.PetOwner = player;
             AddPredictedMonster(osty);
@@ -374,8 +374,8 @@ internal sealed partial class SimulatedCombatState
                 continue;
             CardModel? canonical = power switch
             {
-                InfiniteBladesPower => ModelDb.Card<Shiv>(),
-                SentryModePower => ModelDb.Card<SweepingGaze>(),
+                InfiniteBladesPower => CanonicalModels.Card<Shiv>(),
+                SentryModePower => CanonicalModels.Card<SweepingGaze>(),
                 _ => null,
             };
             if (canonical == null)

--- a/src/Search/SimulatedCombatState.CardPowerHistory.cs
+++ b/src/Search/SimulatedCombatState.CardPowerHistory.cs
@@ -105,7 +105,7 @@ internal sealed partial class SimulatedCombatState
                 continue;
             SlowPower mutable = (SlowPower)GetOrCreatePower(
                 creature,
-                ModelDb.Power<SlowPower>(),
+                CanonicalModels.Power<SlowPower>(),
                 slow.Applier);
             mutable.DynamicVars["SlowAmount"].BaseValue++;
             mutable.DynamicVars["DisplayAmount"].BaseValue =

--- a/src/Search/SimulatedCombatState.Potions.cs
+++ b/src/Search/SimulatedCombatState.Potions.cs
@@ -118,12 +118,22 @@ internal sealed partial class SimulatedCombatState
     private void AppendPotionFingerprint(ref StateFingerprintBuilder fingerprint)
     {
         fingerprint.Add('p');
-        foreach (Player player in Players.OrderBy(player => player.NetId))
+        // 单人战斗是唯一支持的模式；只有多名玩家时才需要按 NetId 排序，避免每次快照都走 LINQ。
+        if (Players.Count == 1)
         {
-            fingerprint.Add((long)player.NetId);
-            fingerprint.Add(PotionSlotCount(player));
-            for (int slot = 0; slot < PotionSlotCount(player); slot++)
-                fingerprint.Add(GetPotionAtSlot(player, slot)?.Id.Entry ?? "-");
+            AppendPlayerPotionFingerprint(ref fingerprint, Players[0]);
+            return;
         }
+        foreach (Player player in Players.OrderBy(player => player.NetId))
+            AppendPlayerPotionFingerprint(ref fingerprint, player);
+    }
+
+    private void AppendPlayerPotionFingerprint(ref StateFingerprintBuilder fingerprint, Player player)
+    {
+        fingerprint.Add((long)player.NetId);
+        int slotCount = PotionSlotCount(player);
+        fingerprint.Add(slotCount);
+        for (int slot = 0; slot < slotCount; slot++)
+            fingerprint.Add(GetPotionAtSlot(player, slot)?.Id.Entry ?? "-");
     }
 }

--- a/src/Search/SimulatedCombatState.RelicTurnStart.cs
+++ b/src/Search/SimulatedCombatState.RelicTurnStart.cs
@@ -17,13 +17,43 @@ namespace CombatSolver;
 
 internal sealed partial class SimulatedCombatState
 {
+    /// <summary>
+    /// 每个回合开始都要枚举一遍参与方的遗物；用普通循环替代 SelectMany/Where/Contains，
+    /// 避免迭代器、闭包与 ForkableList 的装箱枚举器分配。顺序与原实现一致：按玩家顺序、再按遗物顺序。
+    /// </summary>
+    private List<RelicModel> RelicsParticipatingInSideTurn(IReadOnlyList<Creature> participants)
+    {
+        List<RelicModel> relics = [];
+        for (int playerIndex = 0; playerIndex < Players.Count; playerIndex++)
+        {
+            IReadOnlyList<RelicModel> owned = RelicsOf(Players[playerIndex]);
+            for (int relicIndex = 0; relicIndex < owned.Count; relicIndex++)
+            {
+                RelicModel relic = owned[relicIndex];
+                if (relic.IsMelted)
+                    continue;
+                Creature ownerCreature = relic.Owner.Creature;
+                bool participating = false;
+                for (int index = 0; index < participants.Count; index++)
+                {
+                    if (ReferenceEquals(participants[index], ownerCreature))
+                    {
+                        participating = true;
+                        break;
+                    }
+                }
+                if (participating)
+                    relics.Add(relic);
+            }
+        }
+        return relics;
+    }
+
     public void PrepareRelicsBeforeSideTurnStart(
         CombatPredictionSimulator simulator,
         IReadOnlyList<Creature> participants)
     {
-        foreach (RelicModel relic in Players
-                     .SelectMany(RelicsOf)
-                     .Where(relic => !relic.IsMelted && participants.Contains(relic.Owner.Creature)))
+        foreach (RelicModel relic in RelicsParticipatingInSideTurn(participants))
         {
             RelicPredictionStateSupport.ResetBeforeSideTurnStart(simulator, relic);
             switch (relic)
@@ -234,9 +264,7 @@ internal sealed partial class SimulatedCombatState
         CombatSide side,
         IReadOnlyList<Creature> participants)
     {
-        foreach (RelicModel relic in Players
-                     .SelectMany(RelicsOf)
-                     .Where(relic => !relic.IsMelted && participants.Contains(relic.Owner.Creature)))
+        foreach (RelicModel relic in RelicsParticipatingInSideTurn(participants))
         {
             int turn = GetPlayerTurnNumber(relic.Owner);
             RelicPredictionStateSupport.ResetAfterSideTurnStart(simulator, relic, turn);

--- a/src/Search/SimulatedCombatState.cs
+++ b/src/Search/SimulatedCombatState.cs
@@ -670,7 +670,7 @@ internal sealed partial class SimulatedCombatState
         T? power = GetPower<T>(target);
         if (power?.SkipNextDurationTick == true)
         {
-            T mutable = (T)GetOrCreatePower(target, ModelDb.Power<T>(), power.Applier);
+            T mutable = (T)GetOrCreatePower(target, CanonicalModels.Power<T>(), power.Applier);
             mutable.SkipNextDurationTick = false;
             return;
         }
@@ -684,7 +684,7 @@ internal sealed partial class SimulatedCombatState
         int current = GetAmount<T>(target);
         if (current == amount)
             return;
-        T canonical = ModelDb.Power<T>();
+        T canonical = CanonicalModels.Power<T>();
         PowerModel simulated = GetOrCreatePower(target, canonical, null);
         int previousAmount = simulated._amount;
         simulated._amount = Math.Clamp(amount, -999_999_999, 999_999_999);
@@ -787,7 +787,7 @@ internal sealed partial class SimulatedCombatState
         RecordStolenGold(simulator, stolen);
         ThieveryPower simulated = (ThieveryPower)GetOrCreatePower(
             owner,
-            ModelDb.Power<ThieveryPower>(),
+            CanonicalModels.Power<ThieveryPower>(),
             source.Applier);
         simulated._target = source.Target;
         simulated.DynamicVars.Gold.BaseValue += stolen;
@@ -824,7 +824,7 @@ internal sealed partial class SimulatedCombatState
     private static T CreatePowerForApplication<T>(Creature owner, Creature target, Creature? applier)
         where T : PowerModel
     {
-        T incoming = PredictionUtils.CloneModelForSimulation(ModelDb.Power<T>());
+        T incoming = PredictionUtils.CloneModelForSimulation(CanonicalModels.Power<T>());
         incoming._owner = owner;
         incoming._applier = applier;
         incoming._target = target;
@@ -1101,28 +1101,12 @@ internal sealed partial class SimulatedCombatState
             if (ownerPlayer.Osty is { } osty)
             {
                 (_creatureAttacksThisTurn ??= [])[osty] = 0;
-                if (_poweredAttackHitsThisTurn != null)
-                {
-                    foreach ((Creature Dealer, Creature Receiver) key in _poweredAttackHitsThisTurn.Keys
-                                 .Where(key => key.Dealer == osty)
-                                 .ToArray())
-                    {
-                        _poweredAttackHitsThisTurn.Remove(key);
-                    }
-                }
+                RemovePoweredAttackHitsDealtBy(osty);
             }
         }
         _doomAppliersThisTurn?.Remove(owner);
         _unblockedDamageThisTurn?.Remove(owner);
-        if (_poweredAttackHitsThisTurn != null)
-        {
-            foreach ((Creature Dealer, Creature Receiver) key in _poweredAttackHitsThisTurn.Keys
-                         .Where(key => key.Dealer == owner)
-                         .ToArray())
-            {
-                _poweredAttackHitsThisTurn.Remove(key);
-            }
-        }
+        RemovePoweredAttackHitsDealtBy(owner);
         TickDuration<BlurPower>(owner);
         if (GetAmount<DrawCardsNextTurnPower>(owner) > 0)
             SetAmount<DrawCardsNextTurnPower>(owner, 0);
@@ -1152,12 +1136,28 @@ internal sealed partial class SimulatedCombatState
 
     }
 
+    private void RemovePoweredAttackHitsDealtBy(Creature dealer)
+    {
+        if (_poweredAttackHitsThisTurn is not { Count: > 0 })
+            return;
+        List<(Creature Dealer, Creature Receiver)>? stale = null;
+        foreach ((Creature Dealer, Creature Receiver) key in _poweredAttackHitsThisTurn.Keys)
+        {
+            if (key.Dealer == dealer)
+                (stale ??= []).Add(key);
+        }
+        if (stale is null)
+            return;
+        foreach ((Creature Dealer, Creature Receiver) key in stale)
+            _poweredAttackHitsThisTurn.Remove(key);
+    }
+
     public bool ConsumeRitualApplicationDelay(Creature owner)
     {
         RitualPower? ritual = GetPower<RitualPower>(owner);
         if (ritual is not { Amount: > 0 })
             return false;
-        RitualPower mutable = (RitualPower)GetOrCreatePower(owner, ModelDb.Power<RitualPower>(), ritual.Applier);
+        RitualPower mutable = (RitualPower)GetOrCreatePower(owner, CanonicalModels.Power<RitualPower>(), ritual.Applier);
         if (!mutable._wasJustAppliedByEnemy)
             return false;
         mutable._wasJustAppliedByEnemy = false;
@@ -1910,7 +1910,8 @@ internal sealed partial class SimulatedCombatState
         ulong dynamicFirst = 0;
         ulong dynamicSecond = 0;
         int dynamicCount = 0;
-        foreach (var dynamicVar in power.DynamicVars)
+        // DynamicVarSet.GetEnumerator 会装箱内部字典的枚举器；直接枚举已 publicize 的 _vars。
+        foreach (var dynamicVar in power.DynamicVars._vars)
         {
             if (!SemanticStateFieldPolicy.IsSemantic(power, dynamicVar.Key, dynamicVar.Value))
                 continue;
@@ -2254,7 +2255,7 @@ internal sealed partial class SimulatedCombatState
     }
 
     public T CreateCard<T>(Player owner) where T : CardModel
-        => (T)PredictionUtils.CreateCard(ModelDb.Card<T>(), owner);
+        => (T)PredictionUtils.CreateCard(CanonicalModels.Card<T>(), owner);
     public CardModel CreateCard(CardModel canonicalCard, Player owner)
         => PredictionUtils.CreateCard(canonicalCard, owner);
     public CardModel CloneCard(CardModel mutableCard)

--- a/src/Search/StrategicEffectModel.cs
+++ b/src/Search/StrategicEffectModel.cs
@@ -36,12 +36,15 @@ internal readonly record struct StrategicEffectVector(
 {
     public static StrategicEffectVector Zero { get; } = new(0, 0, 0, 0, 0);
 
-    public int RetentionValue => SaturatingSum(
-        DamagePotential,
-        PreventionPotential,
-        ResourcePotential,
-        CardAccessPotential,
-        ScalingPotential);
+    // 快照与剪枝每个节点都读这个值；固定五项直接累加，不走 params 数组分配。
+    public int RetentionValue => (int)Math.Clamp(
+        (long)DamagePotential
+            + PreventionPotential
+            + ResourcePotential
+            + CardAccessPotential
+            + ScalingPotential,
+        0L,
+        int.MaxValue);
 
     public static StrategicEffectVector operator +(
         StrategicEffectVector left,
@@ -177,16 +180,17 @@ internal readonly record struct StrategicEffectContext(
             bool hasDebuffDynamicVar = false;
             if ((needsBlockSkillCount && cardType == CardType.Skill) || needsDebuffCount)
             {
-                foreach (KeyValuePair<string, MegaCrit.Sts2.Core.Localization.DynamicVars.DynamicVar> dynamicVar
-                         in card.DynamicVars)
+                // DynamicVarSet 的 GetEnumerator 会把内部 Dictionary 的结构体枚举器装箱，
+                // 每张牌每次快照都要跑一遍；直接枚举其（已 publicize 的）内部字典。
+                foreach (KeyValuePair<string, MegaCrit.Sts2.Core.Localization.DynamicVars.DynamicVar> dynamicVar in card.DynamicVars._vars)
                 {
-                    string key = dynamicVar.Key;
-                    if (needsBlockSkillCount && !hasBlockDynamicVar && cardType == CardType.Skill)
-                        hasBlockDynamicVar = IsBlockDynamicVar(key);
-                    if (needsDebuffCount && !hasDebuffDynamicVar)
-                        hasDebuffDynamicVar = IsDebuffDynamicVar(key);
-                    if ((!needsDebuffCount || hasDebuffDynamicVar)
-                        && (!needsBlockSkillCount || cardType != CardType.Skill || hasBlockDynamicVar))
+                    if (ObserveDynamicVarKey(
+                            dynamicVar.Key,
+                            cardType,
+                            needsBlockSkillCount,
+                            needsDebuffCount,
+                            ref hasBlockDynamicVar,
+                            ref hasDebuffDynamicVar))
                     {
                         break;
                     }
@@ -302,6 +306,23 @@ internal readonly record struct StrategicEffectContext(
         => matchingCards == 0
             ? 0
             : Math.Max(1, (int)Math.Ceiling((double)matchingCards * reachableCards / deckSize));
+
+    /// <summary>返回 true 表示需要的标记都已确定，可以停止扫描。</summary>
+    private static bool ObserveDynamicVarKey(
+        string key,
+        CardType cardType,
+        bool needsBlockSkillCount,
+        bool needsDebuffCount,
+        ref bool hasBlockDynamicVar,
+        ref bool hasDebuffDynamicVar)
+    {
+        if (needsBlockSkillCount && !hasBlockDynamicVar && cardType == CardType.Skill)
+            hasBlockDynamicVar = IsBlockDynamicVar(key);
+        if (needsDebuffCount && !hasDebuffDynamicVar)
+            hasDebuffDynamicVar = IsDebuffDynamicVar(key);
+        return (!needsDebuffCount || hasDebuffDynamicVar)
+            && (!needsBlockSkillCount || cardType != CardType.Skill || hasBlockDynamicVar);
+    }
 
     private static bool IsDebuffDynamicVar(string key)
         => key.Contains("Weak", StringComparison.OrdinalIgnoreCase)

--- a/src/UI/SolverOverlaySnapshot.cs
+++ b/src/UI/SolverOverlaySnapshot.cs
@@ -305,20 +305,37 @@ internal sealed record SolverOverlaySnapshot(
             action.ReplayCount);
     }
 
+    // ModelDb.AllCards 是惰性 LINQ 查询，每次枚举都重跑 SelectMany/Distinct 并分配整套 HashSet；
+    // 进度刷新会对路线里每个动作各查一次。按牌 Id 建一次只读索引即可（ModelDb 在 Init 后不变）。
+    private static Dictionary<string, SolverOverlayActionVisualKind>? _visualKindsByCardId;
+
     private static SolverOverlayActionVisualKind ResolveVisualKind(PlanAction action)
     {
         if (action.Kind == PlanActionKind.UsePotion)
             return SolverOverlayActionVisualKind.Potion;
-        CardModel? card = ModelDb.AllCards.FirstOrDefault(candidate =>
-            candidate.Id.Entry.Equals(action.CardId, StringComparison.Ordinal));
-        return card?.Type.ToString() switch
+        Dictionary<string, SolverOverlayActionVisualKind> index =
+            _visualKindsByCardId ??= BuildVisualKindIndex();
+        return action.CardId is { } cardId && index.TryGetValue(cardId, out SolverOverlayActionVisualKind kind)
+            ? kind
+            : SolverOverlayActionVisualKind.Other;
+    }
+
+    private static Dictionary<string, SolverOverlayActionVisualKind> BuildVisualKindIndex()
+    {
+        Dictionary<string, SolverOverlayActionVisualKind> index = new(StringComparer.Ordinal);
+        foreach (CardModel card in ModelDb.AllCards)
         {
-            "Attack" => SolverOverlayActionVisualKind.Attack,
-            "Skill" => SolverOverlayActionVisualKind.Skill,
-            "Power" => SolverOverlayActionVisualKind.Power,
-            "Curse" or "Status" => SolverOverlayActionVisualKind.Negative,
-            _ => SolverOverlayActionVisualKind.Other,
-        };
+            // 与原实现 FirstOrDefault 一致：同名 Id 只保留首个匹配。
+            index.TryAdd(card.Id.Entry, card.Type.ToString() switch
+            {
+                "Attack" => SolverOverlayActionVisualKind.Attack,
+                "Skill" => SolverOverlayActionVisualKind.Skill,
+                "Power" => SolverOverlayActionVisualKind.Power,
+                "Curse" or "Status" => SolverOverlayActionVisualKind.Negative,
+                _ => SolverOverlayActionVisualKind.Other,
+            });
+        }
+        return index;
     }
 
     private static string FormatTurnStartChoice(PlanCardChoice choice)


### PR DESCRIPTION
## 动机

用 `dotnet-trace`（`dotnet-sampled-thread-time` + `gc-verbose`）对固定机甲骑士首轮搜索采样。普通 GC 下 GC 暂停约占墙钟 22%，NoGC 下则表现为搜索中阻塞回收，所以分配量是本机的主杠杆。分配采样里排得上号、且与语义无关的来源：

- `ModelDb.Power/Card/…<T>()` 每次调用都 `new ModelId(SlugifyCategory, Slugify)`，两次 `StringHelper.Slugify` 共三次 `Regex.Replace` 再查字典；`SetAmount`、`Tick`、生成牌等热路径每次都调（CPU 采样约 6%）。`ModelDb.Init` 只在 `OneTimeInitialization` 调用一次，之后规范实例不再变化。
- `DynamicVarSet.GetEnumerator` 只是返回 `_vars.GetEnumerator()`，把内部字典的结构体枚举器装箱；每张牌每次快照都跑一遍（分配约 4.2%）。
- `StrategicEffectVector.RetentionValue` 走 `params int[]`，每个节点快照与剪枝都读（`Int32[]` 约 3.9%）。
- `PredictionStateStore.ReadEntries<T>` 每个动作后整表扫描并 `ToArray`，绝大多数调用结果为空。
- `MethodMirrorRegistry.Lookup` 未命中注册表后再走 `ConcurrentDictionary<Type, Lazy<>>` 两层。
- 回合开始遗物枚举、攻击结果展平、毒触发求和、药水指纹、UI 路线图标等处的 LINQ 与闭包。

## 改动

全部语义不变，不触碰 Beam、评分、剪枝、RNG 与 Fork 结构。

- 新增 `Engine/Common/CanonicalModels`：按封闭泛型缓存 `ModelDb` 规范实例，首次访问时填充，不放类型初始化器。
- `PredictionStateStore` 增加按状态类型计数，`ReadEntries<T>` 无条目时直接返回；计数在 `Get` 两条路径、`Remove`、`RemapModel`（同类型移键，计数不变）、`Fork` 维护。
- `MethodMirrorRegistry.Lookup` 增加写时复制的已解析快照，读取无锁；`AllowInference` 变更时清空。
- `RetentionValue` 固定五项相加并 clamp 到 `[0, int.MaxValue]`，与原 `SaturatingSum` 一致。
- `StrategicEffectContext.Build`、`SimulatedCombatState.AddPower` 直接枚举已 publicize 的 `DynamicVars._vars`。
- 回合开始遗物过滤改普通循环，顺序与原 `SelectMany/Where` 一致；`Creature` 未重写 `Equals`，`ReferenceEquals` 与原 `Contains` 等价。
- 攻击结果展平、毒触发求和、`_poweredAttackHitsThisTurn` 清理、单玩家药水指纹、遗物状态工厂改 `Get<TModel, TState>` 重载加静态 lambda。
- `SolverOverlaySnapshot.ResolveVisualKind` 按牌 Id 建一次索引；`ModelDb.AllCards` 是惰性 LINQ，原实现每次进度刷新对路线里每个动作各重跑一遍 `SelectMany/Distinct`。

## 实测

固定机甲骑士首轮（与 `MECHA-MEMORY-FULL-AUTO-FINAL-070` 同参数，`StopAfterInitialSolverResultAssertion`，并行 4，`EnableNoGcRegionForTest 0`，不开 `MeasureSearchPhases`）。两平台上两版本的展开、转移、分数、掉血、结束回合全部一致。

Windows 11，i7-12700H / 16 GB，10827 展开 / 96967 转移 / 分数 10000197968 / 掉血 28：

| 版本 | 耗时（两次） | 工作线程分配 | GC 暂停 |
| --- | --- | ---: | ---: |
| 基线 469bf8e | 29.52 / 29.47 s | 7.40 GB | 6.6 s |
| 本 PR | 26.21 / 26.92 s | 6.20 GB | 6.2 s |

macOS，Apple M4 / 16 GB，ABBA 交替各两轮，14501 展开 / 143838 转移 / 分数 10000197968 / 掉血 28：

| 版本 | 耗时（两次） | 工作线程分配 |
| --- | --- | ---: |
| 基线 469bf8e | 48.13 / 49.20 s | 10.40 GB |
| 本 PR | 43.20 / 43.53 s | 9.44 GB |

墙钟约 −10%，分配 −9% 到 −16%。NoGC 开启时分配减少直接换成更少的搜索中阻塞回收，但受系统内存波动影响未单独量化。

## 验证

- `tools/verify-refactor-boundaries.ps1`：`REFACTOR_BOUNDARIES_OK`。
- 哨兵全部 Passed：`FAIRY-AUTOMATIC-RESCUE-FINAL2-0150`（药水 + 增量校验）、`RINGING-HAVOC-AUTOPLAY-0160-FINAL`（Power + 增量校验）、`POST0201-BRAND-POST-CHOICE-POWER-FORK-FINAL`（Power Fork）、`MECHA-MEMORY-FULL-AUTO`（去掉时序阈值：第 3 回合精确续用、第 7 回合结束、0 次非预期重算）。
- `BUILTIN-LISTENER-IDENTITY-533` 在基线 DLL 上同样 Failed（1340 展开 / 5747 转移 / 同分数 / 跨过 1 次洗牌，期望"洗牌次数 ≥ 2"），是 0.28.1 上既有的矩阵期望过期，不是本 PR 引入；本 PR 未改 `TEST_MATRIX.md`，请作者裁决。

## 已知边界

- 若第三方 Mod 在 `ModelDb.Init` 之后调用 `ModelDb.Inject/Remove` 替换规范模型，`CanonicalModels` 不会感知。游戏本身不调用这两个方法，当前也没有已知 Mod 这样做；需要的话可以加一个清缓存入口。
- UI 图标索引在首次渲染时建立，之后注入的牌只会显示为"其他"，不影响搜索。

## 未包含

Fork 的结构性拷贝（`SimCardPile.Fork` 逐牌包装、Power 全量深克隆、hook listener 重建）仍占剩余分配的大头，改动面大、涉及别名与写时复制安全，不在本 PR 范围。
