### PR TITLE
perf: Fork 与热路径去分配，搜索线程分配 −12%

### DIFF
--- a/src/Engine/Common/PredictionForking.cs
+++ b/src/Engine/Common/PredictionForking.cs
@@ -306,11 +306,32 @@ internal sealed class PredictionForkContext : IDisposable
     private const int IndexedLookupThreshold = 64;
     private const int HashLoadNumerator = 3;
     private const int HashLoadDenominator = 4;
-    private object[] _sources = ArrayPool<object>.Shared.Rent(40);
-    private object[] _forks = ArrayPool<object>.Shared.Rent(40);
+    private const int MinimumEntryCapacity = 40;
+
+    // 同一条搜索线程上相邻两次 Fork 登记的条目数几乎相同。用上一次的实际条目数预估容量，
+    // 让第一次 Register 就落在最终大小的条目数组与身份哈希索引上：既省掉线性扫描阶段的
+    // O(n²) 比较，也省掉跨过阈值后按 3/4 装载率反复重建索引的开销。命中与否只影响容量，
+    // 查找结果只由引用身份决定，因此映射结果与原实现逐条相同。
+    [ThreadStatic]
+    private static int _entryCountHint;
+
+    private object[] _sources;
+    private object[] _forks;
     private int[]? _buckets;
     private int _bucketResizeThreshold;
     private int _count;
+
+    public PredictionForkContext()
+    {
+        int capacity = Math.Max(MinimumEntryCapacity, _entryCountHint);
+        _sources = ArrayPool<object>.Shared.Rent(capacity);
+        _forks = ArrayPool<object>.Shared.Rent(capacity);
+        if (capacity >= IndexedLookupThreshold)
+            BuildHashIndex(BucketCountFor(capacity));
+    }
+
+    private static int BucketCountFor(int entryCapacity)
+        => checked((int)((long)entryCapacity * HashLoadDenominator / HashLoadNumerator) + 1);
 
     public void Register<T>(T source, T fork)
         where T : class
@@ -444,6 +465,7 @@ internal sealed class PredictionForkContext : IDisposable
 
     public void Dispose()
     {
+        _entryCountHint = _count;
         object[] sources = _sources;
         object[] forks = _forks;
         int[]? buckets = _buckets;

--- a/src/Engine/Common/PredictionForking.cs
+++ b/src/Engine/Common/PredictionForking.cs
@@ -16,6 +16,17 @@ internal interface ICombatPredictionHookListenerSource
     IReadOnlyList<MegaCrit.Sts2.Core.Models.AbstractModel> RunHookListeners { get; }
 }
 
+/// <summary>
+/// 由两段只读列表逐条同序拼接而成的监听表。hook 分发按段迭代，避免在最热循环里为每个元素
+/// 多付一次接口调用和一次分支（视图自己的索引器每次都要判断落在前缀还是后缀）。
+/// </summary>
+internal interface ISegmentedModelList
+{
+    IReadOnlyList<MegaCrit.Sts2.Core.Models.AbstractModel> Prefix { get; }
+
+    IReadOnlyList<MegaCrit.Sts2.Core.Models.AbstractModel> Suffix { get; }
+}
+
 internal interface ICombatPredictionRunSnapshot
 {
     MegaCrit.Sts2.Core.Entities.Cards.CardMultiplayerConstraint CardMultiplayerConstraint { get; }

--- a/src/Engine/Common/PredictionStateStore.cs
+++ b/src/Engine/Common/PredictionStateStore.cs
@@ -4,37 +4,22 @@ namespace CombatSolver.Engine.Common;
 
 internal sealed class PredictionStateStore
 {
-    private readonly Dictionary<(AbstractModel Model, Type StateType), StateEntry> _states;
-    private readonly Dictionary<AbstractModel, AbstractModel> _modelAliases;
+    // 条目原本被包在唯一实现 OwnedStateEntry 里，而 Read/Materialize 都只是把构造时收下的
+    // 那一个引用还回去。包装层每条目多一次分配（Fork 时按条目数成倍出现），直接存状态对象。
+    private readonly Dictionary<(AbstractModel Model, Type StateType), object> _states;
+    // 绝大多数 store 从来不登记别名，惰性建表让 ResolveModel 在空表上直接短路。
+    private Dictionary<AbstractModel, AbstractModel>? _modelAliases;
     // 每种状态类型当前的条目数。ReadEntries<TState> 是热路径（每次动作后都要同步 Power 数量），
     // 绝大多数调用时该类型根本没有条目，用计数直接短路，避免整表扫描。
     private readonly Dictionary<Type, int> _countByType = new();
 
     public PredictionStateStore()
-        : this(0, 0)
+        : this(0)
     {
     }
 
-    private PredictionStateStore(int stateCapacity, int aliasCapacity)
-    {
-        _states = new Dictionary<(AbstractModel Model, Type StateType), StateEntry>(stateCapacity);
-        _modelAliases = new Dictionary<AbstractModel, AbstractModel>(aliasCapacity);
-    }
-
-    private abstract class StateEntry
-    {
-        public abstract object Read();
-        public abstract object Materialize();
-    }
-
-    private sealed class OwnedStateEntry(object value) : StateEntry
-    {
-        private readonly object _value = value;
-
-        public override object Read() => _value;
-
-        public override object Materialize() => _value;
-    }
+    private PredictionStateStore(int stateCapacity)
+        => _states = new Dictionary<(AbstractModel Model, Type StateType), object>(stateCapacity);
 
     public TState Get<TState>(AbstractModel model)
         where TState : IPredictionStateForkable, new()
@@ -58,16 +43,15 @@ internal sealed class PredictionStateStore
         where TState : IPredictionStateForkable
     {
         var key = (ResolveModel(model), typeof(TState));
-        if (!_states.TryGetValue(key, out StateEntry? entry))
+        if (!_states.TryGetValue(key, out object? entry))
         {
-            object state = create(argument)
+            entry = create(argument)
                 ?? throw new InvalidOperationException("Prediction state factory returned null.");
-            entry = new OwnedStateEntry(state);
             _states[key] = entry;
             IncrementCount(typeof(TState));
         }
 
-        return (TState)entry.Materialize();
+        return (TState)entry;
     }
 
     public TState GetReadOnly<TState>(AbstractModel model, Func<TState> create)
@@ -86,15 +70,14 @@ internal sealed class PredictionStateStore
         where TState : IPredictionStateForkable
     {
         var key = (ResolveModel(model), typeof(TState));
-        if (!_states.TryGetValue(key, out StateEntry? entry))
+        if (!_states.TryGetValue(key, out object? entry))
         {
-            object state = create(argument)
+            entry = create(argument)
                 ?? throw new InvalidOperationException("Prediction state factory returned null.");
-            entry = new OwnedStateEntry(state);
             _states[key] = entry;
             IncrementCount(typeof(TState));
         }
-        return (TState)entry.Read();
+        return (TState)entry;
     }
 
     /// <summary>
@@ -116,8 +99,8 @@ internal sealed class PredictionStateStore
         Func<TArgument, TState> create)
         where TState : IPredictionStateForkable
     {
-        if (_states.TryGetValue((ResolveModel(model), typeof(TState)), out StateEntry? entry))
-            return (TState)entry.Read();
+        if (_states.TryGetValue((ResolveModel(model), typeof(TState)), out object? entry))
+            return (TState)entry;
         return create(argument)
             ?? throw new InvalidOperationException("Prediction state factory returned null.");
     }
@@ -125,9 +108,9 @@ internal sealed class PredictionStateStore
     public bool TryGetReadOnly<TState>(AbstractModel model, out TState? state)
         where TState : class, IPredictionStateForkable
     {
-        if (_states.TryGetValue((ResolveModel(model), typeof(TState)), out StateEntry? entry))
+        if (_states.TryGetValue((ResolveModel(model), typeof(TState)), out object? entry))
         {
-            state = (TState)entry.Read();
+            state = (TState)entry;
             return true;
         }
         state = null;
@@ -139,10 +122,10 @@ internal sealed class PredictionStateStore
     {
         if (!_countByType.TryGetValue(typeof(TState), out int count) || count == 0)
             yield break;
-        foreach (((AbstractModel model, Type stateType), StateEntry entry) in _states)
+        foreach (((AbstractModel model, Type stateType), object entry) in _states)
         {
             if (stateType == typeof(TState))
-                yield return (model, (TState)entry.Read());
+                yield return (model, (TState)entry);
         }
     }
 
@@ -170,30 +153,30 @@ internal sealed class PredictionStateStore
             .ToArray();
         foreach ((AbstractModel _, Type stateType) in keys)
         {
-            StateEntry entry = _states[(resolvedSource, stateType)];
+            object entry = _states[(resolvedSource, stateType)];
             _states.Remove((resolvedSource, stateType));
             if (!_states.TryAdd((resolvedReplacement, stateType), entry))
                 throw new InvalidOperationException($"Prediction state remap collided for {stateType.FullName}.");
         }
 
-        foreach (AbstractModel alias in _modelAliases
+        Dictionary<AbstractModel, AbstractModel> aliases = _modelAliases ??= [];
+        foreach (AbstractModel alias in aliases
                      .Where(pair => ReferenceEquals(pair.Value, resolvedSource))
                      .Select(pair => pair.Key)
                      .ToArray())
         {
-            _modelAliases[alias] = resolvedReplacement;
+            aliases[alias] = resolvedReplacement;
         }
-        _modelAliases[source] = resolvedReplacement;
-        _modelAliases[resolvedSource] = resolvedReplacement;
+        aliases[source] = resolvedReplacement;
+        aliases[resolvedSource] = resolvedReplacement;
     }
 
     internal PredictionStateStore Fork(PredictionForkContext context)
     {
         AssertForkable();
-        PredictionStateStore fork = new(_states.Count, _modelAliases.Count);
-        foreach (((AbstractModel model, Type stateType), StateEntry entry) in _states)
+        PredictionStateStore fork = new(_states.Count);
+        foreach (((AbstractModel model, Type stateType), object state) in _states)
         {
-            object state = entry.Read();
             AbstractModel forkedModel = context.RemapOrSelf(model);
             object forkedState;
             if (context.TryRemap(state, out object? existing))
@@ -210,36 +193,41 @@ internal sealed class PredictionStateStore
                 forkedState = forkable.Fork(context);
                 context.Register(state, forkedState);
             }
-            fork._states.Add((forkedModel, stateType), new OwnedStateEntry(forkedState));
+            fork._states.Add((forkedModel, stateType), forkedState);
         }
         foreach ((Type stateType, int count) in _countByType)
         {
             if (count != 0)
                 fork._countByType[stateType] = count;
         }
-        foreach ((AbstractModel source, AbstractModel replacement) in _modelAliases)
+        if (_modelAliases is { Count: > 0 } aliases)
         {
-            AbstractModel forkedSource = context.RemapOrSelf(source);
-            AbstractModel forkedReplacement = context.RemapOrSelf(replacement);
-            if (!ReferenceEquals(forkedSource, forkedReplacement))
-                fork._modelAliases[forkedSource] = forkedReplacement;
+            foreach ((AbstractModel source, AbstractModel replacement) in aliases)
+            {
+                AbstractModel forkedSource = context.RemapOrSelf(source);
+                AbstractModel forkedReplacement = context.RemapOrSelf(replacement);
+                if (!ReferenceEquals(forkedSource, forkedReplacement))
+                    (fork._modelAliases ??= [])[forkedSource] = forkedReplacement;
+            }
         }
         return fork;
     }
 
     internal void AssertForkable()
     {
-        foreach (StateEntry entry in _states.Values)
+        foreach (object state in _states.Values)
         {
-            if (entry.Read() is IPredictionForkBoundary boundary)
+            if (state is IPredictionForkBoundary boundary)
                 boundary.AssertForkable();
         }
     }
 
     private AbstractModel ResolveModel(AbstractModel model)
     {
+        if (_modelAliases is not { Count: > 0 } aliases)
+            return model;
         AbstractModel current = model;
-        for (int guard = 0; guard < 16 && _modelAliases.TryGetValue(current, out AbstractModel? replacement); guard++)
+        for (int guard = 0; guard < 16 && aliases.TryGetValue(current, out AbstractModel? replacement); guard++)
             current = replacement;
         return current;
     }

--- a/src/Engine/Common/PredictionTrace.cs
+++ b/src/Engine/Common/PredictionTrace.cs
@@ -71,8 +71,26 @@ internal sealed class PredictionTraceFrame
 /// </remarks>
 internal sealed class PredictionTrace
 {
+    // 绝大多数镜像分发在自己的作用域里一条历史都不记，帧对象建了就直接丢。改为只把
+    // 来源/调用记进一段可复用的栈，等真的有人读 Current 时才物化，并把结果缓存在槽里。
+    // 帧的引用身份因此保持原样：同一个活动作用域内每次读 Current 都拿到同一个对象，
+    // 作用域弹出后槽被清空，下一次 Push 到同一深度会得到一个全新的对象；物化更深的帧时
+    // 父帧一律取自缓存，所以 Parent 链上的对象和逐层 Push 时建出来的完全一致。
+    private struct Slot
+    {
+        public AbstractModel? Source;
+        public PredictionInvocation Invocation;
+        public PredictionTraceFrame? Materialized;
+    }
+
+    private Slot[] _slots = new Slot[16];
+    private int _depth;
+
+    /// <summary>Gets whether any scope is active, without materializing its frame.</summary>
+    public bool HasCurrentFrame => _depth > 0;
+
     /// <summary>Gets the active innermost frame, or <see langword="null"/> when no scope is active.</summary>
-    public PredictionTraceFrame? Current { get; private set; }
+    public PredictionTraceFrame? Current => _depth == 0 ? null : Materialize(_depth - 1);
 
     /// <summary>Pushes one source/invocation frame and returns the scope that pops that exact frame.</summary>
     /// <param name="source">The exact model identity responsible for work performed in the new scope.</param>
@@ -80,27 +98,51 @@ internal sealed class PredictionTrace
     /// <returns>An idempotent disposable scope that must be disposed in strict LIFO order.</returns>
     public TraceScope Push(AbstractModel source, PredictionInvocation invocation)
     {
-        var frame = new PredictionTraceFrame
-        {
-            Parent = Current,
-            Source = source,
-            Invocation = invocation
-        };
-        Current = frame;
-        return new TraceScope(this, frame);
+        if (_depth == _slots.Length)
+            Array.Resize(ref _slots, _slots.Length * 2);
+        _slots[_depth].Source = source;
+        _slots[_depth].Invocation = invocation;
+        _slots[_depth].Materialized = null;
+        _depth++;
+        return new TraceScope(this, _depth);
     }
 
-    private void Pop(PredictionTraceFrame frame)
+    private PredictionTraceFrame Materialize(int index)
     {
-        if (!ReferenceEquals(Current, frame))
+        if (_slots[index].Materialized is { } cached)
+            return cached;
+        int start = index;
+        while (start > 0 && _slots[start - 1].Materialized is null)
+            start--;
+        PredictionTraceFrame? frame = start == 0 ? null : _slots[start - 1].Materialized;
+        for (int slotIndex = start; slotIndex <= index; slotIndex++)
+        {
+            frame = new PredictionTraceFrame
+            {
+                Parent = frame,
+                Source = _slots[slotIndex].Source
+                    ?? throw new InvalidOperationException("Prediction trace slot has no source."),
+                Invocation = _slots[slotIndex].Invocation,
+            };
+            _slots[slotIndex].Materialized = frame;
+        }
+        return frame!;
+    }
+
+    private void Pop(int depth)
+    {
+        if (_depth != depth)
         {
             throw new InvalidOperationException("Prediction trace scopes are unbalanced.");
         }
 
-        Current = frame.Parent;
+        _depth = depth - 1;
+        // 已经交出去的帧对象仍然有效；这里只是让槽不再钉住它和它的整条父链。
+        _slots[_depth].Materialized = null;
+        _slots[_depth].Source = null;
     }
 
-    internal struct TraceScope(PredictionTrace trace, PredictionTraceFrame frame) : IDisposable
+    internal struct TraceScope(PredictionTrace trace, int depth) : IDisposable
     {
         private bool _disposed;
 
@@ -111,7 +153,7 @@ internal sealed class PredictionTrace
                 return;
             }
 
-            trace.Pop(frame);
+            trace.Pop(depth);
             _disposed = true;
         }
     }

