### PR TITLE
fix: 只覆写战斗外 hook 的 ModHelper 订阅器不再判为不兼容 Mod

### DIFF
--- a/src/Prediction/PredictionModHookSubscriberCapture.cs
+++ b/src/Prediction/PredictionModHookSubscriberCapture.cs
@@ -137,6 +137,15 @@ internal sealed class PredictionModHookSubscriberCapture
         {
             return;
         }
+        // 只覆写了地图/进幕/事件/休息处/商店这类战斗外 hook 的订阅器不可能改变战斗模拟结果，
+        // 不必把整个 Mod 判为不兼容。任何战斗 hook 覆写（含继承来的）仍走下面的拒绝路径。
+        if (PredictionModHookSubscriberInertness.IsCombatInert(type, out string overriddenHooks))
+        {
+            Entry.Logger.Info(
+                $"[CombatSolver/Test] MOD_HOOK_SUBSCRIBER_COMBAT_INERT scope={scope} " +
+                $"mod={mod?.manifest?.id ?? "-"} type={type.FullName} hooks={overriddenHooks}");
+            return;
+        }
         if (!isBaseGame
             && mod?.manifest?.id is { Length: > 0 } modId
             && !string.Equals(modId, Entry.ModId, StringComparison.OrdinalIgnoreCase))

