### PR TITLE
[观者适配] 给第三方 Power 开一个战略估值登记点：以手拒之现在会正确被识别用于起甲

### DIFF
--- a/docs/third-party-strategic-effects.md
+++ b/docs/third-party-strategic-effects.md
@@ -1,0 +1,100 @@
+# 第三方 Power 的战略估值登记
+
+## 这是给谁用的
+
+第三方 mod 加了一层 Power，而这层 Power 会改变**玩家该按什么顺序出牌**。
+
+不改变出牌顺序的 Power 不需要登记。求解器对未知 Power 类型有兜底：按叠加层数记一点
+`ScalingPotential`。它会让"打出这张 Power 牌"这个动作被归进 `PersistentSetup` 族、不至于
+被完全剪掉，对绝大多数 mod 内容够用。
+
+需要登记的是这一类：**这层 Power 的收益取决于它和别的动作的先后关系。**
+
+## 为什么兜底不够
+
+`CombatBeamSolver.ClassifyActionOptionFamilies` 给每个动作打族标签，同族里只留代表。判一个
+动作算不算 `ImmediateDefense`，看四样东西：
+
+```csharp
+if (block > 0
+    || after.ProjectedPlayerHp > before.ProjectedPlayerHp
+    || after.PlayerHp > before.PlayerHp
+    || after.StrategicEffects.PreventionPotential > before.StrategicEffects.PreventionPotential)
+```
+
+四样里唯一能被一层 Power 影响的是 `PreventionPotential`。一张"自己不给甲、但让后续攻击给甲"
+的牌，这四样一样都不动，于是被归成纯 `ImmediateOffense`，和攻击牌同族但伤害更低，在族内代表
+里被压掉，只能排到攻击后面——而它的收益恰恰依赖排在攻击前面。
+
+还有一层：`CombatBeamSolver.StateEvaluation` 那两圈设置估值原本写死了
+`ReferenceEquals(power.Owner, _player.Creature)`，也就是**只看玩家自己身上的增益**。挂在敌人
+身上、收益归玩家的 Power 连这一圈都进不来。
+
+## 怎么登记
+
+```csharp
+StrategicEffectMirrors.Register<MyPower>(
+    StrategicEffectRequirements.AttackPlays,
+    static (power, context) => StrategicEffectModel.Prevention(
+        Math.Max(1, power.Amount) * context.AttackPlays,
+        context),
+    StrategicEffectHost.Enemy);
+```
+
+三个参数：
+
+| 参数 | 说明 |
+|---|---|
+| `requirements` | 估值要读 `StrategicEffectContext` 的哪几项。只有被要求的项才会被算出来，没要求的留在便宜的默认值上。如实填：多填浪费，少填读到的是默认值而不是报错 |
+| `evaluate` | 由这一层 Power 得出一个 `StrategicEffectVector` |
+| `host` | 这层 Power 挂在谁身上 |
+
+`host` 两种：
+
+- `StrategicEffectHost.Player`（默认）——挂在玩家身上的增益，和原版一样的判定：层数为正、
+  当前层数下是 `PowerType.Buff`、不是 `ITemporaryPower`。
+- `StrategicEffectHost.Enemy`——挂在**敌人**身上但收益归玩家。判定换成：层数为正、不是
+  `ITemporaryPower`、宿主不是玩家。**不查增益/减益**，因为它在宿主眼里通常是减益，查了就
+  永远进不来。
+
+登记要在 mod 加载时做一次。登记表为空时两处热路径只多一次 `Count` 检查。
+
+## 估值往哪个方向偏
+
+用 `StrategicEffectModel` 的五个工厂方法构造向量，不要自己拼字段——它们各自带着上限逻辑，
+比如 `Prevention` 会把值夹在「这回合进来的伤害 × min(2, 剩余回合)」以内。
+
+| 工厂 | 落在哪一项 |
+|---|---|
+| `Damage(value, enemyHp)` | `DamagePotential`，上限是敌人当前生命 |
+| `Prevention(value, context)` | `PreventionPotential`，上限见上 |
+| `Resource(value)` | `ResourcePotential` |
+| `CardAccess(value)` | `CardAccessPotential` |
+| `Scaling(value)` | `ScalingPotential` |
+
+数值分两件事看，两件事对精度的要求差很多：
+
+- **准入**：`ClassifyActionOptionFamilies` 判的是**有没有变大**，只要非零就够。这一半只要求
+  你别把值算成 0。
+- **排名**：数值决定这条线在收益真正兑现之前能在 Beam 里活多久。估低了会把好线剪掉，估高了
+  只是多留几个节点。所以拿不准时**往高了估**，不要往低了估。
+
+## 一个真实例子
+
+观者 mod 的「以手拒之」：打出后给目标挂一层反弹格挡，之后玩家每打中这个敌人**一段**就起
+`Amount` 点甲，不自减，整场都在。
+
+实测没登记之前：手里以手拒之加两张打击、敌人这回合打 4 点，求解器给的顺序是
+「打击 打击 以手拒之」，第 1 回合 `max_block=0`，白挨 4 点；换成「以手拒之 打击 打击」本可以
+4 甲全挡掉。第 2、3、4 回合都是 `max_block=4 actual_block=4`——层数一旦挂上去，后面每回合都
+算得对，唯独挂上去的那一回合被浪费。
+
+登记以后，打出以手拒之这个动作会让 `PreventionPotential` 从 0 变正，于是它同时进
+`ImmediateDefense` 族，不再被打击在同族里压掉。
+
+估值取「层数 × 可打出的攻击牌张数」。按张不按段是低估——反弹格挡是按伤害段数触发的
+（`CombatPredictionSimulator.Attack` 是 `for (i < hitCount) { Damage(...) }`，每段各产生一个
+`DamageResult`、各分发一次 `AfterDamageGiven`），而 `StrategicEffectRequirements.AttackPlays`
+数的是 `liveCards` 里 `Type == Attack` 的张数。求解器现成的量里没有按段计数，`CardValue` 也
+只读 `Damage` 基础值。低估在这里可以接受，因为准入那一半不受影响，而排名那一半有 `Prevention`
+的上限兜着：对任何有威胁的局面，层数 × 张数早就顶到上限了。