--- a/src/Engine/InCombat/Mirrors/HookMirrors.cs
+++ b/src/Engine/InCombat/Mirrors/HookMirrors.cs
@@ -387,12 +387,27 @@ internal static class HookMirrors
             return originalCost;
         }
 
-        var context = new ModifyEnergyCostInCombatMirrorContext
+        // 费用查询是最热的 hook 之一（每次可玩性判定都要为手里每张牌跑一遍）。这个 context
+        // 调用返回后无人持有，按模拟器复用一份即可；绑在模拟器上是因为 Simulator 是 required
+        // init，复用范围不能跨模拟器。取用时先摘空槽位，万一某个游戏侧 hook 递归回到这里，
+        // 内层会自建一份，两层互不干扰。
+        ModifyEnergyCostInCombatMirrorContext context;
+        if (simulator.EnergyCostMirrorScratch is { } scratch)
         {
-            Simulator = simulator,
-            Card = card,
-            Cost = originalCost
-        };
+            simulator.EnergyCostMirrorScratch = null;
+            scratch.Card = card;
+            scratch.Cost = originalCost;
+            context = scratch;
+        }
+        else
+        {
+            context = new ModifyEnergyCostInCombatMirrorContext
+            {
+                Simulator = simulator,
+                Card = card,
+                Cost = originalCost
+            };
+        }
 
         foreach (var listener in IterateCombatHookListeners(simulator))
         {
@@ -411,7 +426,9 @@ internal static class HookMirrors
             context.Cost = 0m;
         }
 
-        return context.Cost;
+        decimal cost = context.Cost;
+        simulator.EnergyCostMirrorScratch = context;
+        return cost;
     }
 
     /// <summary>

--- a/src/Engine/InCombat/Mirrors/HookMirrors.cs
+++ b/src/Engine/InCombat/Mirrors/HookMirrors.cs
@@ -1132,37 +1132,71 @@ internal static class HookMirrors
     // IReadOnlyList<T>.GetEnumerator returns an interface enumerator and boxes List/array
     // enumerators. Hook dispatch is frequent enough for those tiny objects to become a visible
     // search allocation source, so iterate the immutable listener snapshot by index instead.
-    private readonly struct HookListenerEnumerable(
-        IReadOnlyList<AbstractModel> listeners)
+    private readonly struct HookListenerEnumerable
     {
-        public IReadOnlyList<AbstractModel> Listeners { get; } = listeners;
+        // 运行级监听表可能是"根牌组前缀 + 战斗监听表"的拼接视图。走视图自己的索引器意味着
+        // 每个元素两次接口调用外加一次分支；这里拆成两段各自按下标推进，元素与顺序不变。
+        private readonly IReadOnlyList<AbstractModel> _first;
+        private readonly IReadOnlyList<AbstractModel>? _second;
+
+        public HookListenerEnumerable(IReadOnlyList<AbstractModel> listeners)
+        {
+            if (listeners is ISegmentedModelList segmented)
+            {
+                _first = segmented.Prefix;
+                _second = segmented.Suffix;
+            }
+            else
+            {
+                _first = listeners;
+                _second = null;
+            }
+        }
 
         public Enumerator GetEnumerator()
-            => new(Listeners);
+            => new(_first, _second);
 
         public bool Contains(AbstractModel candidate)
         {
-            for (int index = 0; index < Listeners.Count; index++)
+            for (int index = 0; index < _first.Count; index++)
             {
-                if (EqualityComparer<AbstractModel>.Default.Equals(Listeners[index], candidate))
+                if (EqualityComparer<AbstractModel>.Default.Equals(_first[index], candidate))
+                    return true;
+            }
+            if (_second is null)
+                return false;
+            for (int index = 0; index < _second.Count; index++)
+            {
+                if (EqualityComparer<AbstractModel>.Default.Equals(_second[index], candidate))
                     return true;
             }
             return false;
         }
 
-        internal struct Enumerator(IReadOnlyList<AbstractModel> listeners)
+        internal struct Enumerator(
+            IReadOnlyList<AbstractModel> first,
+            IReadOnlyList<AbstractModel>? second)
         {
+            private IReadOnlyList<AbstractModel> _segment = first;
+            private IReadOnlyList<AbstractModel>? _pending = second;
             private int _index = -1;
 
-            public AbstractModel Current => listeners[_index];
+            public AbstractModel Current => _segment[_index];
 
             public bool MoveNext()
             {
                 int next = _index + 1;
-                if (next >= listeners.Count)
+                if (next < _segment.Count)
+                {
+                    _index = next;
+                    return true;
+                }
+                if (_pending is null)
                     return false;
-                _index = next;
-                return true;
+                _segment = _pending;
+                _pending = null;
+                _index = -1;
+                return MoveNext();
             }
         }
     }

--- a/src/Engine/InCombat/Mirrors/Hooks/Card/ModifyEnergyCostInCombatMirrors.cs
+++ b/src/Engine/InCombat/Mirrors/Hooks/Card/ModifyEnergyCostInCombatMirrors.cs
@@ -131,9 +131,12 @@ internal static class ModifyEnergyCostInCombatMirrors
     }
 }
 
+// 这个 context 在调用返回后没有任何持有者：本文件的每个 handler 只读它的属性（状态仓工厂
+// 都是 static lambda，不捕获它），MethodMirrorRegistry 只是转交给 handler，回退路径交给游戏的
+// 只是 CardModel 与 decimal。因此它可以按模拟器复用一份，Card/Cost 每次取用时重置。
 internal sealed class ModifyEnergyCostInCombatMirrorContext : CombatMirrorContext
 {
-    public required PredictedCard Card { get; init; }
+    public required PredictedCard Card { get; set; }
 
     public required decimal Cost { get; set; }
 }

--- a/src/Engine/InCombat/Simulation/CombatPredictedCardExtensions.cs
+++ b/src/Engine/InCombat/Simulation/CombatPredictedCardExtensions.cs
@@ -199,8 +199,18 @@ internal static class CombatPredictedCardExtensions
 
         try
         {
-            foreach (CardKeyword localKeyword in card.Preview.LocalKeywords)
-                keywords.Add(localKeyword);
+            // LocalKeywords 以接口类型暴露一个数组，foreach 会为每次查询装箱一个枚举器。
+            // 这里只往集合里塞元素再问 Contains，插入顺序不影响结果。
+            if (card.Preview.LocalKeywords is IReadOnlyList<CardKeyword> indexableKeywords)
+            {
+                for (int index = 0; index < indexableKeywords.Count; index++)
+                    keywords.Add(indexableKeywords[index]);
+            }
+            else
+            {
+                foreach (CardKeyword localKeyword in card.Preview.LocalKeywords)
+                    keywords.Add(localKeyword);
+            }
             Hook.ModifyKeywordsInCombat(state.CombatState, card.Preview, keywords);
             return keywords.Contains(keyword);
         }