--- a/src/Prediction/PredictionModHookSubscriberInertness.cs
+++ b/src/Prediction/PredictionModHookSubscriberInertness.cs
@@ -1,0 +1,128 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using MegaCrit.Sts2.Core.Models;
+
+namespace CombatSolver;
+
+/// <summary>
+/// 判断一个 ModHelper 订阅器是否与战斗预测无关：它在 <see cref="AbstractModel"/> 上覆写的所有
+/// hook 要么只在战斗之外分发（地图生成、进幕、事件抽取、休息处、商店），要么只在战斗开始时分发一次、
+/// 早于求解器在回合开始捕获预测根，且求解器从不镜像它们。这样的订阅器不可能改变模拟结果，
+/// 不必把整个 Mod 判为不兼容。判定沿继承链向上收集全部覆写（含中间基类与泛型基类），
+/// 任何一个落在清单之外的 hook 都视为参与战斗。
+/// </summary>
+internal static class PredictionModHookSubscriberInertness
+{
+    /// <summary>
+    /// 与战斗预测无关的 hook。前一组只在战斗之外分发，每一项都核对过游戏里的调用点：
+    /// 地图与进幕在 RunManager，事件抽取在 ActModel，未知节点房型在 UnknownMapPointOdds，
+    /// 休息处在 RestSite 选项，商店在 Merchant 条目与 CardFactory 的商店牌池。
+    /// 后两组分别是战斗开始 hook 与战斗结束 hook：前者在 CombatManager.TurnStarted 之前就已经执行完毕，
+    /// 效果已经落在被捕获的根状态里（与 KnownPreRootSubscriberTypeNames 同一道理）；后者在胜负判定
+    /// 之后才由 CombatRoom 分发，搜索到战斗结束就停止。求解器的镜像从不触发这两组中的任何一个。
+    /// 战斗期间也会触发的 hook（例如 AfterRoomEntered、金币、药水、奖励选项、加牌入牌组）刻意不在其中。
+    /// </summary>
+    private static readonly HashSet<string> PredictionInertHookNames = new(StringComparer.Ordinal)
+    {
+        nameof(AbstractModel.ModifyGeneratedMap),
+        nameof(AbstractModel.ModifyGeneratedMapLate),
+        nameof(AbstractModel.AfterMapGenerated),
+        nameof(AbstractModel.AfterActEntered),
+        nameof(AbstractModel.ModifyNextEvent),
+        nameof(AbstractModel.ModifyUnknownMapPointRoomTypes),
+        nameof(AbstractModel.ModifyOddsIncreaseForUnrolledRoomType),
+        nameof(AbstractModel.AfterRestSiteHeal),
+        nameof(AbstractModel.AfterRestSiteSmith),
+        nameof(AbstractModel.ModifyRestSiteHealAmount),
+        nameof(AbstractModel.TryModifyRestSiteHealRewards),
+        nameof(AbstractModel.TryModifyRestSiteOptions),
+        nameof(AbstractModel.AfterItemPurchased),
+        nameof(AbstractModel.ModifyMerchantCardPool),
+        nameof(AbstractModel.ModifyMerchantCardRarity),
+        nameof(AbstractModel.ModifyMerchantCardCreationResults),
+        nameof(AbstractModel.ModifyMerchantPrice),
+        nameof(AbstractModel.BeforeCombatStart),
+        nameof(AbstractModel.BeforeCombatStartLate),
+        nameof(AbstractModel.AfterCombatVictoryEarly),
+        nameof(AbstractModel.AfterCombatVictory),
+        nameof(AbstractModel.AfterCombatEnd),
+        nameof(AbstractModel.BeforeCombatRewardOffered),
+    };
+
+    /// <summary>
+    /// <see cref="AbstractModel"/> 上不是 hook 的虚成员。覆写它们不会让订阅器收到任何战斗事件：
+    /// <c>ShouldReceiveCombatHooks</c> 只决定战斗 hook 是否投递，投递到一个没有覆写任何战斗 hook 的
+    /// 模型上仍是空操作；其余是比较与展示用途。
+    /// </summary>
+    private static readonly HashSet<string> NonHookMemberNames = new(StringComparer.Ordinal)
+    {
+        nameof(AbstractModel.ShouldReceiveCombatHooks),
+        nameof(AbstractModel.IsMock),
+        nameof(AbstractModel.PreviewOutsideOfCombat),
+        nameof(AbstractModel.CompareTo),
+    };
+
+    private static readonly ConcurrentDictionary<Type, (bool Inert, string Overrides)> Cache = new();
+
+    /// <summary>
+    /// 订阅器类型是否与战斗无关。<paramref name="overriddenHooks"/> 返回沿继承链收集到的全部
+    /// <see cref="AbstractModel"/> hook 覆写名（逗号分隔，用于日志）。
+    /// 反射失败、类型不是 <see cref="AbstractModel"/>、或任一覆写不在清单内，都返回 false。
+    /// </summary>
+    public static bool IsCombatInert(Type subscriberType, out string overriddenHooks)
+    {
+        (bool inert, string overrides) = Cache.GetOrAdd(subscriberType, Classify);
+        overriddenHooks = overrides;
+        return inert;
+    }
+
+    private static (bool Inert, string Overrides) Classify(Type subscriberType)
+    {
+        if (!typeof(AbstractModel).IsAssignableFrom(subscriberType) || subscriberType.IsAbstract)
+            return (false, string.Empty);
+
+        SortedSet<string> hooks = new(StringComparer.Ordinal);
+        try
+        {
+            for (Type? type = subscriberType;
+                 type is not null && type != typeof(AbstractModel);
+                 type = type.BaseType)
+            {
+                foreach (MethodInfo method in type.GetMethods(
+                             BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic
+                             | BindingFlags.DeclaredOnly))
+                {
+                    if (!method.IsVirtual || method.IsAbstract)
+                        continue;
+                    MethodInfo baseDefinition = method.GetBaseDefinition();
+                    if (baseDefinition.DeclaringType != typeof(AbstractModel))
+                        continue;
+                    string name = StripAccessorPrefix(baseDefinition.Name);
+                    if (NonHookMemberNames.Contains(name))
+                        continue;
+                    hooks.Add(name);
+                }
+            }
+        }
+        catch (Exception)
+        {
+            // 反射失败就无法证明它与战斗无关，交给原有的拒绝路径。
+            return (false, string.Empty);
+        }
+
+        string overrides = string.Join(",", hooks);
+        foreach (string hook in hooks)
+        {
+            if (!PredictionInertHookNames.Contains(hook))
+                return (false, overrides);
+        }
+        return (true, overrides);
+    }
+
+    private static string StripAccessorPrefix(string name)
+    {
+        if (name.StartsWith("get_", StringComparison.Ordinal) || name.StartsWith("set_", StringComparison.Ordinal))
+            return name[4..];
+        return name;
+    }
+}

--- a/src/Testing/UnattendedTestRunner.FailureBoundaries.cs
+++ b/src/Testing/UnattendedTestRunner.FailureBoundaries.cs
@@ -82,6 +82,7 @@ internal sealed partial class UnattendedTestRunner
         {
             throw new InvalidOperationException("第三方玩法 Mod 初始化失败日志缺少 Mod 或订阅器上下文。");
         }
+        AssertModHookSubscriberInertness();
 
         bool firstInferredActionRan = false;
         InvalidOperationException inferredFailure = new("inferred-action-failure");
@@ -112,6 +113,108 @@ internal sealed partial class UnattendedTestRunner
             PotionSlot: 0,
             PotionId: "FAILURE_POTION"));
         AssertExpectedSearchTransitionExceptionsPassThrough();
