### PR TITLE
[观者适配] 一份第三方 Mod 适配手册，并把「改登记点就同步手册」写进仓库约定

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ CombatSolver 是《杀戮尖塔 2》的单人战斗路线求解器 Mod，使用 
 - [核验审计](docs/refactoring/verified-audit-4117eb0.md)：本轮重构的逐阶段证据；它是历史结果，不是持续规则。
 - [测试矩阵](docs/TEST_MATRIX.md) 与 `coverage/test-evidence.json`：可重跑场景和结构化证据。
 - [开发笔记](docs/DEVELOPMENT_NOTES.md)：版本历史与未发布行为变化。
+- [第三方 Mod 适配手册](docs/THIRD_PARTY_ADAPTERS.md)：面向外部 Mod 作者的登记点总表、登记纪律与验收标准；同时是「哪些位置还是封闭开关」的单一维护入口。
 - `tools/verify-refactor-boundaries.ps1`（Windows / PowerShell 7）与 `tools/verify-refactor-boundaries.sh`（Linux / Bash）：当前架构边界的等价可执行门禁。
 
 源码与当前可重跑结果优先于历史说明。职责发生变化时，同一提交更新 `docs/ARCHITECTURE.md`、相关 skill 和结构门禁，避免多份地图继续漂移。
@@ -187,6 +188,8 @@ Windows `.ps1` 与 Linux `.sh` 都是受维护的平台原生入口：PowerShell
 
 - 改动职责边界：更新 `docs/ARCHITECTURE.md`、相关 skill、结构门禁及必要的重构路线/核验记录。
 - 改动语义、搜索、性能、UI 或测试方式：更新 `docs/DEVELOPMENT_NOTES.md` 与 `docs/TEST_MATRIX.md`；需要进入覆盖目录时同步结构化证据。
+- 改动任何第三方登记点：在同一提交更新 `docs/THIRD_PARTY_ADAPTERS.md`。登记点指外部 Mod 能写入的入口——镜像注册表、`StrategicEffectMirrors` 这类按类型登记的表、订阅者门禁，以及手册第 6 节列出的封闭开关。新增登记入口要写进第 2 节并从第 6 节移除对应行；改动既有入口的签名、语义或登记时机要更新对应章节；发现新的封闭开关要补进第 6 节。登记点有专属子文档时（例如 `docs/third-party-strategic-effects.md`）一并更新，手册只保留概述和链接。
+- 功能修复顺带暴露出手册没讲清的行为时，把它补进手册，不要只写进开发笔记——手册是外部作者唯一会读的那份。
 - 面向玩家的更新日志和开发文档使用当前支持游戏版本的官方中文译名；名称从游戏内本地化或实机路线日志核对，不沿用玩家口语、旧译名或自行翻译。原始问题摘录保持用户原文，并明确标记为原始描述。
 - 用户声明“这一批不发版”“直到我说发版都记入 `X`”或等价要求时，建立活动发布批次。批次内每项改动均写入 `X（开发中）` 并正常提交，不逐项提升版本、构建、打包、创建标签或上传；直到用户明确结束批次。该批次声明优先于“修复后默认最小发包”。
 - 版本创建标签或成功上传创意工坊后即冻结。后续行为改动进入新的“下一版本（开发中）”记录，不追加到已发布版本的更新日志或开发章节；用户尚未指定新版本号时不擅自编造，等下次版本指令再统一命名。

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -167,6 +167,9 @@ Smart 层间使用 `SmartLayerMemoryForecast` 的同窗分配和转移高水位�
 
 ### 4.2 Mirror
 
+> 面向外部 Mod 作者的登记点总表、登记纪律与验收标准见
+> [第三方 Mod 适配手册](THIRD_PARTY_ADAPTERS.md)。
+
 `src/Engine/InCombat/Mirrors/` 精确实现原版 Hook、卡牌、药水、附魔和球方法。Facade 保持原版调用时序，registry 按运行时类型与方法分派。
 
 苦无、手里剑和彩虹戒指的属性施加在各自 `AfterCardPlayed` 镜像内完成：在原版 `IsInProgress` 门内更新计数，按每次 `PowerCmd.Apply` 的 `IsEnding` 门决定是否施加，不能延到其他监听器之后。彩虹戒指的领域生命周期仅同步既有激活投影，不再施加属性；末击不会提前中断整组监听器。

