### PR TITLE
[观者适配] 给第三方卡牌的玩家选择开一个登记点：许愿的三选一现在是真分支

### DIFF
--- a/docs/THIRD_PARTY_ADAPTERS.md
+++ b/docs/THIRD_PARTY_ADAPTERS.md
@@ -149,7 +149,40 @@ PotionChoiceMirrors.Register<TYourPotion>(spec, apply);
 减去被弃牌牌值，并加上弃牌触发收益。`maxBranches` 对排序后的候选设置保留上限，省略时沿用
 现有枚举策略；传 `1` 只保留排序第一项，会牺牲其他选择路线，适配者应使用目标场景验证取舍。
 
-### 2.5 还没有登记入口的地方
+### 2.5 卡牌的玩家选择
+
+```csharp
+CardChoiceMirrors.Register<TYourCard>(spec, apply);
+```
+
+和药水那条是同一堵墙的两面。`CardChoiceSupport.GetSpec` 是按原版卡牌类型写死的 `switch`，
+默认分支返回 `null`，也就是「这张牌没有选择」。第三方卡牌落到那里就是这个答案，于是它的选牌
+效果**永远不会被展开成搜索分支**：牌照样打得出去，效果在模拟里静默变成空操作。卡牌自己的
+`CardOnPlayMirrors` 补不了这个——选择的展开发生在出牌路径上，不在效果镜像里。
+
+两个委托：
+
+- `spec(simulator, playedCard, card)` 返回一个 `CardChoiceSpec`。
+- `apply(simulator, combat, playedCard, card, choice)` 施加效果，返回是否已经结算完。
+
+比药水那条多两件要注意的事：
+
+1. **升级等级必须对。** 部署时按 CardId 加升级等级在原生页面上定位选项。三选一这类牌通常会让
+   三张选项跟着本牌一起升级，`spec` 里就要把选项牌也升级，否则部署定位不到。
+2. **选项牌不在任何模拟牌堆里。** 所以 `apply` 拿到的是计划里的 `PlanCardToken`，不是
+   `PredictedCard`；按 CardId 自己认，求解器不会替你解析。数值要读就从选项牌自己的
+   `DynamicVars` 上读，不要写死。
+
+效果同样用 `PlanChoiceEffect.ModDefined`。求解器自己从不产生这个值；如果它出现在卡牌选牌上
+而没有登记方认领，结算会直接抛，不会静默空操作。
+
+**一个真实例子。** 观者的许愿是 3 费，打出后在「力量 +3」「多层护甲 6」「金币 25」之间三选一
+（升级后 4 / 8 / 30，三张选项牌各自的 `MagicNumber` 就是这三个数）。三个选项的单位完全不同，
+但都不需要新的估值刻度：力量和多层护甲本来就是 Power，金币走求解器现成的长期资源刻度
+（`GainPlayerGold` 加 `RecordLongTermResource`，`贪婪之手` 就是面值直记）。登记成三个真分支之后，
+「值不值这 3 点能量」和「三个里挑哪个」都由搜索自己比出来，不需要写任何策略规则。
+
+### 2.6 还没有登记入口的地方
 
 见第 6 节。目前只能 Harmony 打补丁，或者等对应的扩展点合并。
 
@@ -265,7 +298,6 @@ PotionChoiceMirrors.Register<TYourPotion>(spec, apply);
 | 位置 | 症状 | 状态 |
 |---|---|---|
 | `PredictionModHookSubscriberCapture.KnownPreRootSubscriberTypeNames` | 私有静态白名单，没有公开登记入口 | 待做 |