+    }
+
+    // 只覆写战斗外 hook 的订阅器（例如通过 RitsuLib HookedSingletonModel(HookType.Run) 注册、
+    // 只做地图恢复的模型）必须被视为与战斗无关；任何战斗 hook 覆写，包括从基类继承来的，
+    // 都必须继续被拒绝。
+    private class MapOnlySubscriber : AbstractModel
+    {
+        public override bool ShouldReceiveCombatHooks => false;
+        public override MegaCrit.Sts2.Core.Map.ActMap ModifyGeneratedMapLate(
+            MegaCrit.Sts2.Core.Runs.IRunState runState,
+            MegaCrit.Sts2.Core.Map.ActMap map,
+            int actIndex) => map;
+        public override Task AfterMapGenerated(MegaCrit.Sts2.Core.Map.ActMap map, int actIndex) => Task.CompletedTask;
+    }
+
+    private sealed class MapAndCombatSubscriber : MapOnlySubscriber
+    {
+        public override Task AfterCardPlayed(
+            MegaCrit.Sts2.Core.GameActions.Multiplayer.PlayerChoiceContext choiceContext,
+            MegaCrit.Sts2.Core.Entities.Cards.CardPlay cardPlay) => Task.CompletedTask;
+    }
+
+    private class CombatBaseSubscriber : AbstractModel
+    {
+        public override bool ShouldReceiveCombatHooks => true;
+        public override Task AfterCardPlayed(
+            MegaCrit.Sts2.Core.GameActions.Multiplayer.PlayerChoiceContext choiceContext,
+            MegaCrit.Sts2.Core.Entities.Cards.CardPlay cardPlay) => Task.CompletedTask;
+    }
+
+    private sealed class MapOnlyOverCombatBaseSubscriber : CombatBaseSubscriber
+    {
+        public override Task AfterMapGenerated(MegaCrit.Sts2.Core.Map.ActMap map, int actIndex) => Task.CompletedTask;
+    }
+
+    // 战斗开始 hook 早于根捕获执行且从不被镜像；这个形状就是 RitsuLib HookedSingletonModel(HookType.Combat)
+    // 常见的"只在自定义遭遇战开始时布置一次"的泛型基类 + 具体子类。
+    private abstract class CombatStartOnlyBase<TMarker> : AbstractModel
+    {
+        public override bool ShouldReceiveCombatHooks => true;
+        public sealed override Task BeforeCombatStart() => Task.CompletedTask;
+    }
+
+    private sealed class CombatStartOnlySubscriber : CombatStartOnlyBase<string>
+    {
+    }
+
+    private sealed class CombatStartAndVictorySubscriber : CombatStartOnlyBase<long>
+    {
+        public override Task AfterCombatVictory(MegaCrit.Sts2.Core.Rooms.CombatRoom room) => Task.CompletedTask;
+    }
+
+    private sealed class CombatStartAndTurnSubscriber : CombatStartOnlyBase<int>
+    {
+        public override Task AfterPlayerTurnStart(
+            MegaCrit.Sts2.Core.GameActions.Multiplayer.PlayerChoiceContext choiceContext,
+            MegaCrit.Sts2.Core.Entities.Players.Player player) => Task.CompletedTask;
+    }
+
+    private sealed class RoomEnteredSubscriber : AbstractModel
+    {
+        public override bool ShouldReceiveCombatHooks => false;
+        public override Task AfterRoomEntered(MegaCrit.Sts2.Core.Rooms.AbstractRoom room) => Task.CompletedTask;
+    }
+
+    private sealed class NoOverrideSubscriber : AbstractModel
+    {
+        public override bool ShouldReceiveCombatHooks => true;
+    }
+
+    private abstract class AbstractSubscriber : AbstractModel
+    {
+        public override bool ShouldReceiveCombatHooks => false;
+    }
+
+    private static void AssertModHookSubscriberInertness()
+    {
+        AssertInert(typeof(MapOnlySubscriber), expected: true, "只覆写地图 hook 的订阅器应视为与战斗无关");
+        AssertInert(typeof(NoOverrideSubscriber), expected: true, "没有覆写任何 hook 的订阅器应视为与战斗无关");
+        AssertInert(typeof(MapAndCombatSubscriber), expected: false, "同时覆写战斗 hook 的订阅器必须被拒绝");
+        AssertInert(typeof(MapOnlyOverCombatBaseSubscriber), expected: false, "从基类继承战斗 hook 覆写的订阅器必须被拒绝");
+        AssertInert(typeof(RoomEnteredSubscriber), expected: false, "AfterRoomEntered 在战斗房也会触发，必须被拒绝");
+        AssertInert(typeof(CombatStartOnlySubscriber), expected: true, "只覆写战斗开始 hook 的泛型基类子类应视为与预测无关");
+        AssertInert(typeof(CombatStartAndVictorySubscriber), expected: true, "战斗开始加战斗胜利 hook 都在搜索窗口之外，应视为与预测无关");
+        AssertInert(typeof(CombatStartAndTurnSubscriber), expected: false, "战斗开始之外还覆写回合 hook 的订阅器必须被拒绝");
+        AssertInert(typeof(AbstractSubscriber), expected: false, "抽象类型无法判定，必须被拒绝");
+        AssertInert(typeof(string), expected: false, "非 AbstractModel 类型必须被拒绝");
+
+        if (!PredictionModHookSubscriberInertness.IsCombatInert(typeof(MapOnlySubscriber), out string hooks)
+            || hooks != "AfterMapGenerated,ModifyGeneratedMapLate")
+        {
+            throw new InvalidOperationException($"订阅器覆写清单不正确：{hooks}");
+        }
+        PredictionModHookSubscriberInertness.IsCombatInert(typeof(MapOnlyOverCombatBaseSubscriber), out hooks);
+        if (hooks != "AfterCardPlayed,AfterMapGenerated")
+            throw new InvalidOperationException($"继承的覆写没有被收集：{hooks}");
+    }
+
+    private static void AssertInert(Type type, bool expected, string message)
+    {
+        if (PredictionModHookSubscriberInertness.IsCombatInert(type, out string hooks) != expected)
+            throw new InvalidOperationException($"{message}（{type.Name}，覆写：{hooks}）。");
     }
 
     private static void AssertSearchTransitionFailure(PlanAction action)