--- a/docs/THIRD_PARTY_ADAPTERS.md
+++ b/docs/THIRD_PARTY_ADAPTERS.md
@@ -1,0 +1,234 @@
+# 第三方 Mod 适配手册
+
+写给想让战斗路线求解器看懂自家 Mod 的作者。
+
+求解器不认识任何第三方内容。它靠一套**镜像**（mirror）在自己的模拟里重现游戏行为，而镜像是
+按类型登记的。你的牌、Power、遗物、药水没有登记，求解器就只能退化处理，路线会算错。
+
+这份文档讲：默认会发生什么、有哪些登记点、登记的纪律、怎么验证自己做对了。
+
+## 0. 先判断你要不要读下去
+
+| 你的 Mod | 要做什么 |
+|---|---|
+| 清单里 `affects_gameplay: false`（纯美术、UI、音效） | **什么都不用做**，自动放行 |
+| 只改地图、进幕、事件、休息处、商店这类战斗外内容 | **什么都不用做**，求解器会判定它对战斗惰性 |
+| 加了牌、Power、遗物、药水、敌人，或改了战斗数值 | 往下读 |
+
+前两条是自动的。第三条不做适配的话，装上你的 Mod 之后求解器会直接停在
+「检测到不兼容的第三方 Mod」，玩家用不了。
+
+## 1. 求解器默认怎么对待未知内容
+
+### 1.1 门禁：先让 Mod 进得来
+
+求解器扫描所有 ModHelper 战斗 hook 订阅者。放行有三条路：
+
+1. 清单 `affects_gameplay: false`；
+2. `PredictionModHookSubscriberInertness.IsCombatInert` 判定为战斗惰性——只重写了战斗外的
+   hook，或者只重写了战斗开始 / 战斗结束 hook（前者的效果已经落在被捕获的根状态里，后者在
+   胜负判定之后才分发，求解器搜到战斗结束就停）；
+3. 在 `PredictionModHookSubscriberCapture.KnownPreRootSubscriberTypeNames` 白名单里。
+
+三条都不满足就抛 `IncompatibleGameplayModException`，整个求解器停摆。
+
+> **当前限制。** 第 3 条那份白名单是私有静态集合，没有公开登记入口。目前只能靠 publicizer
+> 写进去。这是明确要补的扩展点之一，见第 6 节。
+
+### 1.2 镜像：进来之后每个类型的五种下场
+
+每个被镜像的虚方法都有一张按**精确运行时类型**索引的注册表。查一个类型会得到五种结果之一
+（`MirrorDispatchKind`）：
+
+| 结果 | 含义 | 后果 |
+|---|---|---|
+| `NotOverridden` | 这个类型没有重写该方法 | 走基类行为，**正确**，不用管 |
+| `Handled` | 有登记的镜像 | **正确**，这是你要达到的状态 |
+| `Inferred` | 没登记，但结构上能推断出一个尽力而为的实现 | 可能对，求解器**记一条风险** |
+| `Ignored` | 人工复核过，确认对预测无影响 | 正确，静默 |
+| `Unsupported` | 有重写但没有安全的预测实现 | 求解器**记一条风险** |
+
+**风险不是静默错误。** 求解器会在路线上打红字标明「这里有未镜像的效果」，玩家看得见，日志里
+也有 `COVERAGE source=... method=... reason=...`。但红字**只是显示**——它不会把不可能的续接从
+搜索里去掉。凡是会改变「接下来还能做什么」的效果（强制结束回合、额外回合、让某张牌打不出），
+必须真的建模，只记风险不够。
+
+### 1.3 只读 hook 会自动回落
+
+`Modify*` / `Should*` 这类只读 hook，求解器在无法镜像时会回落到你自己的实现，本来就正确。
+姿态的伤害倍率、费用修改这类就在其中，一般不需要登记。
+
+## 2. 登记点总表
+
+### 2.1 统一形状的镜像注册表（44 张）
+
+绝大多数登记走同一个形状：
+
+```csharp
+XxxMirrors.Registry.Register<TYourType>(handler);
+```
+
+44 张注册表按域分布在 `src/Engine/InCombat/Mirrors/` 下：
+
+| 目录 | 注册表数 | 覆盖什么 | 你多半要用的 |
+|---|---|---|---|
+| `Hooks/` | 37 | 战斗 hook：攻击、格挡、伤害、死亡、卡牌、球体、回合边界 | 按你重写了哪个 hook 挑，例如 `AfterDamageGivenMirrors` |
+| `Cards/` | 4 | 出牌、可打出性、回合结束留手、结算落点 | `CardOnPlayMirrors`、`CardIsPlayableMirrors` |
+| `Potions/` | 1 | 药水使用 | `PotionOnUseMirrors` |
+| `Enchantments/`、`Afflictions/` | 各 1 | 附魔与病症的出牌效果 | 少见 |
+
+**注意目录里的文件数比注册表多。** `Cards/` 下有十几个 `*Mirrors.cs`，但注册表只有 4 张——
+`BespokeCardMirrors`、`CardGenerationCardMirrors` 这些是**处理器文件**，它们往
+`CardOnPlayMirrors.Registry` 这张共享注册表里登记，自己不持有注册表。找登记入口时认
+`static readonly Registry Registry` 这个字段，不要认文件名。
+
+**怎么知道自己要登记哪几个。** 把你的每个类型对基类虚方法的重写列出来，和这 44 张表逐一对照。
+只重写了求解器不分发的方法，不用登记；重写了它分发的方法，就要登记。这一步不要靠印象，
+要交叉核对——漏一个的表现是「效果看起来正常但其实没发生」。
+
+同一张表里 `Register` 用的是 `Dictionary.Add`，**重复登记会抛异常**，不会静默覆盖。
+
+### 2.2 战略估值：会改变出牌顺序的 Power
+
+```csharp
+StrategicEffectMirrors.Register<TYourPower>(requirements, evaluate, host);
+```
+
+只有当你的 Power **收益取决于它和别的动作的先后关系**时才需要。详见
+[第三方 Power 的战略估值登记](third-party-strategic-effects.md)。
+
+不登记的后果：求解器按叠加层数记一点 `ScalingPotential` 兜底。对大多数 Power 够用；对
+「自己不给甲、但让后续攻击给甲」这类会被排到错误位置。
+
+### 2.3 还没有登记入口的地方
+
+见第 6 节。目前只能 Harmony 打补丁，或者等对应的扩展点合并。
+
+## 3. 登记的纪律
+
+这几条不是风格建议，是踩过的坑。
+
+### 3.1 加载时一次性登记完
+
+注册表**按精确运行时类型缓存查询结果，而且 `Register` 不会让缓存失效**。一旦某个类型被查过
+一次（拿到 `Inferred` 或 `Unsupported`），之后再登记也不会生效，而且不报错。
+
+所以：在 Mod 初始化时把所有登记做完，绝不在战斗中途登记。
+
+### 3.2 失败要关死，不要装一半
+
+自检不通过时**一个镜像都不要登记**。装一半比不装更糟：求解器会拿着一部分正确的镜像给出看起来
+可信的路线，缺掉的那部分静默变成空操作。全都不装的话，求解器会明确停在门禁上并显示原因，
+玩家至少知道出了事。
+
+同理，解析不到 Harmony 目标方法就抛异常让整层注册失败，不要跳过继续。
+
+### 3.3 按反编译出来的实现写，不要照卡面文字猜
+
+卡面文字和实现经常不一致：触发时机、目标选择、数值来源、结算顺序。逐条对照反编译源码写，
+一张牌一个方法、一行一效果、按原版的调用顺序排列，这样可以逐行复核。
+
+典型的坑：变量键名。`PowerVar<T>` 单参数构造生成的键是 `typeof(T).Name`（例如
+`VulnerablePower`），不是卡面上显示的那个词。写错会让整次搜索失败。
+
+### 3.4 钉死你依赖的版本，并在运行期自检
+
+求解器的内部接口会变。适配层应当：
+
+- 构建期引用确定版本；
+- 运行期核对自己用到的那几个方法签名和字段还在不在，不在就干净地拒绝加载。
+
+同理，如果你在适配**别人的** Mod，按文件哈希钉死比按版本号更稳——作者不一定每次改动都升版本
+号，而一个没升版本号的签名改动会让某张牌变成「没有效果但看起来正常」。
+
+### 3.5 时机比数值更容易错
+
+抽牌发生在触发它的那张牌离开出牌堆之前还是之后、Power 在这张牌自己结算之前还是之后到位、
+「上一张牌」是本回合的还是整场的——这些一错，数值全对但结果不对。写注释说明你选的时机和依据。
+
+## 4. 怎么验证自己做对了
+
+### 4.1 两条验收标准
+
+**不要用胜率或手感做验收。** 镜像低估自己的伤害会让求解器打得保守，于是活得久——这种路线能
+通过手感检验，通不过严格 diff。
+
+标准是：
+
+1. **严格 diff 零差异**：模拟的终局状态和真实终局状态逐字段相等。
+2. **`PredictionGaps` 里非补偿项为空**：求解器自己不报告任何未镜像效果。
+
+胜率是在这两条都干净**之后**才有意义的指标，用来抓 diff 抓不到的东西，比如某个 Power 在估值
+函数里定价错了。反过来先看胜率，会让你在错误的地方停下来。
+
+### 4.2 夹具要能自己验算，而且要有反向对照
+
+好夹具的判据落在能用算术自己验的量上——能量够不够打第二张牌、格挡数值、正好击杀的回合数——
+而不是「跑起来不报错」。
+
+**每条夹具都要做一次反向对照**：把你要验的那行登记注释掉重新构建，夹具必须不过；加回来必须
+过。没做过反向对照的夹具证明不了任何事。
+
+无头夹具的跑法见 [HEADLESS_TESTING.md](HEADLESS_TESTING.md)。
+
+### 4.3 用玩家的问题包，不要只看描述
+
+求解器自带问题包导出，里面有完整路线、逐检查点状态、日志和一份自动分类（例如
+`BetterWorldline 预计战损 11 → 0` 就是「玩家手打比求解器的路线好，好 11 点血」）。
+带问题包基本都能定位；只有文字描述通常不够。
+
+## 5. 一个完整例子
+
+观者 Mod 的「以手拒之」：打出后给目标挂一层反弹格挡，之后玩家每打中这个敌人一段就起
+`Amount` 点甲。
+
+**症状。** 手里以手拒之 + 两张打击，敌人这回合打 4 点。求解器给的顺序是
+「打击 打击 以手拒之」，第 1 回合 `max_block=0`，白挨 4 点。第 2、3、4 回合都是
+`max_block=4 actual_block=4`——层数一旦挂上去后面每回合都算得对，唯独挂上去的那一回合被浪费。
+
+**排查。** 先确认镜像本身对不对：反弹格挡的钩子分发和逐条判定（目标判定、施加者判定、
+`IsPoweredAttack`、`TotalDamage > 0`、受益者三级回退、`Unpowered` 不吃敏捷、不自减）都和反编译
+出来的实现核对过，两条夹具锁住了这一半。**镜像是对的，坏的是排序。**
+
+**根因。** `ClassifyActionOptionFamilies` 判一个动作算不算 `ImmediateDefense`，看四样：这次动作
+的格挡增量、`ProjectedPlayerHp`、`PlayerHp`、`StrategicEffects.PreventionPotential`。以手拒之
+打出的瞬间这四样一样都不动——它自己不给甲，而反弹格挡这层 Power 挂在**敌人身上**，设置估值那圈
+原本只统计玩家自己身上的增益。于是它被归成一张纯 `ImmediateOffense`，和打击同族但伤害更低，
+在族内代表里被打击压掉。
+
+**修法。** 用 `StrategicEffectMirrors.Register<BlockReturnPower>(..., StrategicEffectHost.Enemy)`
+登记估值。登记之后打出它会让 `PreventionPotential` 从 0 变正，于是它同时进 `ImmediateDefense`
+族，不再被压掉。
+
+**验证。** 夹具 `WATCHER-TALK-TO-THE-HAND-ORDERING`：以手拒之加两张打击、3 能量，判
+`max_block >= 4`（以手拒之给 2 层，两张打击各 1 段，排最前面 = 4 甲，排中间 = 2，排最后 = 0）。
+做过反向对照：注释掉那行登记，夹具不过。
+
+**这个例子的一般教训**：现象是「AI 不会用这张牌」，根因既不在这张牌的镜像里，也不在搜索深度或
+估值权重上，而在动作分类那一层。排查顺序应当是：先确认镜像对不对，再看它有没有被搜索看见，
+最后才怀疑估值。
+
+## 6. 已知的封闭开关
+
+下面这些位置目前是按原版类型写死的开关，第三方登记不进去。要用只能 Harmony 打补丁，或者等
+对应扩展点合并。列在这里是为了让你知道撞上了什么，而不是以为自己写错了。
+
+| 位置 | 症状 | 状态 |
+|---|---|---|
+| `PredictionModHookSubscriberCapture.KnownPreRootSubscriberTypeNames` | 私有静态白名单，没有公开登记入口 | 待做 |
+| `PotionChoiceSupport.RequiresChoice` / `GetSpec` / `Apply` | 第三方药水的玩家选择永远不会被展开成搜索分支；`RequiresChoice` 对第三方类型恒为 `false` | 待做 |
+| `CardChoiceSupport` 的选牌规格 | 第三方卡牌的选牌效果同上 | 待做 |
+| `CorePowerSupport.TriggerPlayerSideTurnEndEffects`、`FlushPlayerHandAtTurnEnd`、`TurnStartPowerSupport.TriggerAfterPlayerTurnStart`、`SimulatedCombatState.TriggerRelicsAfterPlayerTurnStart` | 回合边界的效果没有注册表 | 待做 |
+| `SimulatedCombatState.TryPrepareExtraPlayerTurn` / `TryPrepareLiveExtraPlayerTurn` / `ConsumeExtraTurnSources` | 额外回合的来源硬编码，只认龙涎香和帕尔之眼 | 待做 |
+| `CombatPredictionSimulator.OnPlayWrapper` | 出牌后补抽没有挂载点 | 待做 |
+
+**这些开关新增或改动时，必须在同一个提交里更新这张表和本文档对应章节。** 见
+[AGENTS.md](../AGENTS.md) 第 9 节。
+
+## 7. 相关文档
+
+- [架构与职责地图](ARCHITECTURE.md)：源码入口和所有权，`§4.2 Mirror` 是镜像层的位置。
+- [战斗钩子覆盖目录](COMBAT_HOOK_COVERAGE.md)：求解器分发哪些 hook。
+- [第三方 Power 的战略估值登记](third-party-strategic-effects.md)。
+- [无头测试](HEADLESS_TESTING.md)：夹具怎么跑。
+- [检查点回放](CHECKPOINT_REPLAY.md)：问题包怎么导入。

