### PR TITLE
fix: NoGC 区域未建立或建立失败时不再把并行度锁死在 2

### DIFF
--- a/src/Runtime/SearchGcPolicy.cs
+++ b/src/Runtime/SearchGcPolicy.cs
@@ -429,9 +429,7 @@ internal static class SearchGcPolicy
                                 noGcRegionBudgetBytes,
                                 noGcRegionLohBudgetBytes);
                             NoGcRegionStartOutcome startOutcome = effectiveBudget.CanStart
-                                ? TryStartNoGcRegion(
-                                    effectiveBudget.TotalBytes,
-                                    effectiveBudget.LohBytes)
+                                ? TryStartNoGcRegionWithSizeFallback(ref effectiveBudget)
                                 : NoGcRegionStartOutcome.SystemHeadroomInsufficient;
                             _noGcRegionActive = startOutcome == NoGcRegionStartOutcome.Started;
                             if (_noGcRegionActive)
@@ -482,7 +480,8 @@ internal static class SearchGcPolicy
                             }
                             else
                             {
-                                memoryPressureSignal.UseDefaultGcFallback();
+                                memoryPressureSignal.UseDefaultGcFallback(
+                                    IsSystemHeadroomOutcome(startOutcome));
                             }
                             _activeSearches++;
                             return new SearchScope(allocatedBytesAtEntry, memoryPressureSignal);
@@ -1496,7 +1495,7 @@ internal static class SearchGcPolicy
                     _noGcRegionLohBudgetBytes = 0;
                     _noGcRegionAllocatedBytesAtStart = 0;
                     RestoreLatencyModeLocked();
-                    signal.UseDefaultGcFallback();
+                    signal.UseDefaultGcFallback(systemHeadroomConstrained: false);
                 }
                 else
                 {
@@ -1508,9 +1507,7 @@ internal static class SearchGcPolicy
                     if (endNoGcRegion)
                     {
                         restartOutcome = effectiveBudget.CanStart
-                            ? TryStartNoGcRegion(
-                                effectiveBudget.TotalBytes,
-                                effectiveBudget.LohBytes)
+                            ? TryStartNoGcRegionWithSizeFallback(ref effectiveBudget)
                             : NoGcRegionStartOutcome.SystemHeadroomInsufficient;
                     }
                     _noGcRegionActive = restartOutcome == NoGcRegionStartOutcome.Started;
@@ -1527,7 +1524,7 @@ internal static class SearchGcPolicy
                         // The runtime may terminate a region for memory pressure or an external
                         // collection. Retrying the same reservation during this search recreates the
                         // failure loop, so fall back once and let the CLR collect normally.
-                        signal.UseDefaultGcFallback();
+                        signal.UseDefaultGcFallback(IsSystemHeadroomOutcome(restartOutcome));
                     }
                     else
                     {
@@ -1640,6 +1637,44 @@ internal static class SearchGcPolicy
             return NoGcRegionStartOutcome.RegionSizeUnsupported;
         }
     }
+
+    /// <summary>
+    /// 运行时对单个 No-GC 区域的 SOH 预留上限没有公开查询接口（macOS/regions GC 下远低于
+    /// 16 GB）。首次尝试遇到 totalSize 越界时按二分逐级缩小预算，直到成功或低于最小预算。
+    /// </summary>
+    private static NoGcRegionStartOutcome TryStartNoGcRegionWithSizeFallback(
+        ref EffectiveNoGcRegionBudget budget)
+    {
+        NoGcRegionStartOutcome outcome = TryStartNoGcRegion(budget.TotalBytes, budget.LohBytes);
+        int attempts = 0;
+        long requested = budget.TotalBytes;
+        while (outcome == NoGcRegionStartOutcome.RegionSizeUnsupported && attempts < 12)
+        {
+            long halved = budget.TotalBytes / 2;
+            if (halved < MinimumNoGcRegionBudgetBytes)
+                break;
+            attempts++;
+            budget = budget with
+            {
+                TotalBytes = halved,
+                LohBytes = Math.Min(budget.LohBytes, Math.Max(1, halved / 6)),
+                Capped = true,
+            };
+            outcome = TryStartNoGcRegion(budget.TotalBytes, budget.LohBytes);
+        }
+        if (attempts > 0)
+        {
+            Entry.Logger.Info(
+                $"[CombatSolver/Test] GC_NO_GC_REGION_SIZE_FALLBACK attempts={attempts} " +
+                $"requested={requested} final_budget={budget.TotalBytes} " +
+                $"final_loh_budget={budget.LohBytes} outcome={FormatStartOutcome(outcome)}");
+        }
+        return outcome;
+    }
+
+    private static bool IsSystemHeadroomOutcome(NoGcRegionStartOutcome outcome)
+        => outcome is NoGcRegionStartOutcome.SystemHeadroomInsufficient
+            or NoGcRegionStartOutcome.InsufficientMemory;
 
     private static string FormatStartOutcome(NoGcRegionStartOutcome outcome)
         => outcome switch