### PR DESCRIPTION
## 问题

`PredictionModHookSubscriberCapture.ValidateSubscriber` 只看订阅器所属 Mod 的 `affectsGameplay`，不看它实际覆写了什么。一个通过 RitsuLib `HookedSingletonModel(HookType.Run)` 注册、只覆写 `ModifyGeneratedMapLate` 和 `AfterMapGenerated` 做地图处理的模型，也会触发 `IncompatibleGameplayModException`，求解器直接无法启动。

## 改动

新增 `PredictionModHookSubscriberInertness`。沿订阅器的继承链（含中间基类和泛型基类）收集所有在 `AbstractModel` 上声明的虚成员覆写，只有每一个都落在下面这张清单里才视为与预测无关并放行，其余照旧走原来的拒绝路径：

- 战斗外分发的 hook：地图生成与进幕（`RunManager`）、事件抽取（`ActModel`）、未知节点房型（`UnknownMapPointOdds`）、休息处（`RestSite` 选项）、商店（`Merchant` 条目、`CardFactory.CreateForMerchant`）。
- 战斗开始 hook（`BeforeCombatStart`、`BeforeCombatStartLate`）：在 `CombatManager.TurnStarted` 捕获根之前就执行完，效果已经在根里，和现有 `KnownPreRootSubscriberTypeNames` 是同一个道理。
- 战斗结束 hook（`AfterCombatEnd`、`AfterCombatVictory(Early)`、`BeforeCombatRewardOffered`）：胜负判定之后才由 `EndCombatInternal` / `CombatRoom` 分发。

求解器的镜像不触发上面任何一个。`ShouldReceiveCombatHooks`、`IsMock`、`PreviewOutsideOfCombat`、`CompareTo` 不是 hook，不计入。反射失败、抽象类型、非 `AbstractModel` 一律按不可判定拒绝。放行时写一行 `MOD_HOOK_SUBSCRIBER_COMBAT_INERT` 日志带上覆写清单。战斗期间也会触发的 hook（`AfterRoomEntered`、金币、药水、奖励选项、加牌入牌组等）没有放进清单。

被放行的订阅器仍留在捕获数组里，`SimulatedCombatState` 里战斗监听表尾部与 Mod 订阅器的对齐检查不受影响，它们本来就不进模拟的监听表。

## 测试

`-VerifyPredictionFailureBoundaries` 里新增九个合成订阅器类型：只覆写地图 hook、没有任何覆写、地图加 `AfterCardPlayed`、从覆写 `AfterCardPlayed` 的基类继承再只加地图 hook、`AfterRoomEntered`、抽象类型、非 `AbstractModel`、泛型基类密封覆写 `BeforeCombatStart` 的子类、再加 `AfterCombatVictory` 或 `AfterPlayerTurnStart`。正反各半，并断言收集到的覆写清单本身。

## 验证

macOS，0.29.0 基线与本 PR 各自编译，活雾场景（铁甲初始牌组）启用一个带此类订阅器的第三方玩法 Mod：

- 基线：`IncompatibleGameplayModException: Unsupported gameplay ModHelper run subscriber …`，搜索未启动。
- 本 PR：1 个 run 订阅器和 17 个 combat 订阅器（只覆写 `BeforeCombatStart`，其中一个再加 `AfterCombatVictory`）全部记为 inert，搜索正常；展开 4397 / 转移 13947 / 分数 10001229958，与不装该 Mod 时完全一致。`PredictionFailureBoundaries` 检查通过。
- `verify-refactor-boundaries.sh` 通过。