-| `CardChoiceSupport` 的选牌规格 | 第三方**卡牌**的选牌效果不会被展开成搜索分支。药水那条已经有入口了（见 2.3），卡牌这条还没有 | 待做 |
 | `CorePowerSupport.TriggerPlayerSideTurnEndEffects`、`FlushPlayerHandAtTurnEnd`、`TurnStartPowerSupport.TriggerAfterPlayerTurnStart`、`SimulatedCombatState.TriggerRelicsAfterPlayerTurnStart` | 回合边界的效果没有注册表 | 待做 |
 | `SimulatedCombatState.TryPrepareExtraPlayerTurn` / `TryPrepareLiveExtraPlayerTurn` / `ConsumeExtraTurnSources` | 额外回合的来源硬编码，只认龙涎香和帕尔之眼 | 待做 |
 | `CombatPredictionSimulator.OnPlayWrapper` | 出牌后补抽没有挂载点 | 待做 |

--- a/src/Search/CardChoiceMirrors.cs
+++ b/src/Search/CardChoiceMirrors.cs
@@ -1,0 +1,93 @@
+using MegaCrit.Sts2.Core.Models;
+using CombatSolver.Engine.Common;
+using CombatSolver.Engine.InCombat.Simulation;
+
+namespace CombatSolver;
+
+/// <summary>
+/// 第三方卡牌的玩家选择登记表。
+/// </summary>
+/// <remarks>
+/// <see cref="CardChoiceSupport.GetSpec"/> 是按原版卡牌类型写死的 <c>switch</c>，默认分支返回
+/// <c>null</c>——也就是"这张牌没有选择"。第三方卡牌落到那里就是这个答案，于是它的选牌效果
+/// 永远不会被展开成搜索分支：牌照样打得出去，效果在模拟里静默变成空操作。卡牌自己的
+/// <c>CardOnPlayMirrors</c> 补不了这个，因为选择的展开发生在出牌路径上、不在效果镜像里。
+///
+/// 登记之后，第三方卡牌和原版带选牌的卡牌走同一条通道：出牌时求解器照常调
+/// <c>ResolveManualCardChoice</c>，拿到登记的 <see cref="CardChoiceSpec"/> 展开分支，选中的结果
+/// 记进计划，部署时照常应答原生选牌页面，而效果由登记方自己的 <c>apply</c> 施加——求解器不需要
+/// 认识任何第三方效果。
+///
+/// 选项牌用 <see cref="PlanChoiceEffect.ModDefined"/>，和药水那条
+/// （<see cref="PotionChoiceMirrors"/>）同一个约定。
+/// </remarks>
+internal static class CardChoiceMirrors
+{
+    private readonly record struct Entry(
+        Func<CombatPredictionSimulator, PredictedCard, CardChoiceSpec> Spec,
+        Func<CombatPredictionSimulator, SimulatedCombatState, PredictedCard, PlanCardChoice, bool> Apply);
+
+    private static readonly Dictionary<Type, Entry> Registry = [];
+
+    /// <summary>
+    /// 为一个卡牌类型登记玩家选择。
+    /// </summary>
+    /// <param name="spec">
+    /// 给出这次选择的候选与上下界。候选必须是玩家在原生页面上真正看到的那几张，顺序也要一致，
+    /// 而且**升级等级要对**——部署时按 CardId 加升级等级在页面上定位，选项牌跟着源牌一起升级的
+    /// 效果（例如三选一的三张选项都随本牌升级）必须在这里如实反映出来，否则定位不到。
+    /// 下界给 0 表示"可以一张都不选"。
+    /// </param>
+    /// <param name="apply">
+    /// 按选中的结果在模拟里施加效果，返回是否已经结算完（还有嵌套选择挂起时返回 <c>false</c>，
+    /// 和原版同一口径）。选项牌不在任何模拟牌堆里，所以传进来的是计划里的令牌本身，
+    /// 由登记方按 CardId 自己认；求解器不会替你把令牌解析成牌。
+    /// </param>
+    public static void Register<TCard>(
+        Func<CombatPredictionSimulator, PredictedCard, TCard, CardChoiceSpec> spec,
+        Func<CombatPredictionSimulator, SimulatedCombatState, PredictedCard, TCard, PlanCardChoice, bool> apply)
+        where TCard : CardModel
+    {
+        ArgumentNullException.ThrowIfNull(spec);
+        ArgumentNullException.ThrowIfNull(apply);
+        // 和镜像注册表同一口径：重复登记是错误，不静默覆盖。
+        Registry.Add(
+            typeof(TCard),
+            new Entry(
+                (simulator, playedCard) => spec(simulator, playedCard, (TCard)playedCard.Preview),
+                (simulator, combat, playedCard, choice) =>
+                    apply(simulator, combat, playedCard, (TCard)playedCard.Preview, choice)));
+    }
+
+    public static bool TryGetSpec(
+        CombatPredictionSimulator simulator,
+        PredictedCard playedCard,
+        out CardChoiceSpec spec)
+    {
+        if (Registry.Count > 0
+            && Registry.TryGetValue(playedCard.Preview.GetType(), out Entry entry))
+        {
+            spec = entry.Spec(simulator, playedCard);
+            return true;
+        }
+        spec = null!;
+        return false;
+    }
+
+    public static bool TryApply(
+        CombatPredictionSimulator simulator,
+        SimulatedCombatState combat,
+        PredictedCard playedCard,
+        PlanCardChoice choice,
+        out bool completed)
+    {
+        if (Registry.Count > 0
+            && Registry.TryGetValue(playedCard.Preview.GetType(), out Entry entry))
+        {
+            completed = entry.Apply(simulator, combat, playedCard, choice);
+            return true;
+        }
+        completed = false;
+        return false;
+    }
+}

