### PR TITLE
一次性保命遗物不再是免费的血：给蜥蜴尾巴的复活计价

### DIFF
--- a/src/Engine/InCombat/Mirrors/Hooks/Death/DeathPreventerMirrors.cs
+++ b/src/Engine/InCombat/Mirrors/Hooks/Death/DeathPreventerMirrors.cs
@@ -45,8 +45,14 @@ internal static class LizardTailMirrors
         if (context.Simulator.IsRecordingActionRelicTriggers)
             context.Simulator.RecordRelicTrigger(relic, "：复活");
 
-        int maxHp = context.State.GetCreature(context.Creature).MaxHp;
-        context.Simulator.Heal(context.Creature, HealAmount(relic, maxHp));
+        SimCreatureState creature = context.State.GetCreature(context.Creature);
+        int hpBeforeRevive = creature.CurrentHp;
+        context.Simulator.Heal(context.Creature, HealAmount(relic, creature.MaxHp));
+        int restored = creature.CurrentHp - hpBeforeRevive;
+        // The revive spends a cross-combat resource, it is not HP the route earned. Without this the route
+        // that walks into lethal damage scores as if it had healed half its max HP for free.
+        if (restored > 0 && context.CombatState is SimulatedCombatState combat)
+            combat.RecordDeathSaveRelicHpRestored(restored);
     }
 
     internal static decimal HealAmount(LizardTail relic, int maxHp)

--- a/src/Runtime/SolverDiagnostics.cs
+++ b/src/Runtime/SolverDiagnostics.cs
@@ -177,6 +177,7 @@ internal static class SolverDiagnostics
             .Append(" sold_hp_threshold=").Append(result.SoldHpThreshold)
             .Append(" battle_hp_lost_so_far=").Append(result.BattleHpLostSoFar)
             .Append(" projected_battle_hp_lost=").Append(result.ProjectedBattleHpLost)
+            .Append(" death_save_relic_hp=").Append(result.Snapshot.DeathSaveRelicHpRestored)
             .Append(" long_term_resource=").Append(result.Snapshot.LongTermResourceValue)
             .Append(" anger_copies=").Append(result.Snapshot.AngerCopiesGenerated)
             .Append(" battle_potions_used_so_far=").Append(result.BattlePotionsUsedSoFar)

--- a/src/Search/ActEndingBossPolicy.cs
+++ b/src/Search/ActEndingBossPolicy.cs
@@ -48,6 +48,45 @@ internal static class ActEndingBossPolicy
         };
     }
 
+    /// <summary>
+    /// What burning a one-shot death-save relic costs a route, in the same units as its battle HP loss.
+    /// </summary>
+    /// <remarks>
+    /// Lizard Tail revives the player at half their maximum HP, and that HP was free: nothing charged the
+    /// route for spending the relic, so walking into lethal damage read as a large heal. Fairy in a Bottle
+    /// does the same thing and never had this problem, because spending it goes through the potion
+    /// accounting; the relic is the only unpriced death save in the game.
+    ///
+    /// The premium is a multiple of the restored HP rather than a match for it, because HP is not the only
+    /// thing the revive buys. Enemy HP is worth <see cref="SolverWeights.EnemyHp"/> a point inside Beam
+    /// ranking, so a two-boss fight puts a hundred-odd HP-equivalents of tempo on the table, and a
+    /// one-to-one premium loses to it — measured, not assumed. At the current multiple every route that
+    /// wins while alive beats every route that wins on the relic, while the charge stays orders of
+    /// magnitude below <see cref="SolverWeights.VictoryBonus"/> and <see cref="SolverWeights.DeathPenalty"/>,
+    /// so a route with no surviving alternative still spends the relic without hesitation.
+    ///
+    /// The run's last fight is the one exception. Saving the relic for later is worth nothing when there is
+    /// no later, so the premium drops to zero and the revive goes back to being free.
+    /// </remarks>
+    public static int DeathSaveRelicPremium(int deathSaveRelicHpRestored, BossHpRelief bossHpRelief)
+        => bossHpRelief == BossHpRelief.RunEnding
+            ? 0
+            : Math.Max(0, deathSaveRelicHpRestored)
+                * SolverWeights.DeathSaveRelicPremiumPercent
+                / 100;
+
+    /// <summary>
+    /// What a route's spent death saves cost inside Beam ranking, where the revive's own HP is still sitting
+    /// in the node's projected HP: it is taken back out, and the premium is charged on top.
+    /// </summary>
+    public static int DeathSaveRelicBeamCost(int deathSaveRelicHpRestored, BossHpRelief bossHpRelief)
+    {
+        if (bossHpRelief == BossHpRelief.RunEnding)
+            return 0;
+        int restored = Math.Max(0, deathSaveRelicHpRestored);
+        return restored + DeathSaveRelicPremium(restored, bossHpRelief);
+    }
+
     public static BossHpRelief ResolveHpRelief(CombatState combatState)
     {
         if (combatState.Encounter?.RoomType != RoomType.Boss)

--- a/src/Search/CombatBeamSolver.BeamRetentionPolicy.cs
+++ b/src/Search/CombatBeamSolver.BeamRetentionPolicy.cs
@@ -63,6 +63,7 @@ internal sealed partial class CombatBeamSolver
     private sealed class BeamRetentionPolicy(
         SolverSearchProfile _profile,
         bool _isActEndingBoss,
+        BossHpRelief _strategicBossHpRelief,
         int _initialEnemyCount,
         int _initialPlayerHp,
         int _initialPlayerMaxHp,
@@ -133,6 +134,7 @@ internal sealed partial class CombatBeamSolver
                             potionFreeBaseline,
                             _initialPlayerHp,
                             _initialPlayerMaxHp,
+                            _strategicBossHpRelief,
                             _theftPolicy) < 0))
                 {
                     potionFreeBaseline = candidate;
@@ -1770,7 +1772,10 @@ internal sealed partial class CombatBeamSolver
 
         private int StrategicHpDeficit(SimulationSnapshot snapshot)
             => snapshot.CumulativePlayerHpLost
-                + Math.Max(0, _initialPlayerMaxHp - snapshot.PlayerMaxHp);
+                + Math.Max(0, _initialPlayerMaxHp - snapshot.PlayerMaxHp)
+                + ActEndingBossPolicy.DeathSaveRelicPremium(
+                    snapshot.DeathSaveRelicHpRestored,
+                    _strategicBossHpRelief);
 
         private int HealthResourceCost(SimulationSnapshot snapshot)
             => _initialPlayerHp - snapshot.PlayerHp

--- a/src/Search/CombatBeamSolver.FinalPlanOrdering.cs
+++ b/src/Search/CombatBeamSolver.FinalPlanOrdering.cs
@@ -69,7 +69,11 @@ internal sealed partial class CombatBeamSolver
                     };
                     int hpDeficit = features.CumulativePlayerHpLost;
                     int maxHpDeficit = Math.Max(0, initialPlayerMaxHp - features.PlayerMaxHp);
