### PR TITLE
fix: 无人测试 sh 的选项表里一个字面 \n（#47 遗留）

### DIFF
--- a/tools/run-unattended-test.sh
+++ b/tools/run-unattended-test.sh
@@ -160,7 +160,8 @@ for name in \
     expected-initial-choice-branches-evaluated-at-least \
     expected-initial-executable-action-count-at-least \
     expected-initial-sold-hp expected-initial-sold-hp-at-most \
-    expected-initial-sold-hp-branches-pruned-at-least \n    expected-initial-death-save-relic-hp \
+    expected-initial-sold-hp-branches-pruned-at-least \
+    expected-initial-death-save-relic-hp \
     expected-initial-action-admission-representatives-protected-at-least \
     expected-initial-hp-investment-branches-protected-at-least \
     expected-initial-potion-count expected-initial-potion-hp-saved-at-least \


### PR DESCRIPTION
我在 #47 里留下的笔误，一行。

`tools/run-unattended-test.sh` 的选项表里，`expected-initial-death-save-relic-hp` 前面的换行落成了**字面的反斜杠加 n**：

```
    expected-initial-sold-hp-branches-pruned-at-least \n    expected-initial-death-save-relic-hp \
```

`for name in ...` 会把它拆成 `-at-least`、`\n`、`expected-initial-death-save-relic-hp` 三个词，于是多注册了一个名叫 `n` 的假选项（`--n`）。

**功能没坏** —— `expected-initial-death-save-relic-hp` 本身注册是对的，行尾续行也没受影响，所以夹具照跑。只是那个假选项该去掉。`ps1` 那一份没有这个问题。

抱歉，是我生成补丁时把 `\n` 写成了字面串。