--- a/src/Runtime/SearchMemoryPressureSignal.cs
+++ b/src/Runtime/SearchMemoryPressureSignal.cs
@@ -76,12 +76,13 @@ internal sealed class SearchMemoryPressureSignal
     public bool IsEnabled => AllocationLimitBytes != long.MaxValue;
 
     /// <summary>
-    /// Keeps allocation-heavy waves narrow while a NoGC request is either active or has
-    /// fallen back because the runtime could not reserve safe system headroom. A user who
-    /// explicitly selects normal GC does not opt into this restriction.
+    /// Keeps allocation-heavy waves narrow only when the runtime reported that system
+    /// headroom itself is constrained. An active NoGC region already sizes waves against its
+    /// remaining allocation budget, and a region that merely failed for runtime size limits
+    /// says nothing about system memory, so neither case caps the user's requested parallelism.
     /// </summary>
     public bool ConservativeParallelismRequired
-        => IsEnabled || Volatile.Read(ref _conservativeParallelismRequired) != 0;
+        => Volatile.Read(ref _conservativeParallelismRequired) != 0;
 
     public long RemainingBytes
     {
@@ -133,7 +134,7 @@ internal sealed class SearchMemoryPressureSignal
         Volatile.Write(ref _systemMemoryLimitBytes, systemMemoryLimitBytes);
         Volatile.Write(ref _reclaimAndContinue, reclaimAndContinue);
         Volatile.Write(ref _unexpectedNoGcLossProbe, unexpectedNoGcLossProbe);
-        Volatile.Write(ref _conservativeParallelismRequired, 1);
+        Volatile.Write(ref _conservativeParallelismRequired, 0);
         Volatile.Write(ref _allocationLimitBytes, allocationLimitBytes);
     }
 
@@ -178,9 +179,9 @@ internal sealed class SearchMemoryPressureSignal
         Volatile.Write(ref _conservativeParallelismRequired, 0);
     }
 
-    public void UseDefaultGcFallback()
+    public void UseDefaultGcFallback(bool systemHeadroomConstrained)
     {
         Disable();
-        Volatile.Write(ref _conservativeParallelismRequired, 1);
+        Volatile.Write(ref _conservativeParallelismRequired, systemHeadroomConstrained ? 1 : 0);
     }
 }

--- a/src/Search/CombatBeamSolver.Phases.cs
+++ b/src/Search/CombatBeamSolver.Phases.cs
@@ -1334,15 +1334,16 @@ internal sealed partial class CombatBeamSolver
                             foreach (ExpansionWorkerOutcome outcome in outcomes)
                                 ObserveParentAllocation(outcome.AllocatedBytes);
                         }
-                        if (workerNodes.Count > 1 && waveStayedWithinReserve)
+                        if (workerNodes.Count > 1)
                         {
-                            parallelWaveCapacity = Math.Min(
-                                expansionParallelism,
-                                parallelWaveCapacity * 2);
-                        }
-                        else
-                        {
-                            parallelWaveCapacity = Math.Min(2, expansionParallelism);
+                            // Multiplicative increase / multiplicative decrease. Collapsing straight
+                            // back to two lanes after a single heavy wave left most of the user's
+                            // requested lanes idle for the following waves.
+                            parallelWaveCapacity = waveStayedWithinReserve
+                                ? Math.Min(expansionParallelism, parallelWaveCapacity * 2)
+                                : Math.Max(
+                                    Math.Min(2, expansionParallelism),
+                                    parallelWaveCapacity / 2);
                         }
                         ReclaimAfterCommittedWork("after_parallel_wave");
                     }