--- a/src/Search/CombatBeamSolver.StateEvaluation.cs
+++ b/src/Search/CombatBeamSolver.StateEvaluation.cs
@@ -207,13 +207,8 @@ internal sealed partial class CombatBeamSolver
         for (int powerIndex = 0; powerIndex < effectivePowers.Count; powerIndex++)
         {
             PowerModel power = effectivePowers[powerIndex];
-            if (!ReferenceEquals(power.Owner, _player.Creature)
-                || power.Amount <= 0
-                || power.TypeForCurrentAmount != PowerType.Buff
-                || power is ITemporaryPower)
-            {
+            if (!StrategicEffectMirrors.Contributes(power, _player.Creature))
                 continue;
-            }
             strategicRequirements |= StrategicEffectModel.Requirements(power);
         }
         StrategicEffectContext? strategicContext = null;
@@ -223,13 +218,8 @@ internal sealed partial class CombatBeamSolver
         for (int powerIndex = 0; powerIndex < effectivePowers.Count; powerIndex++)
         {
             PowerModel power = effectivePowers[powerIndex];
-            if (!ReferenceEquals(power.Owner, _player.Creature)
-                || power.Amount <= 0
-                || power.TypeForCurrentAmount != PowerType.Buff
-                || power is ITemporaryPower)
-            {
+            if (!StrategicEffectMirrors.Contributes(power, _player.Creature))
                 continue;
-            }
             strategicContext ??= StrategicEffectContext.Build(
                 liveCards,
                 enemyHp,

--- a/src/Search/StrategicEffectMirrors.cs
+++ b/src/Search/StrategicEffectMirrors.cs
@@ -1,0 +1,125 @@
+using MegaCrit.Sts2.Core.Entities.Creatures;
+using MegaCrit.Sts2.Core.Entities.Powers;
+using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Models.Powers;
+
+namespace CombatSolver;
+
+/// <summary>
+/// 一个被登记的战略效果挂在谁身上。
+///
+/// 绝大多数增益挂在玩家身上，收益也归玩家，那是 <see cref="Player"/>。少数效果挂在**敌人**
+/// 身上而收益归玩家——观者的以手拒之就是这样：反弹格挡这层 Power 施加在敌人身上，玩家每打中
+/// 它一次就起一次甲。这类效果在"只看玩家身上的增益"那一圈里会被整个跳过，所以需要单独说明。
+/// </summary>
+internal enum StrategicEffectHost
+{
+    /// <summary>挂在玩家身上，并且是增益（<see cref="PowerType.Buff"/>）。</summary>
+    Player,
+
+    /// <summary>挂在敌人身上，收益归玩家。不检查增益/减益——它在宿主眼里通常是减益。</summary>
+    Enemy,
+}
+
+/// <summary>
+/// 第三方 Power 的战略估值登记表。
+///
+/// <see cref="StrategicEffectModel"/> 的 <c>Requirements</c> 和 <c>Evaluate</c> 是按原版 Power
+/// 类型写死的 <c>switch</c>，第三方类型全部落进默认分支、按叠加层数记一点 Scaling。对大多数
+/// mod 的 Power 来说这个兜底够用，但对"改变玩家该按什么顺序出牌"的效果不够：
+/// <c>ClassifyActionOptionFamilies</c> 判一张牌算不算 <c>ImmediateDefense</c>，四个判据里唯一
+/// 能被 Power 影响的就是 <c>StrategicEffects.PreventionPotential</c>。这一项不动，一张自己不
+/// 给甲的防御牌会被归成纯进攻牌，在族内代表里被伤害更高的攻击牌压掉，只能排到攻击后面——
+/// 而它的收益恰恰依赖排在攻击前面。
+///
+/// 所以这里开一个登记点。登记之后：
+/// <list type="bullet">
+/// <item>估值走登记的委托，不再落默认分支；</item>
+/// <item><see cref="StrategicEffectHost.Enemy"/> 的类型会被"只看玩家身上的增益"那一圈放行。</item>
+/// </list>
+///
+/// 求解器本身不认识任何第三方类型，登记由 mod 在加载时自己做。
+/// </summary>
+internal static class StrategicEffectMirrors
+{
+    private readonly record struct Entry(
+        StrategicEffectRequirements Requirements,
+        Func<PowerModel, StrategicEffectContext, StrategicEffectVector> Evaluate,
+        StrategicEffectHost Host);
+
+    private static readonly Dictionary<Type, Entry> Registry = [];
+
+    /// <summary>
+    /// 为一个 Power 类型登记战略估值。
+    /// </summary>
+    /// <param name="requirements">
+    /// 估值要读 <see cref="StrategicEffectContext"/> 的哪几项。只有被要求的项才会被算出来，
+    /// 没要求的留在便宜的默认值上，所以这里要如实填，多填浪费、少填读到的是默认值。
+    /// </param>
+    /// <param name="evaluate">
+    /// 由这一层 Power 得出一个 <see cref="StrategicEffectVector"/>。用
+    /// <c>StrategicEffectVector.Prevention</c> 这一组工厂方法构造，不要自己拼字段——
+    /// 那几个方法带着各自的上限逻辑。
+    /// </param>
+    /// <param name="host">这层 Power 挂在谁身上，见 <see cref="StrategicEffectHost"/>。</param>
+    public static void Register<TPower>(
+        StrategicEffectRequirements requirements,
+        Func<PowerModel, StrategicEffectContext, StrategicEffectVector> evaluate,
+        StrategicEffectHost host = StrategicEffectHost.Player)
+        where TPower : PowerModel
+    {
+        ArgumentNullException.ThrowIfNull(evaluate);
+        Registry[typeof(TPower)] = new Entry(requirements, evaluate, host);
+    }
+
+    /// <summary>登记表是否为空。空表时两处热路径可以整段跳过字典查找。</summary>
+    public static bool IsEmpty => Registry.Count == 0;
+
+    /// <summary>
+    /// 这层 Power 该不该进战略估值。
+    ///
+    /// 原版规则：挂在玩家身上、层数为正、当前层数下是增益、不是临时 Power。
+    /// 登记为 <see cref="StrategicEffectHost.Enemy"/> 的类型换一套：挂在**别人**身上、层数为正、
+    /// 不是临时 Power。不查增益/减益——它在敌人眼里是减益，查了就永远进不来。
+    /// </summary>
+    public static bool Contributes(PowerModel power, Creature playerCreature)
+    {
+        if (power.Amount <= 0 || power is ITemporaryPower)
+            return false;
+        bool onPlayer = ReferenceEquals(power.Owner, playerCreature);
+        if (Registry.Count > 0
+            && Registry.TryGetValue(power.GetType(), out Entry entry)
+            && entry.Host == StrategicEffectHost.Enemy)
+        {
+            return !onPlayer;
+        }
+        return onPlayer && power.TypeForCurrentAmount == PowerType.Buff;
+    }
+
+    public static bool TryGetRequirements(
+        PowerModel power,
+        out StrategicEffectRequirements requirements)
+    {
+        if (Registry.Count > 0 && Registry.TryGetValue(power.GetType(), out Entry entry))
+        {
+            requirements = entry.Requirements;
+            return true;
+        }
+        requirements = StrategicEffectRequirements.None;
+        return false;
+    }
+
+    public static bool TryEvaluate(
+        PowerModel power,
+        StrategicEffectContext context,
+        out StrategicEffectVector effect)
+    {
+        if (Registry.Count > 0 && Registry.TryGetValue(power.GetType(), out Entry entry))
+        {
+            effect = entry.Evaluate(power, context);
+            return true;
+        }
+        effect = StrategicEffectVector.Zero;
+        return false;
+    }
+}

--- a/src/Search/StrategicEffectModel.cs
+++ b/src/Search/StrategicEffectModel.cs
@@ -339,7 +339,11 @@ internal readonly record struct StrategicEffectContext(
 internal static class StrategicEffectModel
 {
     public static StrategicEffectRequirements Requirements(PowerModel power)
-        => power switch
+    {
+        // 第三方登记优先。登记表为空时这是一次字典 Count 检查，热路径上可以忽略。
+        if (StrategicEffectMirrors.TryGetRequirements(power, out StrategicEffectRequirements registered))
+            return registered;
+        return power switch
         {
             AfterimagePower => StrategicEffectRequirements.UsefulCardPlays,
             BufferPower => StrategicEffectRequirements.RemainingTurns,
@@ -369,11 +373,14 @@ internal static class StrategicEffectModel
                 => StrategicEffectRequirements.RemainingTurns,
             _ => StrategicEffectRequirements.None,
         };
+    }
 
     public static StrategicEffectVector Evaluate(
         PowerModel power,
         StrategicEffectContext context)
     {
+        if (StrategicEffectMirrors.TryEvaluate(power, context, out StrategicEffectVector registered))
+            return registered;
         int amount = Math.Max(1, power.Amount);
         int enemyHp = context.EnemyHp;
         int energyUnit = Math.Max(3, context.AverageCardValue);
@@ -425,10 +432,10 @@ internal static class StrategicEffectModel
         };
     }
 
-    private static StrategicEffectVector Damage(int value, int enemyHp)
+    public static StrategicEffectVector Damage(int value, int enemyHp)
         => new(Math.Min(Math.Max(0, enemyHp), Math.Max(0, value)), 0, 0, 0, 0);
 
-    private static StrategicEffectVector Prevention(int value, StrategicEffectContext context)
+    public static StrategicEffectVector Prevention(int value, StrategicEffectContext context)
     {
         int cap = context.IncomingDamage == 0
             ? value
@@ -446,12 +453,12 @@ internal static class StrategicEffectModel
         return Math.Min(context.IncomingDamage, amount * averageHit);
     }
 
-    private static StrategicEffectVector Resource(int value)
+    public static StrategicEffectVector Resource(int value)
         => new(0, 0, Math.Max(0, value), 0, 0);
 
-    private static StrategicEffectVector CardAccess(int value)
+    public static StrategicEffectVector CardAccess(int value)
         => new(0, 0, 0, Math.Max(0, value), 0);
 
-    private static StrategicEffectVector Scaling(int value)
+    public static StrategicEffectVector Scaling(int value)
         => new(0, 0, 0, 0, Math.Max(0, value));
 }


### PR DESCRIPTION
## 问题

第三方 mod 加的 Power，如果收益取决于它和别的动作的**先后关系**，求解器排不对顺序。

`ClassifyActionOptionFamilies` 判一个动作算不算 `ImmediateDefense`，四个判据里唯一能被一层 Power 影响的是 `StrategicEffects.PreventionPotential`。一张「自己不给甲、但让后续攻击给甲」的牌，这四样一样都不动，于是被归成纯 `ImmediateOffense`，和攻击牌同族但伤害更低，在族内代表里被压掉，只能排到攻击后面 —— 而它的收益恰恰依赖排在攻击前面。

第三方类型走 `StrategicEffectModel` 的默认分支，只按层数记一点 `ScalingPotential`，进不了 `PreventionPotential`。而且 `StateEvaluation` 那两圈设置估值写死了 `ReferenceEquals(power.Owner, _player.Creature)`，挂在敌人身上、收益归玩家的 Power 连这一圈都进不来。

## 改法

新增 `StrategicEffectMirrors`：按 Power 类型登记 requirements 和估值委托，外加一个 `host` 说明这层 Power 挂在谁身上。`StrategicEffectHost.Enemy` 换一套准入判定 —— 层数为正、不是临时 Power、宿主不是玩家，不查增益减益，因为它在宿主眼里通常是减益。

`Requirements` 和 `Evaluate` 先查登记表，查不到再走原来的 `switch`。`StateEvaluation` 那两圈重复的过滤条件收进 `StrategicEffectMirrors.Contributes`。

**原版行为一个字没动。** 登记表为空时 `Contributes` 逐条等价于原来那四个条件：

| 原来 | 现在（登记表为空） |
|---|---|
| `owner == player` | `onPlayer` |
| `Amount > 0` | `Amount > 0` |
| `TypeForCurrentAmount == Buff` | 同 |
| `!(power is ITemporaryPower)` | 同 |

`TryGetRequirements` / `TryEvaluate` 都先查 `Registry.Count > 0`，空表时短路，两处热路径只多一次 `Dictionary.Count`。原版不登记任何东西，走的是同一条码。

五个构造向量的工厂方法从 `private` 改 `public`（类本身是 `internal`，可见性没有外扩），好让登记方带着各自的上限逻辑构造结果，而不是自己拼字段。

## 为什么不直接把类型写进 switch

求解器不该认识任何第三方类型。观者的反弹格挡是本次动机，但它的估值应该由观者的适配层提供，这样求解器这边只有机制、没有具体 mod 的知识。

## 用于「以手拒之」

观者的「以手拒之」：打出后给目标挂一层反弹格挡，之后玩家每打中这个敌人**一段**就起 `Amount` 点甲，不自减，整场都在。

修之前实测：手里以手拒之加两张打击、敌人这回合打 4 点，求解器给的顺序是「打击 打击 以手拒之」，第 1 回合 `max_block=0`，白挨 4 点。第 2、3、4 回合都是 `max_block=4 actual_block=4` —— 层数一旦挂上去后面每回合都算得对，唯独挂上去的那一回合被浪费。

登记之后打出它会让 `PreventionPotential` 从 0 变正，于是它同时进 `ImmediateDefense` 族，不再被伤害更高的打击在同族里压掉。

## 验证

观者适配层的 24 条夹具矩阵全通过（游戏 v0.111.0 + 观者 0.9.25 + 求解器 0.31.1 + 本 PR）。其中新增一条专门锁这个行为：以手拒之加两张打击、3 能量，判 `max_block >= 4`（以手拒之给 2 层，两张打击各 1 段，排最前面 = 4 甲，排中间 = 2，排最后 = 0）。

**做过反向对照**：把适配层那行注册注释掉重新构建，这条夹具就不过；加回来就过。

## 文档

`docs/third-party-strategic-effects.md`：怎么用、`host` 两种取值的判定差别、估值该往哪个方向偏（准入只要非零，排名宁可往高估），以及以手拒之这个完整实例。

---

这是观者适配那一批 PR 的第一条。