-                    int strategicHpDeficit = hpDeficit + maxHpDeficit;
+                    int strategicHpDeficit = hpDeficit
+                        + maxHpDeficit
+                        + ActEndingBossPolicy.DeathSaveRelicPremium(
+                            features.DeathSaveRelicHpRestored,
+                            bossHpRelief);
                     int healthResourceCost = initialHp - features.PlayerHp
                         + initialPlayerMaxHp - features.PlayerMaxHp;
                     int strategicSold = battleSold;
@@ -129,6 +133,7 @@ internal sealed partial class CombatBeamSolver
                             policyCandidates[potionFreeBaselineIndex].Node,
                             initialHp,
                             initialPlayerMaxHp,
+                            bossHpRelief,
                             theftPolicy) >= 0)
                 {
                     continue;
@@ -310,6 +315,7 @@ internal sealed partial class CombatBeamSolver
         SearchNode right,
         int initialPlayerHp,
         int initialPlayerMaxHp,
+        BossHpRelief bossHpRelief,
         SolverTheftPolicy? theftPolicy)
     {
         SimulationSnapshot leftSnapshot = left.Snapshot;
@@ -336,9 +342,15 @@ internal sealed partial class CombatBeamSolver
                 return comparison;
         }
         comparison = (leftSnapshot.CumulativePlayerHpLost
-                + Math.Max(0, initialPlayerMaxHp - leftSnapshot.PlayerMaxHp))
+                + Math.Max(0, initialPlayerMaxHp - leftSnapshot.PlayerMaxHp)
+                + ActEndingBossPolicy.DeathSaveRelicPremium(
+                    leftSnapshot.DeathSaveRelicHpRestored,
+                    bossHpRelief))
             .CompareTo(rightSnapshot.CumulativePlayerHpLost
-                + Math.Max(0, initialPlayerMaxHp - rightSnapshot.PlayerMaxHp));
+                + Math.Max(0, initialPlayerMaxHp - rightSnapshot.PlayerMaxHp)
+                + ActEndingBossPolicy.DeathSaveRelicPremium(
+                    rightSnapshot.DeathSaveRelicHpRestored,
+                    bossHpRelief));
         if (comparison != 0)
             return comparison;
         comparison = (leftWon ? left.Action?.Turn ?? int.MaxValue : int.MaxValue)

--- a/src/Search/CombatBeamSolver.Models.cs
+++ b/src/Search/CombatBeamSolver.Models.cs
@@ -87,7 +87,7 @@ internal sealed partial class CombatBeamSolver
         public Dictionary<StateFingerprint, TranspositionFrontier> Transpositions = [];
         public Dictionary<StateFingerprint, TranspositionFrontier> ExpandedTranspositions = [];
         public Dictionary<StateFingerprint, StandPatEvaluation> StandPatCache = [];
-        public Dictionary<(StateFingerprint State, int RoundIndex), int> ThreatProjectionCache = [];
+        public Dictionary<(StateFingerprint State, int RoundIndex), ThreatProjection> ThreatProjectionCache = [];
         public Dictionary<PredictionRiskSignature, CoverageSummary> CoverageCache = [];
         public int Expanded;
         public int DominatedActionsPruned;
@@ -220,6 +220,7 @@ internal sealed partial class CombatBeamSolver
         int PlayerHp,
         int PlayerMaxHp,
         int CumulativePlayerHpLost,
+        int DeathSaveRelicHpRestored,
         int LongTermResourceValue,
         int AngerCopiesGenerated,
         int PlayerBlock,
@@ -259,6 +260,7 @@ internal sealed partial class CombatBeamSolver
                 snapshot.PlayerHp,
                 snapshot.PlayerMaxHp,
                 snapshot.CumulativePlayerHpLost,
+                snapshot.DeathSaveRelicHpRestored,
                 snapshot.LongTermResourceValue,
                 snapshot.AngerCopiesGenerated,
                 snapshot.PlayerBlock,

--- a/src/Search/CombatBeamSolver.Phases.cs
+++ b/src/Search/CombatBeamSolver.Phases.cs
@@ -508,6 +508,7 @@ internal sealed partial class CombatBeamSolver
                 finalSnapshot.PlayerHp,
                 finalSnapshot.PlayerMaxHp,
                 finalSnapshot.CumulativePlayerHpLost,
+                finalSnapshot.DeathSaveRelicHpRestored,
                 finalSnapshot.LongTermResourceValue,
                 finalSnapshot.AngerCopiesGenerated,
                 finalSnapshot.ProjectedPlayerHp,