@@ -1391,8 +1392,7 @@ internal sealed partial class CombatBeamSolver
             foreach (SearchNode node in frontier)
                 CaptureContinuation(node);
             List<SearchNode> retainedAfterRound = [.. completed, .. frontier];
-            ReleaseDroppedSnapshots(ended, retainedAfterRound);
-            foreach (SearchNode candidate in retainedAfterRound)
+            ReleaseDroppedSnapshots(ended, retainedAfterRound);            foreach (SearchNode candidate in retainedAfterRound)
             {
                 ConsiderCompleteVictory(candidate);
                 ConsiderCurrentTurnCandidate(candidate);

--- a/src/Testing/UnattendedTestRunner.SearchPolicy.cs
+++ b/src/Testing/UnattendedTestRunner.SearchPolicy.cs
@@ -562,7 +562,7 @@ internal sealed partial class UnattendedTestRunner
                 memoryLoadBytesAtStart: 0,
                 systemMemoryLimitBytes: long.MaxValue,
                 _ => { });
-            fallbackSignal.UseDefaultGcFallback();
+            fallbackSignal.UseDefaultGcFallback(systemHeadroomConstrained: true);
             if (fallbackSignal.IsEnabled
                 || !fallbackSignal.ConservativeParallelismRequired)
             {


### PR DESCRIPTION
## 问题

`SearchMemoryPressureSignal.ConservativeParallelismRequired` 在 NoGC 开启时恒为 true（`IsEnabled ||`），`UseDefaultGcFallback` 也无条件置位。`CombatBeamSolver.Phases` 有三处据此把并行波次封顶在 2（lane 数、波次起始容量、`MemorySafeParallelWaveCapacity` 的回退分支）。于是只要 `TryStartNoGCRegion` 失败，用户设定的 8 路实际只跑 2 路：

- macOS（regions GC）：`TryStartNoGCRegion` 连 848 MB 都抛 `totalSize` 越界，日志 `GC_LATENCY policy=no_gc_region_unavailable reason=region_size_unsupported`，随后 `parallel_max_concurrency=2`。
- Windows：系统余量不足时同样回退到普通 GC，并携带同一个并行上限。

## 改动

- 保守并行只在 runtime 报告 `SystemHeadroomInsufficient` / `InsufficientMemory` 时启用；`UseDefaultGcFallback` 增加 `systemHeadroomConstrained` 参数。NoGC 已建立时波次仍由 `MemorySafeParallelWaveCapacity` 按剩余预算兜底，这一层没有改动。
- 波次分配超预留时容量减半而不是归 2（原逻辑对成功波次翻倍、失败归 2）。
- `TryStartNoGCRegion` 抛 `totalSize` 越界时按二分缩小预算重试，下限 `MinimumNoGcRegionBudgetBytes`（512 MB），记录 `GC_NO_GC_REGION_SIZE_FALLBACK` 日志。
- 同步更新 `UnattendedTestRunner.SearchPolicy` 中对回退语义的断言（低余量回退仍保持保守并行）。

## 实测

固定机甲骑士首轮，Silent，seed `BJCZX3J13PZJ`，8 路，High 预设，短搜 5 s / 深搜 60 s。工作量在同一配置下完全确定，两版本的展开、转移、路线、分数一致。

macOS，Apple M4 / 16 GB（NoGC 必然回退），默认配置（NoGC 开、16 GB）：

| 版本 | 耗时 | 并行峰值 | 展开 / 转移 |
| --- | ---: | ---: | --- |
| 基线 | 37.2 s | 2 | 14501 / 143838 |
| 本 PR | 27.2 s | 8 | 14501 / 143838 |

Windows 11，i7-12700H / 16 GB（NoGC 正常建立），官方 `MECHA-MEMORY-FULL-AUTO-FINAL-070` 命令三轮交替：基线均值 29.0 s，本 PR 均值 28.8 s，并行峰值均为 4，无可测量差异。本 PR 下没有出现 `fallback_latched=true` 或 `no_gc_region_lost=true`，每次区域耗尽都成功重建。

## 影响范围

只改变 NoGC 不可用时的并行准入，不改变搜索结果。NoGC 可用的平台上行为与之前相同。