--- a/src/Engine/InCombat/Simulation/CombatPredictionHistory.cs
+++ b/src/Engine/InCombat/Simulation/CombatPredictionHistory.cs
@@ -62,7 +62,14 @@ internal sealed class CombatPredictionHistory(PredictionTrace trace)
     }
 
     private HistorySegment? _prefix;
+    // 前缀段是从叶到根的链表，每次枚举都要先把它翻过来。段链只在 SealTail 时变长，
+    // 所以把翻好的顺序缓存下来；SealTail 换新数组而不是就地改，正在跑的迭代器仍看到
+    // 它启动时抓到的那一份，与原来"枚举开始时建一个 Stack"的可见性完全一致。
+    private HistorySegment[]? _orderedSegments;
     private List<CombatPredictionHistoryEntry>? _tail;
+    // 上一段封存时的条目数。同一条搜索里相邻两段长度接近，用它给可变尾表预留容量，
+    // 省掉从 0 开始的多轮扩容。容量只影响分配，不影响任何内容或顺序。
+    private int _tailCapacityHint;
     private Dictionary<CombatPredictionHistoryEntry, CombatPredictionHistoryEntry>? _tailCompletions;
     private int _pendingDeferredEntries;
     private ulong _riskSignatureFirst;
@@ -89,10 +96,12 @@ internal sealed class CombatPredictionHistory(PredictionTrace trace)
         ulong riskSignatureSecond,
         int riskEntryCount,
         int cardDrawnEntryCount,
-        int orbChanneledEntryCount)
+        int orbChanneledEntryCount,
+        int tailCapacityHint)
         : this(trace)
     {
         _prefix = prefix;
+        _tailCapacityHint = tailCapacityHint;
         _riskSignatureFirst = riskSignatureFirst;
         _riskSignatureSecond = riskSignatureSecond;
         _riskEntryCount = riskEntryCount;
@@ -363,7 +372,7 @@ internal sealed class CombatPredictionHistory(PredictionTrace trace)
     {
         entry.Index = EntryCount;
         entry.Trace = trace.Current;
-        (_tail ??= []).Add(entry);
+        (_tail ??= new List<CombatPredictionHistoryEntry>(_tailCapacityHint)).Add(entry);
         if (entry is CombatPredictionCardDrawnEntry)
             _cardDrawnEntryCount++;
         else if (entry is CombatPredictionOrbChanneledEntry)
@@ -416,7 +425,8 @@ internal sealed class CombatPredictionHistory(PredictionTrace trace)
             _riskSignatureSecond,
             _riskEntryCount,
             _cardDrawnEntryCount,
-            _orbChanneledEntryCount);
+            _orbChanneledEntryCount,
+            _tailCapacityHint);
     }
 
     internal void AssertForkable()
@@ -429,13 +439,10 @@ internal sealed class CombatPredictionHistory(PredictionTrace trace)
     {
         if (_prefix is not null)
         {
-            Stack<HistorySegment> segments = new();
-            for (HistorySegment? segment = _prefix; segment is not null; segment = segment.Parent)
-                segments.Push(segment);
-            while (segments.Count > 0)
+            HistorySegment[] ordered = GetOrderedSegments();
+            for (int segmentIndex = 0; segmentIndex < ordered.Length; segmentIndex++)
             {
-                HistorySegment segment = segments.Pop();
-                foreach (CombatPredictionHistoryEntry entry in segment.Entries)
+                foreach (CombatPredictionHistoryEntry entry in ordered[segmentIndex].Entries)
                     yield return entry;
             }
         }
@@ -447,6 +454,23 @@ internal sealed class CombatPredictionHistory(PredictionTrace trace)
     }
 
     System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+
+    // 原来每次枚举都新建一个 Stack（对象 + 逐轮扩容的数组）来把段链翻成从根到叶。
+    // 段链只在 SealTail 变长，翻好的顺序缓存起来即可，元素与顺序完全一致。
+    private HistorySegment[] GetOrderedSegments()
+    {
+        if (_orderedSegments is { } cached)
+            return cached;
+        int count = 0;
+        for (HistorySegment? segment = _prefix; segment is not null; segment = segment.Parent)
+            count++;
+        HistorySegment[] ordered = new HistorySegment[count];
+        int index = count;
+        for (HistorySegment? segment = _prefix; segment is not null; segment = segment.Parent)
+            ordered[--index] = segment;
+        _orderedSegments = ordered;
+        return ordered;
+    }
 
     private bool TryGetCompletion(
         CombatPredictionHistoryEntry originalEntry,
@@ -468,6 +492,8 @@ internal sealed class CombatPredictionHistory(PredictionTrace trace)
             _prefix,
             entries,
             _tailCompletions);
+        _orderedSegments = null;
+        _tailCapacityHint = entries.Length;
         _tail = null;
         _tailCompletions = null;
     }