--- a/src/Search/CombatBeamSolver.Retention.cs
+++ b/src/Search/CombatBeamSolver.Retention.cs
@@ -194,7 +194,10 @@ internal sealed partial class CombatBeamSolver
         {
             SearchNode node = retained[index];
             if (ShouldPruneByPrimaryIncumbent(
-                    node.Snapshot.CumulativePlayerHpLost,
+                    node.Snapshot.CumulativePlayerHpLost
+                        + ActEndingBossPolicy.DeathSaveRelicPremium(
+                            node.Snapshot.DeathSaveRelicHpRestored,
+                            _strategicBossHpRelief),
                     node.Turn,
                     incumbent))
             {
@@ -306,7 +309,10 @@ internal sealed partial class CombatBeamSolver
             // ApplyPrimaryIncumbentBound deliberately keeps using cumulative HP loss alone
             // as the lower bound for incomplete nodes because max HP may still recover.
             int strategicHpDeficit = node.Snapshot.CumulativePlayerHpLost
-                + Math.Max(0, root.InitialPlayerMaxHp - node.Snapshot.PlayerMaxHp);
+                + Math.Max(0, root.InitialPlayerMaxHp - node.Snapshot.PlayerMaxHp)
+                + ActEndingBossPolicy.DeathSaveRelicPremium(
+                    node.Snapshot.DeathSaveRelicHpRestored,
+                    _strategicBossHpRelief);
             TryTightenPrimarySearchIncumbent(
                 _potionFreePolicyBaseline,
                 _minimumPotionUses,

--- a/src/Search/CombatBeamSolver.StateEvaluation.cs
+++ b/src/Search/CombatBeamSolver.StateEvaluation.cs
@@ -123,30 +123,39 @@ internal sealed partial class CombatBeamSolver
 
         int roundIndex = turn - _startTurnNumber;
         SearchMeasurement threatMeasurement = _run.Performance.Begin();
-        int projectedHp;
+        ThreatProjection threat;
         if (won)
         {
             // A lethal player action ends combat immediately. Enemy intent from that round must
             // never lower the route's projected HP or leak into battle-loss reporting.
-            projectedHp = player.CurrentHp;
+            threat = new ThreatProjection(player.CurrentHp, 0);
         }
         else if (boundary != SearchBoundaryReason.None)
         {
-            projectedHp = player.CurrentHp;
+            threat = new ThreatProjection(player.CurrentHp, 0);
         }
-        else if (!_run.ThreatProjectionCache.TryGetValue((key, roundIndex), out projectedHp))
+        else if (!_run.ThreatProjectionCache.TryGetValue((key, roundIndex), out threat))
         {
-            projectedHp = ProjectHpAfterThreat(simulator, player, roundIndex);
-            _run.ThreatProjectionCache.Add((key, roundIndex), projectedHp);
+            threat = ProjectHpAfterThreat(simulator, player, roundIndex);
+            _run.ThreatProjectionCache.Add((key, roundIndex), threat);
         }
+        int projectedHp = threat.Hp;
         _run.Performance.End(SearchMetricPhase.ThreatProjection, threatMeasurement);
         int cumulativePlayerHpLost = combat.GetCumulativeHpLost(_player.Creature);
+        int deathSaveRelicHpRestored = combat.DeathSaveRelicHpRestored;
         double hpWeight = SolverWeights.Hp;
         double score = dead || projectedHp <= 0
             ? SolverWeights.DeathPenalty
             : projectedHp * hpWeight;
         score += (player.MaxHp - root.InitialPlayerMaxHp) * hpWeight;
         score -= cumulativePlayerHpLost * hpWeight;
+        // A one-shot death save is a cross-combat resource. The HP it puts back is still sitting in
+        // projectedHp, so it is taken out again and charged a second time as the price of spending it. The
+        // projected part is included because walking into a lethal intent has to look as expensive as
+        // actually taking it, or retention keeps the route that plans to die and drops the one that does not.
+        score -= ActEndingBossPolicy.DeathSaveRelicBeamCost(
+            deathSaveRelicHpRestored + threat.DeathSaveRelicHpRestored,
+            _strategicBossHpRelief) * hpWeight;
         int exhaustedTheHunts = playerState.ExhaustPile.Cards.Count(card => card.Preview is TheHunt);
         int rewardedTheHunts = Math.Max(0, combat.GetAmount<TheHuntPower>(_player.Creature));
         int missedTheHuntRewards = Math.Max(0, exhaustedTheHunts - rewardedTheHunts);
@@ -372,6 +381,7 @@ internal sealed partial class CombatBeamSolver
             player.CurrentHp,
             player.MaxHp,
             cumulativePlayerHpLost,
+            deathSaveRelicHpRestored,
             longTermResourceValue,
             angerCopiesGenerated,
             projectedHp,
@@ -889,7 +899,13 @@ internal sealed partial class CombatBeamSolver
         return summary;
     }
 
-    private int ProjectHpAfterThreat(
+    /// <summary>
+    /// What the incoming enemy intent leaves the player at, and how much of that HP only exists because a
+    /// one-shot death-save relic would have to be spent to get there.
+    /// </summary>
+    private readonly record struct ThreatProjection(int Hp, int DeathSaveRelicHpRestored);
+
+    private ThreatProjection ProjectHpAfterThreat(
         CombatPredictionSimulator simulator,
         SimCreatureState player,
         int roundIndex)
@@ -944,7 +960,7 @@ internal sealed partial class CombatBeamSolver
                     ref deathPrevention);
             }
         }
-        return hp;
+        return new ThreatProjection(hp, deathPrevention.RelicHpRestored);
     }
 
     private void ProjectThreatHit(
@@ -1040,6 +1056,9 @@ internal sealed partial class CombatBeamSolver
         bool lizardTailAvailable,
         int lizardTailHeal)
     {
+        /// <summary>HP a projected Lizard Tail revive would restore, priced the same way a real one is.</summary>
+        public int RelicHpRestored { get; private set; }
+
         public void TryRevive(ref int hp)
         {
             if (hp > 0)
@@ -1053,6 +1072,9 @@ internal sealed partial class CombatBeamSolver
             if (!lizardTailAvailable)
                 return;
             lizardTailAvailable = false;
+            // Projected HP can run below zero; the real revive heals from zero, so the restored amount is
+            // the full heal either way.
+            RelicHpRestored += lizardTailHeal;
             hp = lizardTailHeal;
         }
     }