--- a/docs/third-party-strategic-effects.md
+++ b/docs/third-party-strategic-effects.md
@@ -1,0 +1,100 @@
+# 第三方 Power 的战略估值登记
+
+## 这是给谁用的
+
+第三方 mod 加了一层 Power，而这层 Power 会改变**玩家该按什么顺序出牌**。
+
+不改变出牌顺序的 Power 不需要登记。求解器对未知 Power 类型有兜底：按叠加层数记一点
+`ScalingPotential`。它会让"打出这张 Power 牌"这个动作被归进 `PersistentSetup` 族、不至于
+被完全剪掉，对绝大多数 mod 内容够用。
+
+需要登记的是这一类：**这层 Power 的收益取决于它和别的动作的先后关系。**
+
+## 为什么兜底不够
+
+`CombatBeamSolver.ClassifyActionOptionFamilies` 给每个动作打族标签，同族里只留代表。判一个
+动作算不算 `ImmediateDefense`，看四样东西：
+
+```csharp
+if (block > 0
+    || after.ProjectedPlayerHp > before.ProjectedPlayerHp
+    || after.PlayerHp > before.PlayerHp
+    || after.StrategicEffects.PreventionPotential > before.StrategicEffects.PreventionPotential)
+```
+
+四样里唯一能被一层 Power 影响的是 `PreventionPotential`。一张"自己不给甲、但让后续攻击给甲"
+的牌，这四样一样都不动，于是被归成纯 `ImmediateOffense`，和攻击牌同族但伤害更低，在族内代表
+里被压掉，只能排到攻击后面——而它的收益恰恰依赖排在攻击前面。
+
+还有一层：`CombatBeamSolver.StateEvaluation` 那两圈设置估值原本写死了
+`ReferenceEquals(power.Owner, _player.Creature)`，也就是**只看玩家自己身上的增益**。挂在敌人
+身上、收益归玩家的 Power 连这一圈都进不来。
+
+## 怎么登记
+
+```csharp
+StrategicEffectMirrors.Register<MyPower>(
+    StrategicEffectRequirements.AttackPlays,
+    static (power, context) => StrategicEffectModel.Prevention(
+        Math.Max(1, power.Amount) * context.AttackPlays,
+        context),
+    StrategicEffectHost.Enemy);
+```
+
+三个参数：
+
+| 参数 | 说明 |
+|---|---|
+| `requirements` | 估值要读 `StrategicEffectContext` 的哪几项。只有被要求的项才会被算出来，没要求的留在便宜的默认值上。如实填：多填浪费，少填读到的是默认值而不是报错 |
+| `evaluate` | 由这一层 Power 得出一个 `StrategicEffectVector` |
+| `host` | 这层 Power 挂在谁身上 |
+
+`host` 两种：
+
+- `StrategicEffectHost.Player`（默认）——挂在玩家身上的增益，和原版一样的判定：层数为正、
+  当前层数下是 `PowerType.Buff`、不是 `ITemporaryPower`。
+- `StrategicEffectHost.Enemy`——挂在**敌人**身上但收益归玩家。判定换成：层数为正、不是
+  `ITemporaryPower`、宿主不是玩家。**不查增益/减益**，因为它在宿主眼里通常是减益，查了就
+  永远进不来。
+
+登记要在 mod 加载时做一次。登记表为空时两处热路径只多一次 `Count` 检查。
+
+## 估值往哪个方向偏
+
+用 `StrategicEffectModel` 的五个工厂方法构造向量，不要自己拼字段——它们各自带着上限逻辑，
+比如 `Prevention` 会把值夹在「这回合进来的伤害 × min(2, 剩余回合)」以内。
+
+| 工厂 | 落在哪一项 |
+|---|---|
+| `Damage(value, enemyHp)` | `DamagePotential`，上限是敌人当前生命 |
+| `Prevention(value, context)` | `PreventionPotential`，上限见上 |
+| `Resource(value)` | `ResourcePotential` |
+| `CardAccess(value)` | `CardAccessPotential` |
+| `Scaling(value)` | `ScalingPotential` |
+
+数值分两件事看，两件事对精度的要求差很多：
+
+- **准入**：`ClassifyActionOptionFamilies` 判的是**有没有变大**，只要非零就够。这一半只要求
+  你别把值算成 0。
+- **排名**：数值决定这条线在收益真正兑现之前能在 Beam 里活多久。估低了会把好线剪掉，估高了
+  只是多留几个节点。所以拿不准时**往高了估**，不要往低了估。
+
+## 一个真实例子
+
+观者 mod 的「以手拒之」：打出后给目标挂一层反弹格挡，之后玩家每打中这个敌人**一段**就起
+`Amount` 点甲，不自减，整场都在。
+
+实测没登记之前：手里以手拒之加两张打击、敌人这回合打 4 点，求解器给的顺序是
+「打击 打击 以手拒之」，第 1 回合 `max_block=0`，白挨 4 点；换成「以手拒之 打击 打击」本可以
+4 甲全挡掉。第 2、3、4 回合都是 `max_block=4 actual_block=4`——层数一旦挂上去，后面每回合都
+算得对，唯独挂上去的那一回合被浪费。
+
+登记以后，打出以手拒之这个动作会让 `PreventionPotential` 从 0 变正，于是它同时进
+`ImmediateDefense` 族，不再被打击在同族里压掉。
+
+估值取「层数 × 可打出的攻击牌张数」。按张不按段是低估——反弹格挡是按伤害段数触发的
+（`CombatPredictionSimulator.Attack` 是 `for (i < hitCount) { Damage(...) }`，每段各产生一个
+`DamageResult`、各分发一次 `AfterDamageGiven`），而 `StrategicEffectRequirements.AttackPlays`
+数的是 `liveCards` 里 `Type == Attack` 的张数。求解器现成的量里没有按段计数，`CardValue` 也
+只读 `Damage` 基础值。低估在这里可以接受，因为准入那一半不受影响，而排名那一半有 `Prevention`
+的上限兜着：对任何有威胁的局面，层数 × 张数早就顶到上限了。