--- a/src/Engine/InCombat/Simulation/CombatPredictionSimulator.CardPile.cs
+++ b/src/Engine/InCombat/Simulation/CombatPredictionSimulator.CardPile.cs
@@ -164,7 +164,7 @@ internal sealed partial class CombatPredictionSimulator
         CardPilePosition position = CardPilePosition.Bottom)
         where TCard : CardModel
     {
-        List<PredictedCard> cards = [];
+        List<PredictedCard> cards = new(count);
         for (var i = 0; i < count; i++)
         {
             cards.Add(PredictedCard.Create(CanonicalModels.Card<TCard>(), player));
@@ -215,12 +215,13 @@ internal sealed partial class CombatPredictionSimulator
             throw new InvalidOperationException("Generated combat cards can only be added to combat piles.");
         }
 
-        if (cards.Any(card => card.GetPile(State) is not null))
+        for (int index = 0; index < cards.Count; index++)
         {
-            throw new InvalidOperationException("Generated combat cards cannot already be in a pile.");
+            if (cards[index].GetPile(State) is not null)
+                throw new InvalidOperationException("Generated combat cards cannot already be in a pile.");
         }
 
-        List<SimCardPileAddResult> results = [];
+        List<SimCardPileAddResult> results = new(cards.Count);
 
         foreach (var card in cards)
         {
@@ -330,7 +331,7 @@ internal sealed partial class CombatPredictionSimulator
             ?? throw new InvalidOperationException("Cannot add cards with no owner to a pile.");
         var playerCombatState = State.GetPlayerCombatState(owner);
 
-        List<SimCardPileAddResult> results = [];
+        List<SimCardPileAddResult> results = new(cards.Count);
 
         foreach (var card in cards)
         {

--- a/src/Engine/InCombat/Simulation/CombatPredictionSimulator.cs
+++ b/src/Engine/InCombat/Simulation/CombatPredictionSimulator.cs
@@ -30,6 +30,15 @@ internal sealed partial class CombatPredictionSimulator
     public PredictionTraceFrame? CurrentFrame => _trace.Current;
 
     /// <summary>
+    /// Reusable mirror context for <see cref="Mirrors.HookMirrors.ModifyEnergyCostInCombat"/>.
+    /// </summary>
+    /// <remarks>
+    /// 该 context 在调用返回后没有任何持有者，可以复用；它的 <c>Simulator</c> 是 required init，
+    /// 所以复用范围绑定在单个模拟器上。取用方负责先摘空这个槽位以防重入。
+    /// </remarks>
+    internal Mirrors.Hooks.Card.ModifyEnergyCostInCombatMirrorContext? EnergyCostMirrorScratch;
+
+    /// <summary>
     /// Mirrors <see cref="CombatTurnState.IsInProgress"/>.
     /// </summary>
     public bool IsInProgress { get; private set; } = true;

--- a/src/Engine/InCombat/Simulation/CombatPredictionSimulator.cs
+++ b/src/Engine/InCombat/Simulation/CombatPredictionSimulator.cs
@@ -107,7 +107,8 @@ internal sealed partial class CombatPredictionSimulator
 
     internal void AssertForkable()
     {
-        if (_trace.Current is not null)
+        // 只是判断有没有活动作用域，不需要把帧物化出来。
+        if (_trace.HasCurrentFrame)
             throw new InvalidOperationException("Combat prediction can only be forked between completed actions.");
         if (ActionRelicTriggers is not null)
             throw new InvalidOperationException("Combat prediction cannot be forked while action relic triggers are being recorded.");

--- a/src/Engine/InCombat/Simulation/CombatPredictionState.cs
+++ b/src/Engine/InCombat/Simulation/CombatPredictionState.cs
@@ -13,7 +13,8 @@ internal sealed class CombatPredictionState
 
     private readonly Dictionary<Creature, SimCreatureState> _creatures;
 
-    private readonly HashSet<Creature> _removedCreatures;
+    // 绝大多数分叉里没有任何生物被移出预测名册。惰性建表让 Fork 少一次空 HashSet 分配。
+    private HashSet<Creature>? _removedCreatures;
 
     private readonly Dictionary<Player, SimPlayerCombatState> _playerCombatStates;
     private HittableEnemyView? _hittableEnemies;
@@ -65,7 +66,6 @@ internal sealed class CombatPredictionState
     {
         CombatState = combatState;
         _creatures = [];
-        _removedCreatures = [];
         _playerCombatStates = [];
         if (combatState is ICombatPredictionStateOwner owner)
             owner.AttachPredictionState(this);
@@ -74,7 +74,7 @@ internal sealed class CombatPredictionState
     private CombatPredictionState(
         ICombatState combatState,
         Dictionary<Creature, SimCreatureState> creatures,
-        HashSet<Creature> removedCreatures,
+        HashSet<Creature>? removedCreatures,
         Dictionary<Player, SimPlayerCombatState> playerCombatStates)
     {
         CombatState = combatState;
@@ -99,7 +99,7 @@ internal sealed class CombatPredictionState
 
     // SimulatedCombatState updates its allies/enemies rosters, but PlayerCreatures is an
     // immutable root projection and can still contain a removed player-side summon.
-    public IReadOnlyList<Creature> PlayerCreatures => _removedCreatures.Count == 0
+    public IReadOnlyList<Creature> PlayerCreatures => _removedCreatures is not { Count: > 0 }
         ? CombatState.PlayerCreatures
         : [.. ExcludeRemoved(CombatState.PlayerCreatures)];
 
@@ -127,7 +127,7 @@ internal sealed class CombatPredictionState
 
     public bool IsHittable(Creature creature)
     {
-        if (_removedCreatures.Contains(creature) || !GetCreature(creature).IsAlive)
+        if (_removedCreatures?.Contains(creature) == true || !GetCreature(creature).IsAlive)
             return false;
         return CombatState is ICombatPredictionCreatureSemantics semantics
             ? semantics.IsHittable(creature)
@@ -154,7 +154,7 @@ internal sealed class CombatPredictionState
     // the first death, which dominates long multi-enemy searches. Keep the fallback for combat
     // state implementations that cannot update their own roster.
     private bool RequiresRemovedCreatureFiltering
-        => _removedCreatures.Count != 0 && CombatState is not ICombatPredictionRosterSink;
+        => _removedCreatures is { Count: > 0 } && CombatState is not ICombatPredictionRosterSink;
 
     public IReadOnlyList<AbstractModel> IterateHookListeners()
     {
@@ -182,7 +182,7 @@ internal sealed class CombatPredictionState
     {
         if (Creatures.Contains(creature))
         {
-            _removedCreatures.Add(creature);
+            (_removedCreatures ??= []).Add(creature);
             if (CombatState is ICombatPredictionRosterSink roster)
                 roster.RemoveCreatureFromPrediction(creature);
         }
@@ -207,7 +207,7 @@ internal sealed class CombatPredictionState
 
     private IEnumerable<Creature> ExcludeRemoved(IEnumerable<Creature> creatures)
     {
-        return creatures.Where(creature => !_removedCreatures.Contains(creature));
+        return creatures.Where(creature => _removedCreatures?.Contains(creature) != true);
     }
 
     internal CombatPredictionState Fork(PredictionForkContext context)
@@ -230,7 +230,7 @@ internal sealed class CombatPredictionState
         CombatPredictionState fork = new(
             combatState,
             creatures,
-            new HashSet<Creature>(_removedCreatures),
+            _removedCreatures is null ? null : new HashSet<Creature>(_removedCreatures),
             players);
         context.Register(this, fork);
         return fork;

--- a/src/Prediction/CorePowerSupport.cs
+++ b/src/Prediction/CorePowerSupport.cs
@@ -557,9 +557,12 @@ internal static class CorePowerSupport
         IReadOnlyList<Creature> enemies,
         ISet<uint> processedDeaths)
     {
+        // enemies / PlayerCreatures / EffectivePowers 都是只读列表，接口 foreach 会为每次调用
+        // 装箱一个枚举器。按下标推进，遍历顺序与判定条件不变。
         List<Creature>? newlyDead = null;
-        foreach (Creature enemy in enemies)
+        for (int enemyIndex = 0; enemyIndex < enemies.Count; enemyIndex++)
         {
+            Creature enemy = enemies[enemyIndex];
             if (enemy.CombatId is not uint combatId
                 || processedDeaths.Contains(combatId)
                 || simulator.State.GetCreature(enemy).IsAlive)
@@ -577,8 +580,10 @@ internal static class CorePowerSupport
                 if (dead.CombatId is uint combatId)
                     processedDeaths.Add(combatId);
                 DeathPowerSupport.Trigger(simulator, combat, dead);
-                foreach (Creature player in combat.PlayerCreatures)
+                IReadOnlyList<Creature> playerCreatures = combat.PlayerCreatures;
+                for (int playerIndex = 0; playerIndex < playerCreatures.Count; playerIndex++)
                 {
+                    Creature player = playerCreatures[playerIndex];
                     ConstrictPower? constrict = combat.GetPower<ConstrictPower>(player);
                     if (constrict?.Applier == dead)
                         combat.SetAmount<ConstrictPower>(player, 0);
@@ -589,12 +594,22 @@ internal static class CorePowerSupport
                     if (shrink?.Applier == dead)
                         combat.SetAmount<ShrinkPower>(player, 0);
                 }
-                foreach (MagicBombPower bomb in combat.EffectivePowers()
-                             .OfType<MagicBombPower>()
-                             .Where(power => ReferenceEquals(power.Applier, dead))
-                             .ToArray())
+                // SetPowerAmount 会让 EffectivePowers 失效，所以命中项仍必须先物化；
+                // 但绝大多数结算根本没有 MagicBomb，改成只在命中时才建表，顺序与原来一致。
+                List<MagicBombPower>? magicBombs = null;
+                IReadOnlyList<PowerModel> effectivePowers = combat.EffectivePowers();
+                for (int powerIndex = 0; powerIndex < effectivePowers.Count; powerIndex++)
                 {
-                    combat.SetPowerAmount(bomb, 0);
+                    if (effectivePowers[powerIndex] is MagicBombPower bomb
+                        && ReferenceEquals(bomb.Applier, dead))
+                    {
+                        (magicBombs ??= []).Add(bomb);
+                    }
+                }
+                if (magicBombs != null)
+                {
+                    foreach (MagicBombPower bomb in magicBombs)
+                        combat.SetPowerAmount(bomb, 0);
                 }
             }
         }

--- a/src/Prediction/EndTurnPowerSupport.cs
+++ b/src/Prediction/EndTurnPowerSupport.cs
@@ -19,8 +19,12 @@ internal static partial class EndTurnPowerSupport
         int etherealExhaustCount = 0)
     {
         HashSet<Creature> participantSet = participants.ToHashSet();
-        foreach (PowerModel power in combat.EffectivePowers().ToArray())
+        // EffectivePowers 的数组发布后不会被就地改写（失效只把缓存字段置空），所以先取一次
+        // 快照按下标推进即可，与 ToArray 的防御性拷贝看到的元素与顺序完全一致。
+        IReadOnlyList<PowerModel> effectivePowers = combat.EffectivePowers();
+        for (int powerIndex = 0; powerIndex < effectivePowers.Count; powerIndex++)
         {
+            PowerModel power = effectivePowers[powerIndex];
             if (power.Amount <= 0)
                 continue;
 

--- a/src/Prediction/TurnStartPowerSupport.cs
+++ b/src/Prediction/TurnStartPowerSupport.cs
@@ -71,7 +71,10 @@ internal static class TurnStartPowerSupport
                 .ToArray();
             foreach (PredictedCard card in selected)
             {
-                simulator.AddToPile([card], PileType.Hand);
+                // 单张牌走单张重载：多张重载对 N==1 的两阶段流程与它逐步等价（同样的所有者
+                // 解析、同样的合法性判定、同样的手牌上限溢出改投弃牌堆、同一次 Shuffle 取位、
+                // 同样的入场事件），但会额外分配一个单元素数组和一张结果表。
+                simulator.AddToPile(card, PileType.Hand);
                 if (card.Preview.IsUpgradable)
                     card.Upgrade();
             }

--- a/src/Prediction/TurnStartPowerSupport.cs
+++ b/src/Prediction/TurnStartPowerSupport.cs
@@ -36,17 +36,26 @@ internal static class TurnStartPowerSupport
         SimulatedCombatState combat,
         IReadOnlyList<Creature> participants)
     {
+        // EffectivePowers 返回的数组一旦发布就不会被就地改写（失效只是把缓存字段置空，
+        // 旧数组内容不变），所以先取一次快照按下标推进，与原来的 ToArray/OfType 迭代器
+        // 看到的元素与顺序完全一致，只是不再复制数组、不再建迭代器。
         if (combat.CurrentSide == CombatSide.Player && combat.RoundNumber <= 1)
         {
-            foreach (PlatingPower plating in combat.EffectivePowers().OfType<PlatingPower>())
+            IReadOnlyList<PowerModel> platingPowers = combat.EffectivePowers();
+            for (int powerIndex = 0; powerIndex < platingPowers.Count; powerIndex++)
             {
+                if (platingPowers[powerIndex] is not PlatingPower plating)
+                    continue;
                 if (plating.Amount > 0 && plating.Owner.IsEnemy)
                     simulator.GainBlock(plating.Owner, plating.Amount, ValueProp.Unpowered);
             }
         }
 
-        foreach (AggressionPower aggression in combat.EffectivePowers().OfType<AggressionPower>().ToArray())
+        IReadOnlyList<PowerModel> aggressionPowers = combat.EffectivePowers();
+        for (int powerIndex = 0; powerIndex < aggressionPowers.Count; powerIndex++)
         {
+            if (aggressionPowers[powerIndex] is not AggressionPower aggression)
+                continue;
             if (aggression.Amount <= 0
                 || !participants.Contains(aggression.Owner)
                 || aggression.Owner.Player is not { } aggressionPlayer)
@@ -68,8 +77,10 @@ internal static class TurnStartPowerSupport
             }
         }
 
-        foreach (PowerModel power in combat.EffectivePowers().ToArray())
+        IReadOnlyList<PowerModel> effectivePowers = combat.EffectivePowers();
+        for (int powerIndex = 0; powerIndex < effectivePowers.Count; powerIndex++)
         {
+            PowerModel power = effectivePowers[powerIndex];
             if (power.Amount <= 0)
                 continue;
 

--- a/src/Search/CombatBeamSolver.BeamRetentionPolicy.cs
+++ b/src/Search/CombatBeamSolver.BeamRetentionPolicy.cs
@@ -343,14 +343,50 @@ internal sealed partial class CombatBeamSolver
         {
             if (nodes.Count == 0)
                 return [];
-            int highestValue = nodes.Max(node => node.Snapshot.LongTermResourceValue);
-            if (nodes.All(node => node.Snapshot.LongTermResourceValue == highestValue))
+            // Max / All / Where 三次遍历外加三个委托，合成一次扫描：最高值、命中数与命中集合
+            // 全部按原顺序一次算出，筛选结果与 Where 的产出逐条相同。
+            int highestValue = int.MinValue;
+            int highestCount = 0;
+            for (int index = 0; index < nodes.Count; index++)
+            {
+                int value = nodes[index].Snapshot.LongTermResourceValue;
+                if (value > highestValue)
+                {
+                    highestValue = value;
+                    highestCount = 1;
+                }
+                else if (value == highestValue)
+                {
+                    highestCount++;
+                }
+            }
+            if (highestCount == nodes.Count)
                 return [];
+            List<SearchNode> highest = new(highestCount);
+            for (int index = 0; index < nodes.Count; index++)
+            {
+                if (nodes[index].Snapshot.LongTermResourceValue == highestValue)
+                    highest.Add(nodes[index]);
+            }
             return RankBest(
-                nodes.Where(node => node.Snapshot.LongTermResourceValue == highestValue),
+                highest,
                 limit,
                 preserveDefensiveRoute: true);
         }
+
+        // 两处 Sort 用的都是同一个比较：捕获 this 的 lambda 每次转委托都要分配，缓存起来。
+        private Comparison<SearchNode>? _beamRankComparison;
+        private Comparison<SearchNode>? _finalCandidateComparison;
+
+        private Comparison<SearchNode> BeamRankComparison
+            => _beamRankComparison ??= (left, right) =>
+            {
+                int byScore = BeamRankScore(right).CompareTo(BeamRankScore(left));
+                return byScore != 0 ? byScore : left.ActionCount.CompareTo(right.ActionCount);
+            };
+
+        private Comparison<SearchNode> FinalCandidateComparison
+            => _finalCandidateComparison ??= CompareFinalCandidates;
 
         public List<SearchNode> RankBest(
             IEnumerable<SearchNode> nodes,
@@ -380,13 +416,7 @@ internal sealed partial class CombatBeamSolver
                 ranked = [.. bestByState.Values];
             }
 
-            ranked.Sort(finalQualityFirst
-                ? CompareFinalCandidates
-                : (left, right) =>
-                {
-                    int byScore = BeamRankScore(right).CompareTo(BeamRankScore(left));
-                    return byScore != 0 ? byScore : left.ActionCount.CompareTo(right.ActionCount);
-                });
+            ranked.Sort(finalQualityFirst ? FinalCandidateComparison : BeamRankComparison);
             List<SearchNode> routingChoices = [];
             if (preserveDefensiveRoute)
             {
@@ -1193,13 +1223,7 @@ internal sealed partial class CombatBeamSolver
                 EnforcePotionUseQuota(ranked, quotaPool, required, usesPotion: true, usedPotionQuota);
                 EnforcePotionUseQuota(ranked, quotaPool, required, usesPotion: false, unusedPotionQuota);
             }
-            ranked.Sort(finalQualityFirst
-                ? CompareFinalCandidates
-                : (left, right) =>
-                {
-                    int byScore = BeamRankScore(right).CompareTo(BeamRankScore(left));
-                    return byScore != 0 ? byScore : left.ActionCount.CompareTo(right.ActionCount);
-                });
+            ranked.Sort(finalQualityFirst ? FinalCandidateComparison : BeamRankComparison);
             AssignRetentionRanks(ranked, required);
             return ranked;
         }
@@ -1302,8 +1326,12 @@ internal sealed partial class CombatBeamSolver
             List<IGrouping<StateFingerprint, SearchNode>> selected,
             IGrouping<StateFingerprint, SearchNode> candidate)
         {
-            if (!selected.Any(group => ReferenceEquals(group, candidate)))
-                selected.Add(candidate);
+            foreach (IGrouping<StateFingerprint, SearchNode> group in selected)
+            {
+                if (ReferenceEquals(group, candidate))
+                    return;
+            }
+            selected.Add(candidate);
         }
 
         private static void AddRoutingCandidate(List<SearchNode> selected, SearchNode? candidate)
@@ -1657,9 +1685,11 @@ internal sealed partial class CombatBeamSolver
 
         private static void AddRequired(List<SearchNode> required, SearchNode? candidate, int limit)
         {
+            // 原来的 Any(lambda) 捕获 candidate，每次调用都要建闭包与委托；
+            // ContainsReference 是同样的顺序扫描 + 短路，只是不分配。
             if (candidate == null
                 || required.Count >= limit
-                || required.Any(node => ReferenceEquals(node, candidate)))
+                || ContainsReference(required, candidate))
             {
                 return;
             }

--- a/src/Search/CombatBeamSolver.BeamRetentionPolicy.cs
+++ b/src/Search/CombatBeamSolver.BeamRetentionPolicy.cs
@@ -374,6 +374,47 @@ internal sealed partial class CombatBeamSolver
                 preserveDefensiveRoute: true);
         }
 
+        // RankBest 每次调用都要重建的六张路由选择表。桶数组按 policy 实例复用；
+        // 键与内容每次都从空表开始重新填，所以聚合结果与每次新建完全一致。
+        private sealed class RoutingChoiceScratch
+        {
+            public Dictionary<RoutingChoiceSignature, SearchNode> BestScore { get; } = [];
+            public Dictionary<RoutingChoiceSignature, SearchNode> BestOffense { get; } = [];
+            public Dictionary<RoutingChoiceSignature, SearchNode> BestDefense { get; } = [];
+            public Dictionary<RoutingChoiceSignature, SearchNode> BestSetup { get; } = [];
+            public Dictionary<RoutingChoiceSignature, SearchNode> BestPileOrder { get; } = [];
+            public Dictionary<RoutingChoiceSignature, List<SearchNode>> NodesByChoice { get; } = [];
+
+            public void Clear()
+            {
+                BestScore.Clear();
+                BestOffense.Clear();
+                BestDefense.Clear();
+                BestSetup.Clear();
+                BestPileOrder.Clear();
+                NodesByChoice.Clear();
+            }
+        }
+
+        private RoutingChoiceScratch? _routingChoiceScratch;
+
+        private RoutingChoiceScratch RentRoutingChoiceScratch()
+        {
+            RoutingChoiceScratch? scratch = _routingChoiceScratch;
+            if (scratch is null)
+                return new RoutingChoiceScratch();
+            _routingChoiceScratch = null;
+            scratch.Clear();
+            return scratch;
+        }
+
+        private void ReturnRoutingChoiceScratch(RoutingChoiceScratch scratch)
+        {
+            // 归还时清空，避免把这一轮的 SearchNode 一直钉在缓冲里。
+            scratch.Clear();
+            _routingChoiceScratch = scratch;
+        }
+
         // 两处 Sort 用的都是同一个比较：捕获 this 的 lambda 每次转委托都要分配，缓存起来。
         private Comparison<SearchNode>? _beamRankComparison;
         private Comparison<SearchNode>? _finalCandidateComparison;
@@ -420,12 +461,16 @@ internal sealed partial class CombatBeamSolver
             List<SearchNode> routingChoices = [];
             if (preserveDefensiveRoute)
             {
-                Dictionary<RoutingChoiceSignature, SearchNode> bestScoreByRoutingChoice = [];
-                Dictionary<RoutingChoiceSignature, SearchNode> bestOffenseByRoutingChoice = [];
-                Dictionary<RoutingChoiceSignature, SearchNode> bestDefenseByRoutingChoice = [];
-                Dictionary<RoutingChoiceSignature, SearchNode> bestSetupByRoutingChoice = [];
-                Dictionary<RoutingChoiceSignature, SearchNode> bestPileOrderByRoutingChoice = [];
-                Dictionary<RoutingChoiceSignature, List<SearchNode>> nodesByRoutingChoice = [];
+                // 这六张表每次剪枝都重建一次，条目数与保留表同量级。它们只在本块内使用，
+                // 块末就没有任何引用逃逸，所以按 policy 实例复用桶数组：取用时先摘空字段
+                // （万一将来出现嵌套调用，内层自建一套），块末清空后归还。
+                RoutingChoiceScratch scratch = RentRoutingChoiceScratch();
+                Dictionary<RoutingChoiceSignature, SearchNode> bestScoreByRoutingChoice = scratch.BestScore;
+                Dictionary<RoutingChoiceSignature, SearchNode> bestOffenseByRoutingChoice = scratch.BestOffense;
+                Dictionary<RoutingChoiceSignature, SearchNode> bestDefenseByRoutingChoice = scratch.BestDefense;
+                Dictionary<RoutingChoiceSignature, SearchNode> bestSetupByRoutingChoice = scratch.BestSetup;
+                Dictionary<RoutingChoiceSignature, SearchNode> bestPileOrderByRoutingChoice = scratch.BestPileOrder;
+                Dictionary<RoutingChoiceSignature, List<SearchNode>> nodesByRoutingChoice = scratch.NodesByChoice;
                 foreach (SearchNode node in ranked)
                 {
                     RoutingChoiceSignature? signature = RetainedRoutingChoice(node);
@@ -585,6 +630,7 @@ internal sealed partial class CombatBeamSolver
                     }
                     routingRound++;
                 }
+                ReturnRoutingChoiceScratch(scratch);
             }
             if (ranked.Count <= limit)
             {
@@ -1570,14 +1616,16 @@ internal sealed partial class CombatBeamSolver
                  cursor?.Action is { } action;
                  cursor = cursor.Parent)
             {
-                if (action.TurnStartChoices is { Count: > 0 })
+                // Enumerable.Reverse 先把整段选择缓冲成一个数组再倒着走。这两段本来就是可按
+                // 下标访问的只读列表，直接倒序索引给出同样的访问序列与同样的首个命中即返回。
+                if (action.TurnStartChoices is { Count: > 0 } turnStartChoices)
                 {
-                    foreach (PlanCardChoice choice in action.TurnStartChoices.Reverse())
+                    for (int index = turnStartChoices.Count - 1; index >= 0; index--)
                     {
                         if (TryBuildRoutingChoice(
                                 node,
                                 cursor,
-                                choice,
+                                turnStartChoices[index],
                                 action.Turn + 1,
                                 minimumChoiceTurn,
                                 out RoutingChoiceSignature turnStartSignature))
@@ -1589,14 +1637,14 @@ internal sealed partial class CombatBeamSolver
                     }
                 }
 
-                if (action.NestedChoices is { Count: > 0 })
+                if (action.NestedChoices is { Count: > 0 } nestedChoices)
                 {
-                    foreach (PlanCardChoice choice in action.NestedChoices.Reverse())
+                    for (int index = nestedChoices.Count - 1; index >= 0; index--)
                     {
                         if (TryBuildRoutingChoice(
                                 node,
                                 cursor,
-                                choice,
+                                nestedChoices[index],
                                 action.Turn,
                                 minimumChoiceTurn,
                                 out RoutingChoiceSignature nestedSignature))

--- a/src/Search/CombatBeamSolver.Retention.cs
+++ b/src/Search/CombatBeamSolver.Retention.cs
@@ -90,16 +90,20 @@ internal sealed partial class CombatBeamSolver
         SearchMeasurement measurement = _run.Performance.Begin();
         try
         {
-            List<SearchNode> pool = nodes.ToList();
+            // Prune 只读取 pool，从不改动它，调用方传进来的若已经是 List 就直接沿用，
+            // 省掉一次整张候选表的复制。
+            List<SearchNode> pool = nodes as List<SearchNode> ?? nodes.ToList();
             List<SearchNode> global = Retention.RankBest(
                 pool,
                 _profile.BeamWidth,
                 preserveDefensiveRoute: true);
             List<SearchNode> selected = [.. global];
             HashSet<SearchNode> selectedSet = new(global, ReferenceEqualityComparer.Instance);
-            Dictionary<SearchNode, int> globalRetentionRanks = new(ReferenceEqualityComparer.Instance);
-            foreach (SearchNode candidate in global)
-                globalRetentionRanks.Add(candidate, candidate.RetentionRank);
+            // RankBest 的返回表按引用去重，保存/还原名次只需要一条与它同序的并行数组，
+            // 还原顺序与原来按插入序枚举字典完全一致。
+            int[] globalRetentionRanks = new int[global.Count];
+            for (int index = 0; index < global.Count; index++)
+                globalRetentionRanks[index] = global[index].RetentionRank;
             Dictionary<SearchNode, int> ancestorRetentionRanks = new(ReferenceEqualityComparer.Instance);
             foreach (SearchNode candidate in pool)
             {
@@ -118,8 +122,8 @@ internal sealed partial class CombatBeamSolver
                 candidate.LongTermResourceRetentionRank = candidate.RetentionRank;
             foreach ((SearchNode ancestor, int retentionRank) in ancestorRetentionRanks)
                 ancestor.RetentionRank = retentionRank;
-            foreach ((SearchNode candidate, int retentionRank) in globalRetentionRanks)
-                candidate.RetentionRank = retentionRank;
+            for (int index = 0; index < global.Count; index++)
+                global[index].RetentionRank = globalRetentionRanks[index];
             foreach (SearchNode candidate in longTermResource
                          .OrderBy(node => node.RetentionRank)
                          .ThenByDescending(node => node.Score))
@@ -163,7 +167,7 @@ internal sealed partial class CombatBeamSolver
                 pool.Count,
                 checked(selected.Count + Math.Max(12, _profile.BeamWidth / 3)));
             for (int round = 0;
-                 selected.Count < expandedLimit && openingChannels.Any(channel => round < channel.Count);
+                 selected.Count < expandedLimit && HasChannelAtRound(openingChannels, round);
                  round++)
             {
                 foreach (IReadOnlyList<SearchNode> channel in openingChannels)
@@ -182,6 +186,17 @@ internal sealed partial class CombatBeamSolver
         {
             _run.Performance.End(SearchMetricPhase.Prune, measurement);
         }
+    }
+
+    // 循环条件里的 Any(lambda) 捕获 round，每轮都要新建闭包与委托。
+    private static bool HasChannelAtRound(List<List<SearchNode>> channels, int round)
+    {
+        foreach (List<SearchNode> channel in channels)
+        {
+            if (round < channel.Count)
+                return true;
+        }
+        return false;
     }
 
     private List<SearchNode> ApplyPrimaryIncumbentBound(List<SearchNode> retained)

--- a/src/Search/CombatBeamSolver.StateEvaluation.cs
+++ b/src/Search/CombatBeamSolver.StateEvaluation.cs
@@ -31,6 +31,35 @@ namespace CombatSolver;
 
 internal sealed partial class CombatBeamSolver
 {
+    // 每个节点的快照都要一份牌组大小的临时牌表。这张表只在 Snapshot 内部被读、排序和洗牌，
+    // SimulationSnapshot 只收下它的 Count，没有任何出口持有它，所以可以按 solver 实例复用。
+    // 每个 CombatBeamSolver 实例只被一条线程使用（协调者跑主线程，每条 lane 有自己的 worker
+    // 和专属线程），取用时又先把字段摘空，万一出现嵌套调用内层会自己新建，不会共享同一块。
+    private List<PredictedCard>? _liveCardBuffer;
+
+    private List<PredictedCard> RentLiveCardBuffer()
+    {
+        List<PredictedCard>? buffer = _liveCardBuffer;
+        if (buffer is null)
+            return [];
+        _liveCardBuffer = null;
+        buffer.Clear();
+        return buffer;
+    }
+
+    private static bool HasUncompensatedDeathGap(IReadOnlyList<PredictionGap> gaps)
+    {
+        for (int index = 0; index < gaps.Count; index++)
+        {
+            if (!gaps[index].Compensated
+                && gaps[index].Method.Contains("Death", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private SimulationSnapshot Snapshot(
         CombatPredictionSimulator simulator,
         int turn,
@@ -88,8 +117,7 @@ internal sealed partial class CombatBeamSolver
         CoverageSummary coverage = GetCoverageSummary(simulator);
         IReadOnlyList<PredictionGap> predictionGaps = coverage.Gaps;
         bool risk = coverage.HasUncompensatedRisk;
-        bool uncertainVictory = won && predictionGaps.Any(gap =>
-            !gap.Compensated && gap.Method.Contains("Death", StringComparison.Ordinal));
+        bool uncertainVictory = won && HasUncompensatedDeathGap(predictionGaps);
         if (uncertainVictory)
             boundary = SearchBoundaryReason.UnsupportedEffect;
 
@@ -109,13 +137,13 @@ internal sealed partial class CombatBeamSolver
         // Projected shuffle needs these piles in this exact pre-sort order. The remaining
         // snapshot metrics are order-independent, so they can reuse the shuffled list instead
         // of materializing a second deck-sized backing array.
-        List<PredictedCard> liveCards = [
-            .. playerState.DiscardPile.Cards,
-            .. playerState.DrawPile.Cards,
-            .. playerState.Hand.Cards,
-        ];
+        List<PredictedCard> liveCards = RentLiveCardBuffer();
+        liveCards.AddRange(playerState.DiscardPile.Cards);
+        liveCards.AddRange(playerState.DrawPile.Cards);
+        liveCards.AddRange(playerState.Hand.Cards);
         (StateFingerprint projectedShuffleOrderKey, int projectedShuffleOrderValue) =
             BuildProjectedShuffleOrder(simulator, liveCards);
+        int liveCardCount = liveCards.Count;
         _run.Performance.End(
             SearchMetricPhase.ProjectedShuffle,
             projectedShuffleMeasurement);
@@ -359,6 +387,10 @@ internal sealed partial class CombatBeamSolver
             aliveEnemyMask,
             potionInventoryKey,
             boundary);
+        // 到这里 liveCards 的最后一个读者已经走完，快照只收 Count。归还缓冲；若上面任何一步
+        // 抛出，缓冲只是被丢弃，下一次 Snapshot 重新分配一块，正确性不受影响。
+        liveCards.Clear();
+        _liveCardBuffer = liveCards;
         return new SimulationSnapshot(
             score,
             key,
@@ -409,7 +441,7 @@ internal sealed partial class CombatBeamSolver
             enemyControlDistributionKey,
             sandpitRemaining,
             liveDeckClutter,
-            liveCards.Count,
+            liveCardCount,
             outstandingStolenResource,
             offensiveProgressValue,
             playerState.Energy,

--- a/src/Search/CombatBeamSolver.StateEvaluation.cs
+++ b/src/Search/CombatBeamSolver.StateEvaluation.cs
@@ -301,20 +301,26 @@ internal sealed partial class CombatBeamSolver
             : simulator.State.GetCreature(currentOsty).CurrentHp;
         int ostyMaxHp = combat.GetOstyMaxHp(simulator, _player);
         persistentBuffValue += liveCards.Count(card => card.Preview is Soul);
-        int delayedDamageValue = combat.KnownEnemies
-            .Where(enemy => combat.ContainsCreature(enemy) && simulator.State.GetCreature(enemy).IsAlive)
-            .Sum(enemy =>
-            {
-                int poison = Math.Max(0, combat.GetAmount<PoisonPower>(enemy));
-                int demise = Math.Max(0, combat.GetAmount<DemisePower>(enemy));
-                int doom = Math.Max(0, combat.GetAmount<DoomPower>(enemy));
-                int currentHp = Math.Max(0, simulator.State.GetCreature(enemy).CurrentHp);
-                int cappedDoom = Math.Min(currentHp, doom);
-                int doomProgress = currentHp <= 0
-                    ? 0
-                    : (int)Math.Min(currentHp, (long)cappedDoom * cappedDoom / currentHp);
-                return poison + demise + doomProgress;
-            });
+        // Where + Sum 两个闭包加一个装箱的 ForkableList 枚举器，换成按下标累加：
+        // 筛选条件、累加顺序与每项的整数运算完全不变。
+        IReadOnlyList<Creature> knownEnemies = combat.KnownEnemies;
+        int delayedDamageValue = 0;
+        for (int enemyIndex = 0; enemyIndex < knownEnemies.Count; enemyIndex++)
+        {
+            Creature enemy = knownEnemies[enemyIndex];
+            if (!combat.ContainsCreature(enemy) || !simulator.State.GetCreature(enemy).IsAlive)
+                continue;
+            int poison = Math.Max(0, combat.GetAmount<PoisonPower>(enemy));
+            int demise = Math.Max(0, combat.GetAmount<DemisePower>(enemy));
+            int doom = Math.Max(0, combat.GetAmount<DoomPower>(enemy));
+            int currentHp = Math.Max(0, simulator.State.GetCreature(enemy).CurrentHp);
+            int cappedDoom = Math.Min(currentHp, doom);
+            int doomProgress = currentHp <= 0
+                ? 0
+                : (int)Math.Min(currentHp, (long)cappedDoom * cappedDoom / currentHp);
+            // Enumerable.Sum 对 int 是 checked 累加，这里照搬同样的溢出语义。
+            delayedDamageValue = checked(delayedDamageValue + poison + demise + doomProgress);
+        }
         int reactiveDamageValue = Math.Max(
             0,
             combat.GetAmount<SleightOfFleshPower>(_player.Creature));
@@ -330,8 +336,9 @@ internal sealed partial class CombatBeamSolver
         uint? mostVulnerableTargetCombatId = null;
         int mostVulnerableTurns = 0;
         StateFingerprintBuilder enemyControlDistribution = new();
-        foreach (Creature enemy in combat.KnownEnemies)
+        for (int enemyIndex = 0; enemyIndex < knownEnemies.Count; enemyIndex++)
         {
+            Creature enemy = knownEnemies[enemyIndex];
             if (!combat.ContainsCreature(enemy) || !simulator.State.GetCreature(enemy).IsAlive)
                 continue;
             int strengthSuppression = -combat.GetAmount<StrengthPower>(enemy);
@@ -852,8 +859,10 @@ internal sealed partial class CombatBeamSolver
         int bestThreat = 0;
         int totalThreat = 0;
         int incomingHitCount = 0;
-        foreach (Creature enemy in combat.KnownEnemies)
+        IReadOnlyList<Creature> knownEnemies = combat.KnownEnemies;
+        for (int enemyIndex = 0; enemyIndex < knownEnemies.Count; enemyIndex++)
         {
+            Creature enemy = knownEnemies[enemyIndex];
             SimCreatureState enemyState = simulator.State.GetCreature(enemy);
             if (!combat.ContainsCreature(enemy)
                 || !enemyState.IsAlive
@@ -867,16 +876,21 @@ internal sealed partial class CombatBeamSolver
             int currentThreat = 0;
             if (!combat.WillSkipNextMove(enemy))
             {
-                foreach (ForecastMove move in moves)
+                for (int moveIndex = 0; moveIndex < moves.Count; moveIndex++)
                 {
+                    ForecastMove move = moves[moveIndex];
                     if (!ReferenceEquals(move.Owner, enemy))
                         continue;
-                    foreach (ForecastAttackHit hit in move.AttackHits)
+                    IReadOnlyList<ForecastAttackHit> attackHits = move.AttackHits;
+                    for (int hitIndex = 0; hitIndex < attackHits.Count; hitIndex++)
                     {
                         incomingHitCount++;
                         currentThreat += Math.Max(
                             0,
-                            combat.AdjustMonsterMoveDamage(enemy, move.Move.Id, hit.BaseDamage));
+                            combat.AdjustMonsterMoveDamage(
+                                enemy,
+                                move.Move.Id,
+                                attackHits[hitIndex].BaseDamage));
                     }
                 }
             }
@@ -936,8 +950,9 @@ internal sealed partial class CombatBeamSolver
             simulatedCombat,
             player.MaxHp);
         IReadOnlyList<ForecastMove> moves = simulatedCombat.CurrentMonsterMoves();
-        foreach (ForecastMove move in moves)
+        for (int moveIndex = 0; moveIndex < moves.Count; moveIndex++)
         {
+            ForecastMove move = moves[moveIndex];
             if (!simulator.State.GetCreature(move.Owner).IsAlive)
                 continue;
             if (simulatedCombat.WillSkipNextMove(move.Owner))
@@ -961,9 +976,13 @@ internal sealed partial class CombatBeamSolver
                     ref deathPrevention);
                 continue;
             }
-            foreach (ForecastAttackHit hit in move.AttackHits)
+            IReadOnlyList<ForecastAttackHit> attackHits = move.AttackHits;
+            for (int hitIndex = 0; hitIndex < attackHits.Count; hitIndex++)
             {
-                int baseDamage = simulatedCombat.AdjustMonsterMoveDamage(move.Owner, move.Move.Id, hit.BaseDamage);
+                int baseDamage = simulatedCombat.AdjustMonsterMoveDamage(
+                    move.Owner,
+                    move.Move.Id,
+                    attackHits[hitIndex].BaseDamage);
                 ProjectThreatHit(
                     simulator,
                     simulatedCombat,
@@ -1119,8 +1138,10 @@ internal sealed partial class CombatBeamSolver
             key.Add(0);
             key.Add(false);
         }
-        foreach (Creature enemy in simulatedCombat.KnownEnemies)
+        IReadOnlyList<Creature> knownEnemies = simulatedCombat.KnownEnemies;
+        for (int enemyIndex = 0; enemyIndex < knownEnemies.Count; enemyIndex++)
         {
+            Creature enemy = knownEnemies[enemyIndex];
             SimCreatureState enemyState = simulator.State.GetCreature(enemy);
             key.Add(enemy.Monster?.Id.Entry);
             key.Add(enemy.CombatId ?? uint.MaxValue);

--- a/src/Search/ForkableCollections.cs
+++ b/src/Search/ForkableCollections.cs
@@ -59,9 +59,14 @@ internal sealed class ForkableList<T> : IReadOnlyList<T>
 
     public bool Remove(T value)
     {
-        if (!_storage.Values.Contains(value))
-            return false;
-        EnsureWritable();
+        // 未命中的 Remove 不得触发写时复制，所以只有共享存储才需要先探测一次。
+        // 独占存储直接删，省掉 Contains + Remove 的双次线性查找。
+        if (_storage.Shared)
+        {
+            if (!_storage.Values.Contains(value))
+                return false;
+            EnsureWritable();
+        }
         return _storage.Values.Remove(value);
     }
 
@@ -145,9 +150,13 @@ internal sealed class ForkableDictionary<TKey, TValue> : IReadOnlyDictionary<TKe
 
     public bool Remove(TKey key)
     {
-        if (!_storage.Values.ContainsKey(key))
-            return false;
-        EnsureWritable();
+        // 未命中的 Remove 不得触发写时复制，所以只有共享存储才需要先探测一次。
+        if (_storage.Shared)
+        {
+            if (!_storage.Values.ContainsKey(key))
+                return false;
+            EnsureWritable();
+        }
         return _storage.Values.Remove(key);
     }
 
@@ -229,9 +238,14 @@ internal sealed class ForkableSet<T> : ISet<T>, IReadOnlySet<T>
 
     public bool Add(T value)
     {
-        if (_storage.Values.Contains(value))
-            return false;
-        EnsureWritable();
+        // 重复的 Add 不得触发写时复制，所以只有共享存储才需要先探测一次。
+        // 独占存储直接加，省掉 Contains + Add 的双次哈希查找。
+        if (_storage.Shared)
+        {
+            if (_storage.Values.Contains(value))
+                return false;
+            EnsureWritable();
+        }
         return _storage.Values.Add(value);
     }
 
@@ -239,9 +253,13 @@ internal sealed class ForkableSet<T> : ISet<T>, IReadOnlySet<T>
 
     public bool Remove(T value)
     {
-        if (!_storage.Values.Contains(value))
-            return false;
-        EnsureWritable();
+        // 未命中的 Remove 不得触发写时复制，所以只有共享存储才需要先探测一次。
+        if (_storage.Shared)
+        {
+            if (!_storage.Values.Contains(value))
+                return false;
+            EnsureWritable();
+        }
         return _storage.Values.Remove(value);
     }
 

--- a/src/Search/SimulatedCombatState.Fork.cs
+++ b/src/Search/SimulatedCombatState.Fork.cs
@@ -176,11 +176,28 @@ internal sealed partial class SimulatedCombatState
 
         if (_effectiveRunHookListeners is not null)
         {
-            fork._effectiveRunHookListeners = ReferenceEquals(
-                _effectiveRunHookListeners,
-                _effectiveHookListeners)
-                ? fork._effectiveHookListeners
-                : RemapCachedModels(_effectiveRunHookListeners, context);
+            if (ReferenceEquals(_effectiveRunHookListeners, _effectiveHookListeners))
+            {
+                fork._effectiveRunHookListeners = fork._effectiveHookListeners;
+            }
+            else if (_effectiveRunHookListeners is ConcatenatedListenerView view
+                && ReferenceEquals(view.Suffix, _effectiveHookListeners)
+                && fork._effectiveHookListeners is { } forkedSuffix)
+            {
+                // 逐元素重映射对拼接是可分配的：remap(前缀 ++ 后缀) == remap(前缀) ++ remap(后缀)。
+                // 后缀就是刚刚重映射好的战斗监听表，前缀是根牌组快照（只含 CardModel/Enchantment，
+                // 从不作为 Fork 源登记），两段都没变时连视图对象一起复用。
+                IReadOnlyList<AbstractModel> forkedPrefix = RemapCachedModels(view.Prefix, context);
+                fork._effectiveRunHookListeners =
+                    ReferenceEquals(forkedPrefix, view.Prefix)
+                        && ReferenceEquals(forkedSuffix, view.Suffix)
+                        ? _effectiveRunHookListeners
+                        : new ConcatenatedListenerView(forkedPrefix, forkedSuffix);
+            }
+            else
+            {
+                fork._effectiveRunHookListeners = RemapCachedModels(_effectiveRunHookListeners, context);
+            }
         }
 
     }

--- a/src/Search/SimulatedCombatState.Fork.cs
+++ b/src/Search/SimulatedCombatState.Fork.cs
@@ -78,7 +78,12 @@ internal sealed partial class SimulatedCombatState
         };
 
         if (_addedPowerInstances is not null)
-            fork._addedPowerInstances = _addedPowerInstances.Select(power => ForkPower(power, context)).ToList();
+        {
+            List<PowerModel> addedPowerInstances = new(_addedPowerInstances.Count);
+            foreach (PowerModel power in _addedPowerInstances)
+                addedPowerInstances.Add(ForkPower(power, context));
+            fork._addedPowerInstances = addedPowerInstances;
+        }
         if (_rootMultiInstancePowerClones is not null)
         {
             fork._rootMultiInstancePowerClones = new(
@@ -110,11 +115,18 @@ internal sealed partial class SimulatedCombatState
         fork._dampenOriginalUpgrades = ForkDampenCards(context);
         fork._lastAttackThisTurn = ForkHistoryCourseCards(_lastAttackThisTurn, context);
         fork._lastAttackPreviousTurn = ForkHistoryCourseCards(_lastAttackPreviousTurn, context);
-        fork._registeredCombatCards = ForkCardList(_registeredCombatCards, context);
-        if (fork._registeredCombatCards is not null)
+        if (_registeredCombatCards is not null)
         {
-            foreach (PredictedCard card in fork._registeredCombatCards)
-                fork.ObserveCardMutations(card);
+            // 观察者只往卡上写一个回调，不读也不写任何被 ForkCard 改动的状态，
+            // 所以可以和分叉同一趟走完：卡的顺序、ForkCard 的调用序列都不变。
+            List<PredictedCard> registeredCombatCards = new(_registeredCombatCards.Count);
+            foreach (PredictedCard card in _registeredCombatCards)
+            {
+                PredictedCard forkedCard = ForkCard(card, context);
+                registeredCombatCards.Add(forkedCard);
+                fork.ObserveCardMutations(forkedCard);
+            }
+            fork._registeredCombatCards = registeredCombatCards;
         }
         fork._generatedCombatCards = ForkCardList(_generatedCombatCards, context);
 

--- a/src/Search/SimulatedCombatState.PowerLifecycle.cs
+++ b/src/Search/SimulatedCombatState.PowerLifecycle.cs
@@ -150,8 +150,10 @@ internal sealed partial class SimulatedCombatState
                 vitalSparkAmount = checked(vitalSparkAmount + vitalSpark.Amount);
         }
         bool hasVitalSpark = vitalSparkAmount > 0;
-        foreach (Player player in Players)
+        IReadOnlyList<Player> players = Players;
+        for (int playerIndex = 0; playerIndex < players.Count; playerIndex++)
         {
+            Player player = players[playerIndex];
             Creature owner = player.Creature;
             // Vital Spark is owned by Infested Prism but its vanilla hooks afflict every player
             // Skill, not creatures on the Power owner's side.
@@ -208,8 +210,10 @@ internal sealed partial class SimulatedCombatState
     private void NormalizeSwordSageReplays(CombatPredictionSimulator simulator)
     {
         _swordSageReplayBonuses ??= [];
-        foreach (Player player in Players)
+        IReadOnlyList<Player> players = Players;
+        for (int playerIndex = 0; playerIndex < players.Count; playerIndex++)
         {
+            Player player = players[playerIndex];
             int desired = GetAmount<SwordSagePower>(player.Creature);
             int liveAmount = player.Creature.GetPower<SwordSagePower>()?.Amount ?? 0;
             foreach (PredictedCard card in simulator.State.GetPlayerCombatState(player).AllCards)

--- a/src/Search/SimulatedCombatState.Relics.cs
+++ b/src/Search/SimulatedCombatState.Relics.cs
@@ -309,11 +309,26 @@ internal sealed partial class SimulatedCombatState
     {
         if (_statefulRelicStates?.TryGetValue(relic, out StatefulRelicState state) == true)
             return state;
-        if (_rootMaterialized && _rootRelics.Values.Any(relics => relics.Contains(relic)))
+        // Any(lambda) 捕获参数 relic，Roslyn 会把参数提升进方法入口就分配的闭包对象里 ——
+        // 连命中缓存的快路径也要付这一次分配。换成显式扫描，判定结果不变。
+        if (_rootMaterialized && IsCapturedRootRelic(relic))
             throw new InvalidOperationException($"Root relic state was not captured for {relic.Id.Entry}.");
         state = CaptureLiveState(_rootRelicSources?.GetValueOrDefault(relic, relic) ?? relic);
         (_statefulRelicStates ??= [])[relic] = state;
         return state;
+    }
+
+    private bool IsCapturedRootRelic(RelicModel relic)
+    {
+        foreach (RelicModel[] relics in _rootRelics.Values)
+        {
+            for (int index = 0; index < relics.Length; index++)
+            {
+                if (EqualityComparer<RelicModel>.Default.Equals(relics[index], relic))
+                    return true;
+            }
+        }
+        return false;
     }
 
     private StatefulRelicState PeekStatefulRelicState(RelicModel relic)
@@ -341,17 +356,7 @@ internal sealed partial class SimulatedCombatState
                 (bool)BeltBuckleDexterityAppliedField.GetValue(buckle)! ? 1 : 0,
                 0),
             BoneTea tea => new StatefulRelicState(tea.CombatsLeft, 0),
-            EmotionChip chip => new StatefulRelicState(
-                CombatManager.Instance.History.Entries
-                    .OfType<DamageReceivedEntry>()
-                    .Any(entry => ReferenceEquals(entry.Receiver, chip.Owner.Creature)
-                                  && !entry.Result.WasFullyBlocked
-                                  && entry.HappenedLastPlayerTurn(chip.Owner)) ? 1 : 0,
-                CombatManager.Instance.History.Entries
-                    .OfType<DamageReceivedEntry>()
-                    .Any(entry => ReferenceEquals(entry.Receiver, chip.Owner.Creature)
-                                  && !entry.Result.WasFullyBlocked
-                                  && entry.HappenedThisTurn(chip.Owner.Creature.CombatState)) ? 1 : 0),
+            EmotionChip chip => CaptureEmotionChipState(chip),
             FakeHappyFlower flower => new StatefulRelicState(flower.TurnsSeen, 0),
             FakeVenerableTeaSet tea => new StatefulRelicState(tea.GainEnergyInNextCombat ? 1 : 0, 0),
             HappyFlower flower => new StatefulRelicState(flower.TurnsSeen, 0),
@@ -371,6 +376,39 @@ internal sealed partial class SimulatedCombatState
             VenerableTeaSet tea => new StatefulRelicState(tea.GainEnergyInNextCombat ? 1 : 0, 0),
             _ => default,
         };
+
+    // 原来这一段挂在 CaptureLiveState 的 switch 分支里，两条 OfType().Any() 各带一个捕获
+    // chip 的闭包，闭包对象随分支作用域在方法里被提升分配。搬成独立方法后 CaptureLiveState
+    // 本身不再有任何闭包，两个判定改成同序短路扫描，结果不变。
+    private static StatefulRelicState CaptureEmotionChipState(EmotionChip chip)
+    {
+        Creature receiver = chip.Owner.Creature;
+        bool lastPlayerTurn = false;
+        foreach (var entry in CombatManager.Instance.History.Entries)
+        {
+            if (entry is DamageReceivedEntry damage
+                && ReferenceEquals(damage.Receiver, receiver)
+                && !damage.Result.WasFullyBlocked
+                && damage.HappenedLastPlayerTurn(chip.Owner))
+            {
+                lastPlayerTurn = true;
+                break;
+            }
+        }
+        bool thisTurn = false;
+        foreach (var entry in CombatManager.Instance.History.Entries)
+        {
+            if (entry is DamageReceivedEntry damage
+                && ReferenceEquals(damage.Receiver, receiver)
+                && !damage.Result.WasFullyBlocked
+                && damage.HappenedThisTurn(receiver.CombatState))
+            {
+                thisTurn = true;
+                break;
+            }
+        }
+        return new StatefulRelicState(lastPlayerTurn ? 1 : 0, thisTurn ? 1 : 0);
+    }
 
     private static bool IsStatefulRelic(RelicModel relic)
         => relic is ArtOfWar

--- a/src/Search/SimulatedCombatState.cs
+++ b/src/Search/SimulatedCombatState.cs
@@ -94,7 +94,7 @@ internal sealed partial class SimulatedCombatState
     // 元素与顺序和把两段拷进同一个 List 完全一致。
     private sealed class ConcatenatedListenerView(
         IReadOnlyList<AbstractModel> prefix,
-        IReadOnlyList<AbstractModel> suffix) : IReadOnlyList<AbstractModel>
+        IReadOnlyList<AbstractModel> suffix) : IReadOnlyList<AbstractModel>, ISegmentedModelList
     {
         public IReadOnlyList<AbstractModel> Prefix { get; } = prefix;
         public IReadOnlyList<AbstractModel> Suffix { get; } = suffix;

--- a/src/Search/SimulatedCombatState.cs
+++ b/src/Search/SimulatedCombatState.cs
@@ -78,12 +78,35 @@ internal sealed partial class SimulatedCombatState
     {
         public int Count => first.Count + second.Count;
         public Creature this[int index] => index < first.Count ? first[index] : second[index - first.Count];
+        // 原来内层用 foreach 走两个接口类型的 IReadOnlyList，除了迭代器状态机自身还各装箱一个
+        // ForkableList 枚举器。按下标推进给出完全相同的序列，只留状态机一个对象。
         public IEnumerator<Creature> GetEnumerator()
         {
-            foreach (Creature creature in first)
-                yield return creature;
-            foreach (Creature creature in second)
-                yield return creature;
+            for (int index = 0; index < first.Count; index++)
+                yield return first[index];
+            for (int index = 0; index < second.Count; index++)
+                yield return second[index];
+        }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    // 只读拼接视图：把两段已经算好的监听器快照按 前缀→后缀 的顺序对外呈现为一个序列，
+    // 元素与顺序和把两段拷进同一个 List 完全一致。
+    private sealed class ConcatenatedListenerView(
+        IReadOnlyList<AbstractModel> prefix,
+        IReadOnlyList<AbstractModel> suffix) : IReadOnlyList<AbstractModel>
+    {
+        public IReadOnlyList<AbstractModel> Prefix { get; } = prefix;
+        public IReadOnlyList<AbstractModel> Suffix { get; } = suffix;
+        public int Count => Prefix.Count + Suffix.Count;
+        public AbstractModel this[int index]
+            => index < Prefix.Count ? Prefix[index] : Suffix[index - Prefix.Count];
+        public IEnumerator<AbstractModel> GetEnumerator()
+        {
+            for (int index = 0; index < Prefix.Count; index++)
+                yield return Prefix[index];
+            for (int index = 0; index < Suffix.Count; index++)
+                yield return Suffix[index];
         }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
     }
@@ -1468,10 +1491,13 @@ internal sealed partial class SimulatedCombatState
             _effectiveRunHookListeners = combatListeners;
             return _effectiveRunHookListeners;
         }
-        List<AbstractModel> listeners = new(_rootRunHookListeners.Length + combatListeners.Count);
-        listeners.AddRange(_rootRunHookListeners);
-        listeners.AddRange(combatListeners);
-        _effectiveRunHookListeners = listeners;
+        // 运行级监听表 = 不可变的根牌组前缀 + 战斗监听表。两段都是已经算好的只读快照，
+        // 原来每次失效都要把它们拷进一个牌组大小的新 List；改用只读拼接视图给出逐条同序的
+        // 同一序列，把整表拷贝降成一个两字段对象。消费方（HookListenerEnumerable、无人测试
+        // 的下标断言）全部按 Count/索引访问，看到的元素与顺序完全一致。
+        _effectiveRunHookListeners = new ConcatenatedListenerView(
+            _rootRunHookListeners,
+            combatListeners);
         return _effectiveRunHookListeners;
     }
 
@@ -1605,8 +1631,12 @@ internal sealed partial class SimulatedCombatState
                 listeners.Add(listener);
             }
         }
-        foreach (Player player in Players)
+        // 下面几处原来用接口类型 foreach / LINQ Where 走 Players、Creatures 与已注册卡表，
+        // 每次重建都要装箱枚举器并新建闭包。改成按下标推进，遍历顺序与筛选条件都不变。
+        IReadOnlyList<Player> players = Players;
+        for (int playerIndex = 0; playerIndex < players.Count; playerIndex++)
         {
+            Player player = players[playerIndex];
             for (int slot = 0; slot < PotionSlotCount(player); slot++)
             {
                 PotionModel? potion = GetPotionAtSlot(player, slot);
@@ -1614,23 +1644,29 @@ internal sealed partial class SimulatedCombatState
                     listeners.Add(potion);
             }
         }
-        foreach (Creature creature in Creatures.Where(creature => !_rootCreatures.Contains(creature)))
+        IReadOnlyList<Creature> creatures = Creatures;
+        for (int creatureIndex = 0; creatureIndex < creatures.Count; creatureIndex++)
         {
+            Creature creature = creatures[creatureIndex];
+            if (_rootCreatures.Contains(creature))
+                continue;
             listeners.AddRange(creature.Powers);
             if (creature.Monster != null)
                 listeners.Add(creature.Monster);
         }
         CombatPredictionState predictionState = _predictionState
             ?? throw new InvalidOperationException("Combat prediction state is not attached.");
-        foreach (Player player in Players)
-            listeners.AddRange(predictionState.GetPlayerCombatState(player).OrbQueue.Orbs);
+        for (int playerIndex = 0; playerIndex < players.Count; playerIndex++)
+            listeners.AddRange(predictionState.GetPlayerCombatState(players[playerIndex]).OrbQueue.Orbs);
         if (_registeredCombatCards != null)
         {
             List<CardModel>? cardAttachedListenerOwners =
                 _modHookSubscribers.HasBaseLibCardModifiers ? [] : null;
-            foreach (PredictedCard card in _registeredCombatCards
-                         .Where(card => !card.Preview.HasBeenRemovedFromState))
+            for (int cardIndex = 0; cardIndex < _registeredCombatCards.Count; cardIndex++)
             {
+                PredictedCard card = _registeredCombatCards[cardIndex];
+                if (card.Preview.HasBeenRemovedFromState)
+                    continue;
                 CardModel preview = card.Preview;
                 listeners.Add(preview);
                 if (preview.Affliction != null)


### PR DESCRIPTION
## 改动

Fork 与剪枝：
- `PredictionForkContext` 按上一次的条目数预估容量、一开始就建身份索引，不再每次 Fork 先线性扫 64 条再重建索引。
- `ForkableList/Dictionary/Set` 在独占存储上直接 Add/Remove，不再先 Contains 一遍；共享存储照旧先探测，未命中不触发复制。
- `SimulatedCombatState.Fork` 里已注册卡的两趟遍历合成一趟；`PredictionStateStore` 去掉只有一个实现的 `StateEntry` 包装，别名表和移除名册改成用到才建。
- 快照里牌组大小的临时牌表按 solver 实例复用；Prune / RankBest 去掉重复遍历、每次调用的闭包和临时字典。

热路径（目标来自 gc-verbose 分配采样）：
- 运行级监听表改成"根牌组前缀 + 战斗监听表"的拼接视图，hook 分发按段迭代；基础监听表重建去掉 LINQ 和装箱枚举器。
- 一批热路径上的接口 foreach 改成按下标推进（`CombinedRosterView`、`HasKeyword`、`ApplyEnemyDeathPowers` 等）。
- `GetStatefulRelicState`、`CaptureLiveState`、回合开始/结束的 Power 触发去掉闭包；`EffectivePowers().ToArray()` 这个防御性拷贝去掉了，数组发布后没有写者。
- 剪枝的六张路由字典按 policy 实例复用；`PredictionTrace` 的帧改成读到 `Current` 才建（帧的引用身份和 Parent 链保持不变）；费用查询的 mirror context 按模拟器复用；单张入堆走单张重载；历史段序缓存。

## 数据

固定机甲骑士首轮（并行 4、普通 GC、不开阶段计量），i7-12700H，交替各两次。两个版本都是 10827 展开 / 96967 转移 / 分数 10000197968 / 掉血 28。

| | 耗时 | 搜索线程分配 | GC 暂停 |
| --- | --- | ---: | ---: |
| 0.28.2 | 29.86 / 30.34 s | 6.20 GB | 6.8 / 6.7 s |
| 本 PR | 29.61 / 30.17 s | 5.46 GB | 6.4 / 6.4 s |

NoGC 默认配置下（本机有效预算 2.6 到 4.5 GB 之间浮动），搜索中的阻塞回收从 4 次降到 3 次、8 次降到 6 次，跟分配比例一致。

## 验证

- `verify-refactor-boundaries.ps1` 通过。
- 活雾 `-VerifyIncrementalSearch`：12076 次前缀回放全部一致，展开 / 转移 / 分数与基线相同。
- 活雾 1 线程与 8 线程对拍：展开、转移、duplicate、transposition、sold_hp、stand_pat、分数全部相等。
- `-VerifyForkBoundaries` 通过。
- 哨兵 `FAIRY-AUTOMATIC-RESCUE-FINAL2-0150`、`RINGING-HAVOC-AUTOPLAY-0160-FINAL`、`POST0201-BRAND-POST-CHOICE-POWER-FORK-FINAL`、`MECHA-MEMORY-FULL-AUTO` 通过。
- `BATCH-164623-ORB-DEATH-POWER-ORDER-CONTINUATION`、`RELIC-REACTIVE-BATCH-057-EMOTION-FINAL`、`RELIC-POCKETWATCH-053`、`CARD-ON-PLAY-BATCH-043-VOID-FORM` 通过。

BaseLib CardModifier 那条分支我这边没有环境跑，麻烦顺手过一下。