--- a/src/Search/CombatBeamSolver.cs
+++ b/src/Search/CombatBeamSolver.cs
@@ -86,6 +86,7 @@ internal sealed partial class CombatBeamSolver(
     private BeamRetentionPolicy Retention => _retention ??= new BeamRetentionPolicy(
         _profile,
         _isActEndingBoss,
+        _strategicBossHpRelief,
         _initialEnemyCount,
         root.InitialPlayerHp,
         root.InitialPlayerMaxHp,

--- a/src/Search/CombatPlan.cs
+++ b/src/Search/CombatPlan.cs
@@ -1032,6 +1032,7 @@ internal sealed class SimulationSnapshot(
     int playerHp,
     int playerMaxHp,
     int cumulativePlayerHpLost,
+    int deathSaveRelicHpRestored,
     int longTermResourceValue,
     int angerCopiesGenerated,
     int projectedPlayerHp,
@@ -1108,6 +1109,11 @@ internal sealed class SimulationSnapshot(
     public int PlayerHp { get; } = playerHp;
     public int PlayerMaxHp { get; } = playerMaxHp;
     public int CumulativePlayerHpLost { get; } = cumulativePlayerHpLost;
+
+    /// <summary>HP a one-shot death-save relic put back on this route.</summary>
+    /// <seealso cref="ActEndingBossPolicy.DeathSaveRelicPremium"/>
+    public int DeathSaveRelicHpRestored { get; } = deathSaveRelicHpRestored;
+
     public int LongTermResourceValue { get; } = longTermResourceValue;
     public int AngerCopiesGenerated { get; } = angerCopiesGenerated;
     public int ProjectedPlayerHp { get; } = projectedPlayerHp;
@@ -1209,6 +1215,7 @@ internal sealed record SolverSnapshot(
     int PlayerHp,
     int PlayerMaxHp,
     int CumulativePlayerHpLost,
+    int DeathSaveRelicHpRestored,
     int LongTermResourceValue,
     int AngerCopiesGenerated,
     int ProjectedPlayerHp,

--- a/src/Search/CombatSearchCoordinator.cs
+++ b/src/Search/CombatSearchCoordinator.cs
@@ -418,11 +418,11 @@ internal static class CombatSearchCoordinator
         int? shortCheckpointMilliseconds,
         SolverResult primary)
     {
-        int primaryDeficit = StrategicHpDeficit(root, primary);
+        int primaryDeficit = StrategicHpDeficit(root, policy, primary);
         int maximumSmartPotionUses = policy.PotionPolicy == SolverPotionPolicy.Smart
             ? MaximumSmartPotionUses(root, policy, potionFreeWon: true, primaryDeficit)
             : Math.Max(1, primary.PotionCount);
-        if (HasReachedProvablePrimaryQualityLowerBound(root, primary)
+        if (HasReachedProvablePrimaryQualityLowerBound(root, policy, primary)
             || policy.PotionPolicy == SolverPotionPolicy.RequireAtLeastOne
                 && battleDamage.PotionsUsedSoFar == 0)
             return primary;
@@ -539,8 +539,8 @@ internal static class CombatSearchCoordinator
             bool posteriorWon = posterior.Snapshot.AllEnemiesDead
                 && !posterior.Snapshot.PlayerDead
                 && posterior.Snapshot.ProjectedPlayerHp > 0;
-            int posteriorDeficit = StrategicHpDeficit(root, posterior);
-            if (IsBetterCompletedResult(root, posterior, selected))
+            int posteriorDeficit = StrategicHpDeficit(root, policy, posterior);
+            if (IsBetterCompletedResult(root, policy, posterior, selected))
             {
                 selected = posterior;
             }
@@ -591,8 +591,8 @@ internal static class CombatSearchCoordinator
             bool linkedWon = linkedPosterior.Snapshot.AllEnemiesDead
                 && !linkedPosterior.Snapshot.PlayerDead
                 && linkedPosterior.Snapshot.ProjectedPlayerHp > 0;
-            int linkedDeficit = StrategicHpDeficit(root, linkedPosterior);
-            if (IsBetterCompletedResult(root, linkedPosterior, selected))
+            int linkedDeficit = StrategicHpDeficit(root, policy, linkedPosterior);
+            if (IsBetterCompletedResult(root, policy, linkedPosterior, selected))
             {
                 selected = linkedPosterior;
             }
@@ -644,13 +644,13 @@ internal static class CombatSearchCoordinator
                 posteriorDeepTriggered);
             searches.Add(resourceDefensePosterior);
 
-            if (IsBetterCompletedResult(root, resourceDefensePosterior, selected))
+            if (IsBetterCompletedResult(root, policy, resourceDefensePosterior, selected))
                 selected = resourceDefensePosterior;
             policy.Diagnostics.Info(
                 $"[CombatSolver/Test] OPENING_RESOURCE_DEFENSE_POSTERIOR " +
                 $"cards={openingResource.CardId}+{defensiveFollowUp.CardId} " +
                 $"won={resourceDefensePosterior.Snapshot.AllEnemiesDead && !resourceDefensePosterior.Snapshot.PlayerDead} " +
-                $"hp_deficit={StrategicHpDeficit(root, resourceDefensePosterior)} " +
+                $"hp_deficit={StrategicHpDeficit(root, policy, resourceDefensePosterior)} " +
                 $"selected={ReferenceEquals(selected, resourceDefensePosterior)}");
         }
 
@@ -692,8 +692,8 @@ internal static class CombatSearchCoordinator
             bool resourceWon = resourcePosterior.Snapshot.AllEnemiesDead
                 && !resourcePosterior.Snapshot.PlayerDead
                 && resourcePosterior.Snapshot.ProjectedPlayerHp > 0;
-            int resourceDeficit = StrategicHpDeficit(root, resourcePosterior);
-            if (IsBetterCompletedResult(root, resourcePosterior, selected))
+            int resourceDeficit = StrategicHpDeficit(root, policy, resourcePosterior);
+            if (IsBetterCompletedResult(root, policy, resourcePosterior, selected))
             {
                 selected = resourcePosterior;
             }
@@ -704,7 +704,7 @@ internal static class CombatSearchCoordinator
                 $"selected={ReferenceEquals(selected, resourcePosterior)}");
         }
 
-        if (HasReachedProvablePrimaryQualityLowerBound(root, selected)
+        if (HasReachedProvablePrimaryQualityLowerBound(root, policy, selected)
             && selected.PotionCount <= 1)
         {
             MergeAuditTotals(selected, searches.ToArray());
@@ -750,9 +750,9 @@ internal static class CombatSearchCoordinator
             bool jointWon = jointPosterior.Snapshot.AllEnemiesDead
                 && !jointPosterior.Snapshot.PlayerDead
                 && jointPosterior.Snapshot.ProjectedPlayerHp > 0;
-            int jointDeficit = StrategicHpDeficit(root, jointPosterior);
-            int comparisonDeficit = StrategicHpDeficit(root, selected);
-            if (IsBetterCompletedResult(root, jointPosterior, selected))
+            int jointDeficit = StrategicHpDeficit(root, policy, jointPosterior);
+            int comparisonDeficit = StrategicHpDeficit(root, policy, selected);
+            if (IsBetterCompletedResult(root, policy, jointPosterior, selected))
             {
                 selected = jointPosterior;
             }
@@ -763,7 +763,7 @@ internal static class CombatSearchCoordinator
                 $"selected={ReferenceEquals(selected, jointPosterior)}");
 
             if (!jointWon
-                || HasReachedProvablePrimaryQualityLowerBound(root, jointPosterior)
+                || HasReachedProvablePrimaryQualityLowerBound(root, policy, jointPosterior)
                 || jointDeficit > comparisonDeficit + 1)
             {
                 continue;
@@ -821,8 +821,8 @@ internal static class CombatSearchCoordinator
             bool defensiveWon = defensivePosterior.Snapshot.AllEnemiesDead
                 && !defensivePosterior.Snapshot.PlayerDead
                 && defensivePosterior.Snapshot.ProjectedPlayerHp > 0;
-            int defensiveDeficit = StrategicHpDeficit(root, defensivePosterior);
-            if (IsBetterCompletedResult(root, defensivePosterior, selected))
+            int defensiveDeficit = StrategicHpDeficit(root, policy, defensivePosterior);
+            if (IsBetterCompletedResult(root, policy, defensivePosterior, selected))
             {
                 selected = defensivePosterior;
             }
@@ -832,7 +832,7 @@ internal static class CombatSearchCoordinator
                 $"follow_up={defensiveFollowUp.CardId} won={defensiveWon} " +
                 $"hp_deficit={defensiveDeficit} selected={ReferenceEquals(selected, defensivePosterior)}");
 
-            if (HasReachedProvablePrimaryQualityLowerBound(root, defensivePosterior))
+            if (HasReachedProvablePrimaryQualityLowerBound(root, policy, defensivePosterior))
                 break;
         }
 
@@ -934,8 +934,8 @@ internal static class CombatSearchCoordinator
                 bool posteriorWon = posterior.Snapshot.AllEnemiesDead
                     && !posterior.Snapshot.PlayerDead
                     && posterior.Snapshot.ProjectedPlayerHp > 0;
-                int posteriorDeficit = StrategicHpDeficit(root, posterior);
-                if (IsBetterCompletedResult(root, posterior, selected))
+                int posteriorDeficit = StrategicHpDeficit(root, policy, posterior);
+                if (IsBetterCompletedResult(root, policy, posterior, selected))
                 {
                     selected = posterior;
                 }
@@ -993,8 +993,8 @@ internal static class CombatSearchCoordinator
                     bool pairWon = pairPosterior.Snapshot.AllEnemiesDead
                         && !pairPosterior.Snapshot.PlayerDead
                         && pairPosterior.Snapshot.ProjectedPlayerHp > 0;
-                    int pairDeficit = StrategicHpDeficit(root, pairPosterior);
-                    if (IsBetterCompletedResult(root, pairPosterior, selected))
+                    int pairDeficit = StrategicHpDeficit(root, policy, pairPosterior);
+                    if (IsBetterCompletedResult(root, policy, pairPosterior, selected))
                     {
                         selected = pairPosterior;
                     }
@@ -1005,7 +1005,7 @@ internal static class CombatSearchCoordinator
                         $"won={pairWon} hp_deficit={pairDeficit} " +
                         $"selected={ReferenceEquals(selected, pairPosterior)}");
 
-                    int selectedDeficit = StrategicHpDeficit(root, selected);
+                    int selectedDeficit = StrategicHpDeficit(root, policy, selected);
                     if (!pairWon || pairDeficit > selectedDeficit + 1)
                         continue;
 
@@ -1056,8 +1056,8 @@ internal static class CombatSearchCoordinator
                     bool defensiveWon = defensivePosterior.Snapshot.AllEnemiesDead
                         && !defensivePosterior.Snapshot.PlayerDead
                         && defensivePosterior.Snapshot.ProjectedPlayerHp > 0;
-                    int defensiveDeficit = StrategicHpDeficit(root, defensivePosterior);
-                    if (IsBetterCompletedResult(root, defensivePosterior, selected))
+                    int defensiveDeficit = StrategicHpDeficit(root, policy, defensivePosterior);
+                    if (IsBetterCompletedResult(root, policy, defensivePosterior, selected))
                     {
                         selected = defensivePosterior;
                     }
@@ -1185,7 +1185,7 @@ internal static class CombatSearchCoordinator
         bool potionFreeWon = potionFree.Snapshot.AllEnemiesDead
             && !potionFree.Snapshot.PlayerDead
             && potionFree.Snapshot.ProjectedPlayerHp > 0;
-        int potionFreeDeficit = StrategicHpDeficit(root, potionFree);
+        int potionFreeDeficit = StrategicHpDeficit(root, policy, potionFree);
         int maximumPotionUses = MaximumSmartPotionUses(
             root,
             policy,
@@ -1236,6 +1236,7 @@ internal static class CombatSearchCoordinator
             }
             PrimarySearchIncumbent? primaryIncumbent = BuildPrimarySearchIncumbent(
                 root,
+                policy,
                 selected);
             SolverResult candidate;
             try
@@ -1287,7 +1288,7 @@ internal static class CombatSearchCoordinator
             interimResultCallback?.Invoke(candidate);
 
             bool candidateWon = IsCompleteVictory(candidate);
-            int candidateDeficit = StrategicHpDeficit(root, candidate);
+            int candidateDeficit = StrategicHpDeficit(root, policy, candidate);
             int hpSaved = potionFreeWon
                 ? Math.Max(0, potionFreeDeficit - candidateDeficit)
                 : candidateWon
@@ -1441,7 +1442,7 @@ internal static class CombatSearchCoordinator
             Won: IsCompleteVictory(result),
             OutstandingStolenResource: result.OutstandingStolenResource,
             ProjectedBattleHpLost: result.ProjectedBattleHpLost,
-            StrategicHpDeficit: StrategicHpDeficit(root, result),
+            StrategicHpDeficit: StrategicHpDeficit(root, policy, result),
             PotionStrategicCost: SmartPotionHpRequired(root, policy, result),
             ProjectedBattlePotionCount: result.ProjectedBattlePotionCount,
             CombatEndedTurn: result.CombatEndedTurn,
@@ -1451,10 +1452,11 @@ internal static class CombatSearchCoordinator
 
     private static bool IsBetterCompletedResult(
         CombatRootSnapshot root,
+        SearchPolicySnapshot policy,
         SolverResult candidate,
         SolverResult current)
     {
-        int primaryQuality = CompareCompletedResultPrimaryQuality(root, candidate, current);
+        int primaryQuality = CompareCompletedResultPrimaryQuality(root, policy, candidate, current);
         if (primaryQuality != 0)
             return primaryQuality < 0;
         return candidate.PotionCount < current.PotionCount
@@ -1501,14 +1503,15 @@ internal static class CombatSearchCoordinator
 
     private static int CompareCompletedResultPrimaryQuality(
         CombatRootSnapshot root,
+        SearchPolicySnapshot policy,
         SolverResult candidate,
         SolverResult current)
         => SolverInterimResultOrdering.ComparePrimaryQuality(
             IsCompleteVictory(candidate),
-            StrategicHpDeficit(root, candidate),
+            StrategicHpDeficit(root, policy, candidate),
             candidate.CombatEndedTurn,
             IsCompleteVictory(current),
-            StrategicHpDeficit(root, current),
+            StrategicHpDeficit(root, policy, current),
             current.CombatEndedTurn);
 
     private static bool IsCompleteVictory(SolverResult result)
@@ -1534,10 +1537,11 @@ internal static class CombatSearchCoordinator
 
     private static bool HasReachedProvablePrimaryQualityLowerBound(
         CombatRootSnapshot root,
+        SearchPolicySnapshot policy,
         SolverResult result)
         => HasReachedProvablePrimaryQualityLowerBound(
             IsCompleteVictory(result),
-            StrategicHpDeficit(root, result),
+            StrategicHpDeficit(root, policy, result),
             result.CombatEndedTurn,
             root.StartTurnNumber);
 
@@ -1560,12 +1564,13 @@ internal static class CombatSearchCoordinator
 
     private static PrimarySearchIncumbent? BuildPrimarySearchIncumbent(
         CombatRootSnapshot root,
+        SearchPolicySnapshot policy,
         SolverResult result)
     {
         if (!IsCompleteVictory(result) || result.CombatEndedTurn is not { } combatEndedTurn)
             return null;
         return new PrimarySearchIncumbent(
-            StrategicHpDeficit(root, result),
+            StrategicHpDeficit(root, policy, result),
             combatEndedTurn);
     }
 
@@ -1602,9 +1607,15 @@ internal static class CombatSearchCoordinator
             StrategicBossHpRelief(root, policy));
     }
 