--- a/src/Search/CombatBeamSolver.StateEvaluation.cs
+++ b/src/Search/CombatBeamSolver.StateEvaluation.cs
@@ -207,13 +207,8 @@ internal sealed partial class CombatBeamSolver
         for (int powerIndex = 0; powerIndex < effectivePowers.Count; powerIndex++)
         {
             PowerModel power = effectivePowers[powerIndex];
-            if (!ReferenceEquals(power.Owner, _player.Creature)
-                || power.Amount <= 0
-                || power.TypeForCurrentAmount != PowerType.Buff
-                || power is ITemporaryPower)
-            {
+            if (!StrategicEffectMirrors.Contributes(power, _player.Creature))
                 continue;
-            }
             strategicRequirements |= StrategicEffectModel.Requirements(power);
         }
         StrategicEffectContext? strategicContext = null;
@@ -223,13 +218,8 @@ internal sealed partial class CombatBeamSolver
         for (int powerIndex = 0; powerIndex < effectivePowers.Count; powerIndex++)
         {
             PowerModel power = effectivePowers[powerIndex];
-            if (!ReferenceEquals(power.Owner, _player.Creature)
-                || power.Amount <= 0
-                || power.TypeForCurrentAmount != PowerType.Buff
-                || power is ITemporaryPower)
-            {
+            if (!StrategicEffectMirrors.Contributes(power, _player.Creature))
                 continue;
-            }
             strategicContext ??= StrategicEffectContext.Build(
                 liveCards,
                 enemyHp,

--- a/src/Search/StrategicEffectMirrors.cs
+++ b/src/Search/StrategicEffectMirrors.cs
@@ -1,0 +1,125 @@
+using MegaCrit.Sts2.Core.Entities.Creatures;
+using MegaCrit.Sts2.Core.Entities.Powers;
+using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Models.Powers;
+
+namespace CombatSolver;
+
+/// <summary>
+/// 一个被登记的战略效果挂在谁身上。
+///
+/// 绝大多数增益挂在玩家身上，收益也归玩家，那是 <see cref="Player"/>。少数效果挂在**敌人**
+/// 身上而收益归玩家——观者的以手拒之就是这样：反弹格挡这层 Power 施加在敌人身上，玩家每打中
+/// 它一次就起一次甲。这类效果在"只看玩家身上的增益"那一圈里会被整个跳过，所以需要单独说明。
+/// </summary>
+internal enum StrategicEffectHost
+{
+    /// <summary>挂在玩家身上，并且是增益（<see cref="PowerType.Buff"/>）。</summary>
+    Player,
+
+    /// <summary>挂在敌人身上，收益归玩家。不检查增益/减益——它在宿主眼里通常是减益。</summary>
+    Enemy,
+}
+
+/// <summary>
+/// 第三方 Power 的战略估值登记表。
+///
+/// <see cref="StrategicEffectModel"/> 的 <c>Requirements</c> 和 <c>Evaluate</c> 是按原版 Power
+/// 类型写死的 <c>switch</c>，第三方类型全部落进默认分支、按叠加层数记一点 Scaling。对大多数
+/// mod 的 Power 来说这个兜底够用，但对"改变玩家该按什么顺序出牌"的效果不够：
+/// <c>ClassifyActionOptionFamilies</c> 判一张牌算不算 <c>ImmediateDefense</c>，四个判据里唯一
+/// 能被 Power 影响的就是 <c>StrategicEffects.PreventionPotential</c>。这一项不动，一张自己不
+/// 给甲的防御牌会被归成纯进攻牌，在族内代表里被伤害更高的攻击牌压掉，只能排到攻击后面——
+/// 而它的收益恰恰依赖排在攻击前面。
+///
+/// 所以这里开一个登记点。登记之后：
+/// <list type="bullet">
+/// <item>估值走登记的委托，不再落默认分支；</item>
+/// <item><see cref="StrategicEffectHost.Enemy"/> 的类型会被"只看玩家身上的增益"那一圈放行。</item>
+/// </list>
+///
+/// 求解器本身不认识任何第三方类型，登记由 mod 在加载时自己做。
+/// </summary>
+internal static class StrategicEffectMirrors
+{
+    private readonly record struct Entry(
+        StrategicEffectRequirements Requirements,
+        Func<PowerModel, StrategicEffectContext, StrategicEffectVector> Evaluate,
+        StrategicEffectHost Host);
+
+    private static readonly Dictionary<Type, Entry> Registry = [];
+
+    /// <summary>
+    /// 为一个 Power 类型登记战略估值。
+    /// </summary>
+    /// <param name="requirements">
+    /// 估值要读 <see cref="StrategicEffectContext"/> 的哪几项。只有被要求的项才会被算出来，
+    /// 没要求的留在便宜的默认值上，所以这里要如实填，多填浪费、少填读到的是默认值。
+    /// </param>
+    /// <param name="evaluate">
+    /// 由这一层 Power 得出一个 <see cref="StrategicEffectVector"/>。用
+    /// <c>StrategicEffectVector.Prevention</c> 这一组工厂方法构造，不要自己拼字段——
+    /// 那几个方法带着各自的上限逻辑。
+    /// </param>
+    /// <param name="host">这层 Power 挂在谁身上，见 <see cref="StrategicEffectHost"/>。</param>
+    public static void Register<TPower>(
+        StrategicEffectRequirements requirements,
+        Func<PowerModel, StrategicEffectContext, StrategicEffectVector> evaluate,
+        StrategicEffectHost host = StrategicEffectHost.Player)
+        where TPower : PowerModel
+    {
+        ArgumentNullException.ThrowIfNull(evaluate);
+        Registry[typeof(TPower)] = new Entry(requirements, evaluate, host);
+    }
+
+    /// <summary>登记表是否为空。空表时两处热路径可以整段跳过字典查找。</summary>
+    public static bool IsEmpty => Registry.Count == 0;
+
+    /// <summary>
+    /// 这层 Power 该不该进战略估值。
+    ///
+    /// 原版规则：挂在玩家身上、层数为正、当前层数下是增益、不是临时 Power。
+    /// 登记为 <see cref="StrategicEffectHost.Enemy"/> 的类型换一套：挂在**别人**身上、层数为正、
+    /// 不是临时 Power。不查增益/减益——它在敌人眼里是减益，查了就永远进不来。
+    /// </summary>
+    public static bool Contributes(PowerModel power, Creature playerCreature)
+    {
+        if (power.Amount <= 0 || power is ITemporaryPower)
+            return false;
+        bool onPlayer = ReferenceEquals(power.Owner, playerCreature);
+        if (Registry.Count > 0
+            && Registry.TryGetValue(power.GetType(), out Entry entry)
+            && entry.Host == StrategicEffectHost.Enemy)
+        {
+            return !onPlayer;
+        }
+        return onPlayer && power.TypeForCurrentAmount == PowerType.Buff;
+    }
+
+    public static bool TryGetRequirements(
+        PowerModel power,
+        out StrategicEffectRequirements requirements)
+    {
+        if (Registry.Count > 0 && Registry.TryGetValue(power.GetType(), out Entry entry))
+        {
+            requirements = entry.Requirements;
+            return true;
+        }
+        requirements = StrategicEffectRequirements.None;
+        return false;
+    }
+
+    public static bool TryEvaluate(
+        PowerModel power,
+        StrategicEffectContext context,
+        out StrategicEffectVector effect)
+    {
+        if (Registry.Count > 0 && Registry.TryGetValue(power.GetType(), out Entry entry))
+        {
+            effect = entry.Evaluate(power, context);
+            return true;
+        }
+        effect = StrategicEffectVector.Zero;
+        return false;
+    }
+}

--- a/src/Search/StrategicEffectModel.cs
+++ b/src/Search/StrategicEffectModel.cs
@@ -339,7 +339,11 @@ internal readonly record struct StrategicEffectContext(
 internal static class StrategicEffectModel
 {
     public static StrategicEffectRequirements Requirements(PowerModel power)
-        => power switch
+    {
+        // 第三方登记优先。登记表为空时这是一次字典 Count 检查，热路径上可以忽略。
+        if (StrategicEffectMirrors.TryGetRequirements(power, out StrategicEffectRequirements registered))
+            return registered;
+        return power switch
         {
             AfterimagePower => StrategicEffectRequirements.UsefulCardPlays,
             BufferPower => StrategicEffectRequirements.RemainingTurns,
@@ -369,11 +373,14 @@ internal static class StrategicEffectModel
                 => StrategicEffectRequirements.RemainingTurns,
             _ => StrategicEffectRequirements.None,
         };
+    }
 
     public static StrategicEffectVector Evaluate(
         PowerModel power,
         StrategicEffectContext context)
     {
+        if (StrategicEffectMirrors.TryEvaluate(power, context, out StrategicEffectVector registered))
+            return registered;
         int amount = Math.Max(1, power.Amount);
         int enemyHp = context.EnemyHp;
         int energyUnit = Math.Max(3, context.AverageCardValue);
@@ -425,10 +432,10 @@ internal static class StrategicEffectModel
         };
     }
 
-    private static StrategicEffectVector Damage(int value, int enemyHp)
+    public static StrategicEffectVector Damage(int value, int enemyHp)
         => new(Math.Min(Math.Max(0, enemyHp), Math.Max(0, value)), 0, 0, 0, 0);
 
-    private static StrategicEffectVector Prevention(int value, StrategicEffectContext context)
+    public static StrategicEffectVector Prevention(int value, StrategicEffectContext context)
     {
         int cap = context.IncomingDamage == 0
             ? value
@@ -446,12 +453,12 @@ internal static class StrategicEffectModel
         return Math.Min(context.IncomingDamage, amount * averageHit);
     }
 
-    private static StrategicEffectVector Resource(int value)
+    public static StrategicEffectVector Resource(int value)
         => new(0, 0, Math.Max(0, value), 0, 0);
 
-    private static StrategicEffectVector CardAccess(int value)
+    public static StrategicEffectVector CardAccess(int value)
         => new(0, 0, 0, Math.Max(0, value), 0);
 
-    private static StrategicEffectVector Scaling(int value)
+    public static StrategicEffectVector Scaling(int value)
         => new(0, 0, 0, 0, Math.Max(0, value));
 }


### PR DESCRIPTION
## 这是什么

新增 `docs/THIRD_PARTY_ADAPTERS.md`，写给想给第三方 Mod 做适配层的人。**纯文档，不动任何代码。**

七节：

0. 先判断要不要读下去（不改 gameplay 的 Mod 不用适配）
1. 求解器默认怎么对待不认识的内容 —— 关键是它不会静默算错，会记未镜像效果
2. 全部登记点清单：44 个注册表（Hooks 37、Cards 4、Potions 1、附魔 1、异常 1），按用途分组
3. 登记纪律：`Register<T>` 用 `Dictionary.Add`，重复登记直接抛；而且它**不会让查找缓存失效**，所以某个类型一旦被查过一次，之后再登记会静默不生效 —— 必须在 Entry 里一次登记完
4. 怎么验收：严格 diff 零差异 + 未镜像效果为空，别用胜率
5. 一个完整的实例：以手拒之的排序问题从现象到定位到修法
6. 已知的封闭开关清单 —— 现在还登记不进去的地方，给后来人省排查时间
7. 相关文档

同时：

- `AGENTS.md` 第 3 节把手册列进事实来源，第 9 节加了同步规则：改动任何第三方登记点，要在同一个提交里更新手册；新增入口写进第 2 节并从第 6 节移除；发现新的封闭开关补进第 6 节。功能修复顺带暴露出手册没讲清的行为，也补进手册而不是只写进开发笔记 —— 手册是外部作者唯一会读的那份。
- `docs/ARCHITECTURE.md` 的 Mirror 那节加了交叉链接。

## 几个写的时候查清楚的事实

- **44 个注册表，不是 48。** 48 是「引用了 `MethodMirrorRegistry<` 的文件数」，其中不少 `*Mirrors.cs` 是往同一个注册表里登记的 handler 文件。判断入口要看有没有 `static readonly Registry Registry` 字段，不能看文件名。这一条也写进手册了，因为按文件名数是很自然的错法。
- `MirrorDispatchKind` 五个取值的语义差别（NotOverridden / Handled / Inferred / Ignored / Unsupported），特别是 Inferred 和 Ignored 什么时候该用。

## 依赖

建立在 #51 之上（手册第 2 节和第 5 节要引用那条加的 `StrategicEffectMirrors`）。#51 合并之后这条的 diff 就只剩上面那三个文件。
