### PR TITLE
[Fix]: Skip Bone Shards damage and block when the Osty is gone

### DIFF
--- a/coverage/unattended/bone-shards-osty-replay-0300.json
+++ b/coverage/unattended/bone-shards-osty-replay-0300.json
@@ -1,0 +1,17 @@
+[
+  {
+    "monsterId": "FuzzyWurmCrawler",
+    "moveId": "INHALE",
+    "clearPlayerHandBeforeMove": true,
+    "ostyHpBefore": 10,
+    "playerEnergyBefore": 30,
+    "cardsBeforeMove": [
+      { "cardId": "BONE_SHARDS", "pile": "Hand" },
+      { "cardId": "BONE_SHARDS", "pile": "Hand" }
+    ],
+    "cardPlayChecksAfterMove": [
+      { "cardId": "BONE_SHARDS", "occurrence": 0, "target": "None" },
+      { "cardId": "BONE_SHARDS", "occurrence": 0, "target": "None" }
+    ]
+  }
+]

--- a/src/Engine/InCombat/Mirrors/Cards/OnPlay/BespokeCardMirrors.cs
+++ b/src/Engine/InCombat/Mirrors/Cards/OnPlay/BespokeCardMirrors.cs
@@ -18,6 +18,24 @@ internal static class BespokeCardMirrors
     public static void DaggerSprayOnPlay(DaggerSpray _, CardOnPlayMirrorContext context)
         => context.AttackAllOpponents(hitCount: 2);
 
+    // Vanilla wraps the whole body in Osty.CheckMissingWithAnim, so the attack and the block are both
+    // skipped once the Osty is gone. The sacrifice stays in CardEffectSpecRegistry, which runs after
+    // this mirror and is gated on the same condition.
+    public static void BoneShardsOnPlay(BoneShards card, CardOnPlayMirrorContext context)
+    {
+        if (context.State.GetOsty(card.Owner) is not { } osty || context.State.GetCreature(osty).IsDead)
+        {
+            return;
+        }
+
+        DamageCmd.Attack(card.DynamicVars.OstyDamage.BaseValue)
+            .FromOsty(osty, card, context.CardPlay)
+            .TargetingAllOpponents(context.CombatState)
+            .Simulate(context.Simulator);
+
+        context.GainBlock(card.Owner.Creature);
+    }
+
     public static void PactsEndOnPlay(PactsEnd card, CardOnPlayMirrorContext context)
     {
         if (context.OwnerState.ExhaustPile.Cards.Count >= card.DynamicVars.Cards.IntValue)

--- a/src/Engine/InCombat/Mirrors/Cards/OnPlay/CardOnPlayMirrors.cs
+++ b/src/Engine/InCombat/Mirrors/Cards/OnPlay/CardOnPlayMirrors.cs
@@ -65,6 +65,7 @@ internal static class CardOnPlayMirrors
         registry.Register<Mangle>(GeneralCardMirrors.GeneralAttackOnPlay);
         registry.Register<IAmInvincible>(GeneralCardMirrors.GeneralBlockOnPlay);
         registry.Register<AstralPulse>(BespokeCardMirrors.AstralPulseOnPlay);
+        registry.Register<BoneShards>(BespokeCardMirrors.BoneShardsOnPlay);
         registry.Register<DaggerSpray>(BespokeCardMirrors.DaggerSprayOnPlay);
         registry.Register<PactsEnd>(BespokeCardMirrors.PactsEndOnPlay);
         registry.Register<TwinStrike>(BespokeCardMirrors.TwinStrikeOnPlay);


### PR DESCRIPTION
# 修复：碎骨在奥斯提已死时不应再算伤害和格挡

玩亡灵契约师的时候碰到的，顺手修了一下。

## 问题

一回合里打第二次碎骨（重放，或者手里有两张），求解器会多算一次格挡，于是高估这条路线
。

原版 `BoneShards.OnPlay` 是把整段效果包在 `Osty.CheckMissingWithAnim` 里的：

```csharp
if (!Osty.CheckMissingWithAnim(base.Owner))
{
    await DamageCmd.Attack(base.DynamicVars.OstyDamage.BaseValue)
        .FromOsty(base.Owner.Osty, this, cardPlay).TargetingAllOpponents(base.Combat
State) ...
    await CreatureCmd.GainBlock(base.Owner.Creature, base.DynamicVars.Block, cardPla
y);
    if (base.Owner.IsOstyAlive)
        await CreatureCmd.Kill(base.Owner.Osty);
}
```

`IsOstyMissing => !IsOstyAlive`，所以奥斯提没了之后，伤害、格挡、献祭三样都不发生，
第二次打出去是纯粹的空过。

碎骨没有注册 mirror，走的是 `CardOnPlayInferrer.Infer` 的宽松 IL 推断，而推断器只识
别 `AttackCommand.Execute` 和 `CreatureCmd.GainBlock`，看不见外层那个 `if`。两条路径
的实际表现：

- 伤害：`GeneralAttackOnPlay` 的 `CardTag.OstyAttack` 分支已经按存活拦截了，本来就是
对的；
- 格挡：`GeneralBlockOnPlay` 无条件加盾 —— 就是这里漏了。

（严格推断器 `InferStrict` 的 `IsEffectConditionallyExecuted` 本来能识别这种条件分支
，但碎骨会写 model 状态，先被 `HasUnsupportedModelWrite` 否掉，于是回落到宽松版。）

## 改动

按 `FetchOnPlay` / `SacrificeOnPlay` 的现成形状注册一个显式 mirror：奥斯提缺失或死亡
直接返回，否则由奥斯提对全体攻击并加盾。

献祭保持在 `CardEffectSpecRegistry`，它在 mirror 之后执行、且已经 gate 在同一条件上
，所以这个效果仍然只有一个权威结算点。

对着 `0.111.0` 反编译核对过全部 13 张 `OstyAttack` 卡：整段带守卫是共同写法，但**只
有碎骨会加盾**，其余的（`Fetch` 等）此前已有显式 mirror，所以影响面就是这一张牌。

## 验证

新增夹具 `coverage/unattended/bone-shards-osty-replay-0300.json`：奥斯提 10 HP，手牌
两张碎骨连续打出。

```powershell
pwsh -NoProfile -File tools\run-unattended-test.ps1 -ScenarioId BONE-SHARDS-OSTY-REP
LAY-0300 -CharacterId NECROBINDER -EnemyCurrentHp 999 -MonsterMoveChecksPath coverag
e\unattended\bone-shards-osty-replay-0300.json -TimeoutSeconds 120 -ExitOnComplete
```

- 改动前一步严格差分失败：`field=block expected={18} actual={9}`（求解器 9+9，实机只
有 9）
- 改动后通过，runId `7542f28068d14b9da6c632f726d6866d`

伤害侧没有出现在差异里，印证了它原本就被守卫拦住。