-    private static int StrategicHpDeficit(CombatRootSnapshot root, SolverResult result)
+    private static int StrategicHpDeficit(
+        CombatRootSnapshot root,
+        SearchPolicySnapshot policy,
+        SolverResult result)
         => result.Snapshot.CumulativePlayerHpLost
-            + Math.Max(0, root.InitialPlayerMaxHp - result.Snapshot.PlayerMaxHp);
+            + Math.Max(0, root.InitialPlayerMaxHp - result.Snapshot.PlayerMaxHp)
+            + ActEndingBossPolicy.DeathSaveRelicPremium(
+                result.Snapshot.DeathSaveRelicHpRestored,
+                StrategicBossHpRelief(root, policy));
 
     internal static bool CanAnySmartPotionQualify(
         CombatRootSnapshot root,

--- a/src/Search/SimulatedCombatState.Fork.cs
+++ b/src/Search/SimulatedCombatState.Fork.cs
@@ -75,6 +75,7 @@ internal sealed partial class SimulatedCombatState
             _outstandingStolenCards = _outstandingStolenCards,
             _longTermResourceValue = _longTermResourceValue,
             _angerCopiesGenerated = _angerCopiesGenerated,
+            _deathSaveRelicHpRestored = _deathSaveRelicHpRestored,
         };
 
         if (_addedPowerInstances is not null)