--- a/src/Search/CardChoiceResolution.cs
+++ b/src/Search/CardChoiceResolution.cs
@@ -20,7 +20,13 @@ internal static partial class CardChoiceSupport
     {
         SimPlayerCombatState owner = simulator.State.GetPlayerCombatState(playedCard.Preview.Owner);
         List<PredictedCard> selected;
-        if (choice.Effect == PlanChoiceEffect.GenerateToHand)
+        if (choice.Effect == PlanChoiceEffect.ModDefined)
+        {
+            // 登记方自己按令牌认选项。选项牌不在任何模拟牌堆里，求解器没有可解析的来源，
+            // 也不需要有——结算整体交给登记方。
+            selected = [];
+        }
+        else if (choice.Effect == PlanChoiceEffect.GenerateToHand)
         {
             CombatPredictionCardGenerationOptionsEntry entry = simulator.History
                 .OfType<CombatPredictionCardGenerationOptionsEntry>()
@@ -100,11 +106,18 @@ internal static partial class CardChoiceSupport
                     return false;
                 break;
             case PlanChoiceEffect.ModDefined:
-                // 由登记方结算的选择只经过 PotionChoiceMirrors 那条通道。走到卡牌选牌结算说明
-                // 登记方把这个效果用在了它不该出现的地方，早报比静默空操作好。
-                throw new InvalidOperationException(
-                    $"卡牌 {playedCard.Preview.Id.Entry} 的选择用了 ModDefined，"
-                    + "但卡牌选牌结算没有登记方通道。");
+                if (!CardChoiceMirrors.TryApply(
+                        simulator, combat, playedCard, choice, out bool modDefinedCompleted))
+                {
+                    // 效果说"由登记方结算"，却没有登记方认这张牌。静默空操作会让路线看起来
+                    // 可信而实际缺一整张牌的效果，所以在这里就报出来。
+                    throw new InvalidOperationException(
+                        $"卡牌 {playedCard.Preview.Id.Entry} 的选择用了 ModDefined，"
+                        + "但没有登记方为它登记结算。");
+                }
+                if (!modDefinedCompleted)
+                    return false;
+                break;
             default:
                 throw new ArgumentOutOfRangeException(nameof(choice));
         }

--- a/src/Search/CardChoiceSupport.cs
+++ b/src/Search/CardChoiceSupport.cs
@@ -72,6 +72,10 @@ internal static partial class CardChoiceSupport
 
     public static CardChoiceSpec? GetSpec(CombatPredictionSimulator simulator, PredictedCard playedCard)
     {
+        // 第三方登记优先。登记表为空时这里只是一次计数比较，原版一条也走不进来。
+        if (CardChoiceMirrors.TryGetSpec(simulator, playedCard, out CardChoiceSpec registered))
+            return registered;
+
         SimPlayerCombatState owner = simulator.State.GetPlayerCombatState(playedCard.Preview.Owner);
         CardModel card = playedCard.Preview;
         IEnumerable<PredictedCard> discardBeforeResolution = owner.DiscardPile.Cards


### PR DESCRIPTION
药水那条（#53）的另一半。同一堵墙的两面：药水的玩家选择已经有登记入口了，卡牌的还没有。

## 问题

`CardChoiceSupport.GetSpec` 是按原版卡牌类型写死的 `switch`，默认分支返回 `null` —— 也就是「这张牌没有选择」。第三方卡牌落到那里就是这个答案，于是它的选牌效果**永远不会被展开成搜索分支**：牌照样打得出去，效果在模拟里静默变成空操作。

卡牌自己的 `CardOnPlayMirrors` 镜像补不了这个：选择的展开发生在出牌路径上（`CombatPredictionSimulator` 调 `ResolveManualCardChoice`），不在效果镜像里。

## 改法

新增 `src/Search/CardChoiceMirrors.cs`，形状和 `PotionChoiceMirrors` 一样：

```csharp
CardChoiceMirrors.Register<TYourCard>(spec, apply);
```

- `spec(simulator, playedCard, card)` 返回 `CardChoiceSpec`
- `apply(simulator, combat, playedCard, card, choice)` 施加效果，返回是否已经结算完

两处接线：

- `GetSpec` 开头加一句查表，命中就直接返回登记的规格
- `CardChoiceResolution` 里 `PlanChoiceEffect.ModDefined` 从「直接抛」改成分派给登记方。#53 加那条抛错时卡牌这一侧还没有通道，现在有了；没有登记方认领时仍然抛，不静默空操作

选项牌不在任何模拟牌堆里，所以 `ModDefined` 这一支跳过「令牌 → 模拟牌堆里的牌」的解析，把 `PlanCardChoice` 原样交给登记方。

## 对原版的影响

**没有。** `GetSpec` 那句在登记表为空时只是一次 `Registry.Count > 0` 比较；`PlanChoiceEffect.ModDefined` 求解器自己从不产生。

## 促成这次改动的实例

观者的许愿（`WATCHER_WISH_P`）：3 费，打出后在「多层护甲 6」「力量 3」「金币 25」之间三选一（升级后 8 / 4 / 30）。

三个选项的单位完全不同，但都不需要新的估值刻度：力量和多层护甲本来就是 Power；金币直接落在现成的长期资源刻度上（`GainPlayerGold` 加 `RecordLongTermResource`，`贪婪之手` 就是面值直记）。登记成三个真分支之后，「值不值这 3 点能量」和「三个里挑哪个」都由搜索自己比出来，不需要写任何策略规则。

顺便记一个部署上的坑，已经写进手册：三张选项牌会跟着本牌一起升级（原版对三张都调了 `UpgradeInternal`），而部署时是按 CardId **加升级等级**在原生页面上定位选项的，所以 `spec` 里必须把选项牌也升级，否则定位不到。

## 依赖与文档

建立在 #53 之上（改的是它加的那个 `ModDefined` 分支），#53 已合并，这条可以直接合。

按仓库约定同步了 `docs/THIRD_PARTY_ADAPTERS.md`：新增 2.5 节，第 6 节里 `CardChoiceSupport` 那一行删掉。已经和你在 46b5259 里加的 2.4 节（牌堆弃牌）合过，编号接在它后面。