--- a/src/Search/SimulatedCombatState.LongTermResources.cs
+++ b/src/Search/SimulatedCombatState.LongTermResources.cs
@@ -4,9 +4,21 @@ internal sealed partial class SimulatedCombatState
 {
     private int _longTermResourceValue;
     private int _angerCopiesGenerated;
+    private int _deathSaveRelicHpRestored;
 
     public int LongTermResourceValue => _longTermResourceValue;
     public int AngerCopiesGenerated => _angerCopiesGenerated;
+
+    /// <summary>
+    /// HP a one-shot death-save relic put back on this route: currently only Lizard Tail.
+    /// </summary>
+    /// <remarks>
+    /// The player really does get this HP, but it is not HP the route <em>earned</em>: the relic is a
+    /// cross-combat resource that is gone afterwards, and the same revive would have been available in every
+    /// later fight. Scoring takes it back out and charges a premium on top; see
+    /// <see cref="ActEndingBossPolicy.DeathSaveRelicPremium"/>.
+    /// </remarks>
+    public int DeathSaveRelicHpRestored => _deathSaveRelicHpRestored;
 
     public void RecordLongTermResource(int value)
     {
@@ -17,4 +29,11 @@ internal sealed partial class SimulatedCombatState
 
     public void RecordAngerCopyGenerated()
         => _angerCopiesGenerated = checked(_angerCopiesGenerated + 1);
+
+    public void RecordDeathSaveRelicHpRestored(int amount)
+    {
+        if (amount <= 0)
+            throw new ArgumentOutOfRangeException(nameof(amount), amount, "保命遗物的回复量必须为正数。");
+        _deathSaveRelicHpRestored = checked(_deathSaveRelicHpRestored + amount);
+    }
 }

--- a/src/Search/SimulatedCombatState.cs
+++ b/src/Search/SimulatedCombatState.cs
@@ -1877,6 +1877,8 @@ internal sealed partial class SimulatedCombatState
         fingerprint.Add(_longTermResourceValue);
         fingerprint.Add('A');
         fingerprint.Add(_angerCopiesGenerated);
+        fingerprint.Add('L');
+        fingerprint.Add(_deathSaveRelicHpRestored);
         AddFeralStates(ref fingerprint, simulator, effectivePowers);
         AddJugglingStates(ref fingerprint, simulator, effectivePowers);
         AddTurnStartStates(ref fingerprint, simulator, effectivePowers);

--- a/src/Search/SolverWeights.cs
+++ b/src/Search/SolverWeights.cs
@@ -69,6 +69,15 @@ internal static class SolverWeights
     public const int EliteSoldHpThreshold = 10;
     public const int BossSoldHpThreshold = 15;
     public const int PotionMinimumHpSaved = 9;
+
+    // 一次性保命遗物（蜥蜴尾巴）用掉就没了。除了不把复活回的血当成路线赚到的血，还要按复活血量的
+    // 若干倍再收一次「把它花掉」的代价。
+    //
+    // 倍数要够大。Beam 里和它抢分的不只是血：敌方总血量按 EnemyHp = -10_000 计价，一场双 Boss 战
+    // 光这一项就值一百多点血，所以按一比一收费时，靠复活换来的输出节奏仍然划算——实测就是这样，
+    // 路线照样把尾巴烧掉。收到十倍之后，任何一条能活着打赢的路线都比烧尾巴强，而这个数量级仍然
+    // 远低于 VictoryBonus 和 DeathPenalty：没有别的活路时，尾巴照用不误。
+    public const int DeathSaveRelicPremiumPercent = 900;
     // This is the minimum cross-turn no-progress horizon and the UI projection horizon. It is not a
     // total turn cap: every new historical combat improvement restarts the no-progress window.
     public const int SetupValueHorizonTurns = 16;

--- a/src/Testing/UnattendedTestProtocol.cs
+++ b/src/Testing/UnattendedTestProtocol.cs
@@ -106,6 +106,7 @@ internal sealed class UnattendedTestRequest
     public int? ExpectedInitialSoldHp { get; init; }
     public int? ExpectedInitialSoldHpAtMost { get; init; }
     public int? ExpectedInitialSoldHpBranchesPrunedAtLeast { get; init; }
+    public int? ExpectedInitialDeathSaveRelicHp { get; init; }
     public int? ExpectedInitialActionAdmissionRepresentativesProtectedAtLeast { get; init; }
     public int? ExpectedInitialHpInvestmentBranchesProtectedAtLeast { get; init; }
     public int? ExpectedInitialPotionCount { get; init; }

--- a/src/Testing/UnattendedTestRunner.ControllerSessions.cs
+++ b/src/Testing/UnattendedTestRunner.ControllerSessions.cs
@@ -969,6 +969,16 @@ internal sealed partial class UnattendedTestRunner
         {
             throw new InvalidOperationException("跨幕回复没有按 80% 同步缩放药水与卖血阈值。");
         }
+        if (ActEndingBossPolicy.DeathSaveRelicPremium(0, BossHpRelief.None) != 0
+            || ActEndingBossPolicy.DeathSaveRelicPremium(40, BossHpRelief.None) != 360
+            || ActEndingBossPolicy.DeathSaveRelicPremium(40, BossHpRelief.ActClearHeal) != 360
+            || ActEndingBossPolicy.DeathSaveRelicPremium(40, BossHpRelief.RunEnding) != 0
+            || ActEndingBossPolicy.DeathSaveRelicBeamCost(40, BossHpRelief.None) != 400
+            || ActEndingBossPolicy.DeathSaveRelicBeamCost(40, BossHpRelief.RunEnding) != 0)
+        {
+            throw new InvalidOperationException(
+                "一次性保命遗物的复活没有按用掉它的代价计价，或者整局最后一战没有免收。");
+        }
         if (ActEndingBossPolicy.ResolveStrategicHpRelief(
                 BossHpRelief.ActClearHeal,
                 BossHpStrategy.ProgressionFirst,

--- a/src/Testing/UnattendedTestRunner.SolverPolicy.cs
+++ b/src/Testing/UnattendedTestRunner.SolverPolicy.cs
@@ -103,6 +103,7 @@ internal sealed partial class UnattendedTestRunner
         => _request.ExpectedInitialSoldHp.HasValue
             || _request.ExpectedInitialSoldHpAtMost.HasValue
             || _request.ExpectedInitialSoldHpBranchesPrunedAtLeast.HasValue
+            || _request.ExpectedInitialDeathSaveRelicHp.HasValue
             || _request.ExpectedInitialActionAdmissionRepresentativesProtectedAtLeast.HasValue
             || _request.ExpectedInitialHpInvestmentBranchesProtectedAtLeast.HasValue
             || _request.ExpectedInitialPotionCount.HasValue
@@ -277,6 +278,13 @@ internal sealed partial class UnattendedTestRunner
         {
             throw new InvalidOperationException(
                 $"首轮卖血预算剪枝为 {result.SoldHpBranchesPruned}，低于预期下限 {minimumPruned}。");
+        }
+        if (_request.ExpectedInitialDeathSaveRelicHp is { } expectedDeathSaveRelicHp
+            && result.Snapshot.DeathSaveRelicHpRestored != expectedDeathSaveRelicHp)
+        {
+            throw new InvalidOperationException(
+                $"首轮路线用掉一次性保命遗物回了 {result.Snapshot.DeathSaveRelicHpRestored} 点血，"
+                + $"预期为 {expectedDeathSaveRelicHp}。");
         }
         if (_request.ExpectedInitialActionAdmissionRepresentativesProtectedAtLeast is { } minimumProtected
             && result.ActionAdmissionRepresentativesProtected < minimumProtected)

--- a/tools/run-unattended-test.ps1
+++ b/tools/run-unattended-test.ps1
@@ -117,6 +117,7 @@ param(
     [int]$ExpectedInitialExecutableActionCountAtLeast = -1,
     [int]$ExpectedInitialSoldHp = -1,
     [int]$ExpectedInitialSoldHpAtMost = -1,
+    [int]$ExpectedInitialDeathSaveRelicHp = -1,
     [int]$ExpectedInitialSoldHpBranchesPrunedAtLeast = -1,
     [int]$ExpectedInitialActionAdmissionRepresentativesProtectedAtLeast = -1,
     [int]$ExpectedInitialHpInvestmentBranchesProtectedAtLeast = -1,
@@ -745,6 +746,7 @@ $request = [ordered]@{
     expectedInitialExecutableActionCountAtLeast = if ($ExpectedInitialExecutableActionCountAtLeast -ge 0) { $ExpectedInitialExecutableActionCountAtLeast } else { $null }
     expectedInitialSoldHp = if ($ExpectedInitialSoldHp -ge 0) { $ExpectedInitialSoldHp } else { $null }
     expectedInitialSoldHpAtMost = if ($ExpectedInitialSoldHpAtMost -ge 0) { $ExpectedInitialSoldHpAtMost } else { $null }
+    expectedInitialDeathSaveRelicHp = if ($ExpectedInitialDeathSaveRelicHp -ge 0) { $ExpectedInitialDeathSaveRelicHp } else { $null }
     expectedInitialSoldHpBranchesPrunedAtLeast = if ($ExpectedInitialSoldHpBranchesPrunedAtLeast -ge 0) { $ExpectedInitialSoldHpBranchesPrunedAtLeast } else { $null }
     expectedInitialActionAdmissionRepresentativesProtectedAtLeast = if ($ExpectedInitialActionAdmissionRepresentativesProtectedAtLeast -ge 0) { $ExpectedInitialActionAdmissionRepresentativesProtectedAtLeast } else { $null }
     expectedInitialHpInvestmentBranchesProtectedAtLeast = if ($ExpectedInitialHpInvestmentBranchesProtectedAtLeast -ge 0) { $ExpectedInitialHpInvestmentBranchesProtectedAtLeast } else { $null }

--- a/tools/run-unattended-test.sh
+++ b/tools/run-unattended-test.sh
@@ -135,7 +135,7 @@ for name in \
     expected-initial-choice-branches-evaluated-at-least \
     expected-initial-executable-action-count-at-least \
     expected-initial-sold-hp expected-initial-sold-hp-at-most \
-    expected-initial-sold-hp-branches-pruned-at-least \
+    expected-initial-sold-hp-branches-pruned-at-least \n    expected-initial-death-save-relic-hp \
     expected-initial-action-admission-representatives-protected-at-least \
     expected-initial-hp-investment-branches-protected-at-least \
     expected-initial-potion-count expected-initial-potion-hp-saved-at-least \


### PR DESCRIPTION
## 症状

蜥蜴尾巴在玩家将死时把生命拉回最大生命的一半。求解器会**主动走进致命伤害去触发它**。

玩家报告的一局（幕末双 Boss，玩家 41/79 血）：路线在第 5 回合手上有 6 点格挡**故意不出**，掉到 0 血触发复活回到 39 血，界面写着「回血 39　净 +27 HP」。尾巴是一次性遗物，用掉就没了，玩家想省着用。

## 根因

复活回的血直接进了节点的 `ProjectedPlayerHp`，和喝药、打回血牌回的血没有区别；而**用掉遗物本身一分钱不收**。于是「挨一刀再复活」在评分里是一笔净赚的买卖。

瓶中仙女做的是同一件事，但它是药水，花掉它要走药水计价，所以从来没有这个问题。`AfterPreventingDeathMirrors` 里只登记了这两个，所以蜥蜴尾巴是原版唯一一条没有计价的保命途径。

## 改动

复活血量单独记进 `SimulatedCombatState.DeathSaveRelicHpRestored`，然后分两笔收费：

1. **从 Beam 打分里把这笔血扣回去** —— 它还留在 `projectedHp` 里，先减掉；
2. **再按同样的血量乘一个倍数收一次「把它花掉」的代价**。

Beam 打分、Beam 保留、`ShouldPruneByPrimaryIncumbent` 的下界、最终排序四处用同一个数。威胁投影里「这一刀会打死你，但尾巴会救你」也照收 —— 不收的话保留阶段会留下打算去死的那条、丢掉打算不死的那条。

下界那处仍然是合法下界：复活已经发生了，收掉的代价只增不减。

## 十倍这个数是量出来的

第一版按一比一收（复活 39 就罚 39）。**跑下来路线照样把尾巴烧掉。**

原因是 Beam 里跟血抢分的不只是血：敌方总血量按 `EnemyHp = -10_000` 计价，那局双 Boss 合计 408 血，光这一项就值 136 点血。靠复活换来的输出节奏比 78 点血的罚款值钱。

我把倍数临时拉到二十倍验证「到底有没有不烧尾巴还能赢的路线」—— **有**。然后落到十倍，同样的结果，留了余量。

这个量级仍然远低于 `VictoryBonus`（1e10）和 `DeathPenalty`（-1e12），差四到七个数量级，所以**没有别的活路时尾巴照用不误**。

## 整局最后一战免收

`BossHpRelief.RunEnding` 时代价归零。后面没有战斗了，留着尾巴毫无价值，复活重新变成免费的。

过幕（`ActClearHeal`）**不**免收：清幕会回血，但不会把尾巴还给你。所以回血折算和遗物代价这两件事在这里是分开的。

## 验证

**行为对照**（复现玩家导出的问题包，同种子、同状态、同搜索设置）：

| | 回合 | 战损 | 尾巴 | 终局血 | 结果 |
|---|---|---|---|---|---|
| 改前 | 6 | 41 | 烧掉 | 39 | 赢 |
| 改后 | 10 | **40** | **留着** | 1 | 赢 |

少掉一点血，多打四个回合，换回一次保命机会。

**这里要说清楚**：这组对照是在我本地的集成分支上跑的，那条分支同时带着 #40 和 #41。本 PR 是照着 `main` 单独重切的 —— `main` 上没有 `RecoveredPlayerHp` 那套，所以这里只有「代价」这一笔，没有「把复活从回血里扣掉」那一笔（`main` 本来就不给回血记分）。**Beam 那一笔两边完全一样**，而上面那次翻转正是 Beam 决定的（一比一失效的原因就是 Beam 里的敌方血量项），所以结论可以搬过来。

**没有 headless fixture。** 复现用的是第三方角色（观者）的存档，没法直接做成原版夹具。造一个原版的蜥蜴尾巴夹具是可行的（低血 + 尾巴 + 逼出「挨打复活 vs 多打几回合」的二选一），需要几轮标定，你要的话我补上。

**静态断言**：`ActEndingBossPolicy.DeathSaveRelicPremium` / `DeathSaveRelicBeamCost` 的取值和最后一战免收已加进 `UnattendedTestRunner` 的自检。

**编译**：Release 零警告零错误。原版没有蜥蜴尾巴复活时 `DeathSaveRelicHpRestored` 恒为 0，新增的几项全部退化成 0，评分与改前逐位相同。

## 顺带

- 结果行新增 `death_save_relic_hp=`。
- 无人测试协议新增 `-ExpectedInitialDeathSaveRelicHp`。
- `ProjectHpAfterThreat` 的返回值从 `int` 改成 `ThreatProjection`（生命 + 预计要花掉的保命血量），投影缓存跟着换类型。
