### PR TITLE
[修复] 胜利判定要等会生成敌人的死亡效果结算完；目前导致求解器在面对巨斧机器人的时候表现比较差

### DIFF
--- a/docs/DEVELOPMENT_NOTES.md
+++ b/docs/DEVELOPMENT_NOTES.md
@@ -14,6 +14,17 @@
 - 统计服务管理端支持独立 HTTPS 监听和公网 Host 配置；非回环监听强制要求 TLS，登录 Origin 按实际连接协议匹配，HTTPS 会话 cookie 使用 Secure。服务端已按维护者端口映射部署，不改变已发布 Mod DLL 或采集协议。
 - 服务器运维手册已补充部署、访问、启停、证书、日志和备份恢复说明；实际地址及端口只写入服务器私有手册与本地私有配置，仓库指南只记录通用环境变量。
 
+## 下一版本（开发中）：胜利判定要等会生成敌人的死亡效果结算完
+
+- 原版 `StockPower.ShouldStopCombatFromEnding()` 直接返回 `true`：**场上还有补货，战斗就不能结束。** 求解器没有照这条走。
+- 求解器把死亡效果推迟到 `CorePowerSupport.ApplyEnemyDeathPowers` 的清扫，而个体在死亡当时（`CombatPredictionSimulator.Damage`）就被移出了 `State.Enemies`。于是中间出现一个「场上没有活着的主要敌人、但马上会有」的窗口。`AdvanceRound` 里那个窗口是显式的：`PlayerTurnEndLifecycle.RunPhaseOne` 内部调了两次 `CheckWinCondition`，而清扫在它返回之后才跑。
+- `CheckWinCondition` 第一行是 `if (TerminalStamp.HasValue) return true;`——**盖章即锁死**，之后补货生成出来也不会再复查。
+- 实机后果（一份 `AXEBOTS_NORMAL` 问题包）：一条路线同时报 `combat_ended_turn=7`、`final_enemy_hp=95` 和含 `VictoryBonus` 的分数，而玩家第 7 回合面对的是一只满血 `95`、力量 `6`、带 `10` 点格挡的新机器人；缓存计划里没有第 8 回合，`continuation_missing=1` 强制重算。假胜利拿的是 `10^10` 的加成，会直接污染搜索的目标函数。
+- 改法：`IsCombatEnding()` 在「还有已死个体欠着一个会生成主要敌人的死亡效果」时返回 false，把胜利推迟到清扫之后再判。判据集中在 `DeathPowerSupport.SpawnsPrimaryEnemyOnDeath`，和那个死亡效果 `switch` 放在一起维护。
+- 覆盖三种：补货（巨斧机器人）、寄生（蠕虫）、惊吓（小恶魔）。这三条走 `MonsterSpawnSupport.Spawn` 都没传 `minion: true`，生成的是主要敌人，所以是同一个洞。幻象和重接**没动**：它们复活的是同一个个体，走既有的 `RevivingEnemyHp` 有效生命路径。
+- 刻画那个窗口用的是「还在 `_knownEnemies` 里、已经不在场上、死亡效果又没结算完」，因为那些个体已经不在 `State.Enemies` 里，逐个问拿不到。
+- 回归用例 `AssertVictoryWaitsForStockRespawn` 加进 Fork 边界批，三段加一条反向对照：没有补货时照常结束；有补货、未清扫时不结束；清扫之后仍不结束（此时是替补真的站上来了）；库存为零的巨斧机器人打死后必须照常结束。
+
 ## 0.33.5：受伤历史与攻击次数修复
 
 - FABRICATOR_NORMAL-20260907-223153-088 包声明 0.33.2.0，P[2] Poison/Minion 顺序差异与 0.33.3 已修召唤站位监听顺序同根。THE_OBSCURA_NORMAL-20260907-223520-357 包声明 0.33.3.0，T3 到 T4 的首个差异为 E1.hp 预测 50、原生 45，来自怨恨少一次攻击，不能归为召唤时序。

--- a/src/Engine/Common/PredictionForking.cs
+++ b/src/Engine/Common/PredictionForking.cs
@@ -310,6 +310,19 @@ internal interface ICombatPredictionCreatureSemantics
     bool IsHittable(MegaCrit.Sts2.Core.Entities.Creatures.Creature creature);
 
     bool ShouldRemoveAfterDeath(MegaCrit.Sts2.Core.Entities.Creatures.Creature creature);
+
+    /// <summary>
+    /// 场上是否还有「已经死掉、但还欠一个会生成新的主要敌人的死亡效果」的个体。
+    /// </summary>
+    /// <remarks>
+    /// 死亡效果被推迟到 <c>ApplyEnemyDeathPowers</c> 的清扫才结算，而个体在死亡当时就被移出了
+    /// <c>State.Enemies</c>，所以中间有一个「场上没有活着的主要敌人、但马上会有」的窗口。在那个
+    /// 窗口里宣布胜利会把胜利戳永久锁死（<c>CheckWinCondition</c> 第一行就是
+    /// <c>if (TerminalStamp.HasValue) return true;</c>），之后补货生成出来也不会再复查。
+    ///
+    /// 问的是整场而不是逐个，正因为那些个体已经不在 <c>State.Enemies</c> 里了，调用方拿不到它们。
+    /// </remarks>
+    bool HasUnresolvedSpawningDeath();
 }
 
 internal interface ICombatPredictionMonsterStateSink

--- a/src/Engine/InCombat/Simulation/CombatPredictionSimulator.cs
+++ b/src/Engine/InCombat/Simulation/CombatPredictionSimulator.cs
@@ -280,6 +280,12 @@ internal sealed partial class CombatPredictionSimulator
                 return false;
             }
         }
+        // 原版在杀死的那一刻就把死亡效果同步结算完了，求解器把它推迟到 ApplyEnemyDeathPowers
+        // 的清扫，而个体在死亡当时就被移出了 State.Enemies。于是中间有一个「场上没有活着的主要
+        // 敌人、但马上会有」的窗口。在那个窗口里宣布胜利会把胜利戳永久锁死，之后补货生成出来
+        // 也不会再复查。
+        if (semantics?.HasUnresolvedSpawningDeath() == true)
+            return false;
         return !Hook.ShouldStopCombatFromEnding(State.CombatState);
     }
 }

--- a/src/Prediction/DeathPowerSupport.cs
+++ b/src/Prediction/DeathPowerSupport.cs
@@ -9,6 +9,24 @@ namespace CombatSolver;
 
 internal static class DeathPowerSupport
 {
+    /// <summary>
+    /// 这个死亡效果会不会往场上放一个新的<b>主要</b>敌人。
+    /// </summary>
+    /// <remarks>
+    /// 下面那个 switch 里三条走 <see cref="MonsterSpawnSupport.Spawn{T}" /> 且没传
+    /// <c>minion: true</c>，所以生成出来的是主要敌人：巨斧机器人的补货、寄生的蠕虫、
+    /// 惊吓的小恶魔。**这三种死亡效果没结算完之前不能宣布胜利**——原版是在杀死的那一刻同步
+    /// 结算完死亡效果的，求解器把死亡效果推迟到 <see cref="CorePowerSupport.ApplyEnemyDeathPowers" />
+    /// 的清扫，于是中间存在一个「场上没有活着的主要敌人、但马上会有」的窗口。
+    ///
+    /// 幻象和重接不在这里：它们复活的是同一个个体，走的是
+    /// <c>SimulatedCombatState.RevivingEnemyHp</c> 那条既有的有效生命路径。
+    ///
+    /// 新增会生成主要敌人的死亡效果时，这里和下面那个 switch 要一起改。
+    /// </remarks>
+    public static bool SpawnsPrimaryEnemyOnDeath(PowerModel power)
+        => power.Amount > 0 && power is StockPower or InfestedPower or SurprisePower;
+
     public static bool Trigger(
         CombatPredictionSimulator simulator,
         SimulatedCombatState combat,

--- a/src/Search/SimulatedCombatState.cs
+++ b/src/Search/SimulatedCombatState.cs
@@ -2586,6 +2586,29 @@ internal sealed partial class SimulatedCombatState
             && GetAmount<IllusionPower>(creature) <= 0
             && GetAmount<ReattachPower>(creature) <= 0
             && GetAmount<SteamEruptionPower>(creature) <= 0;
+    bool ICombatPredictionCreatureSemantics.HasUnresolvedSpawningDeath()
+    {
+        // 死亡当时个体就被移出了 _enemies，但还留在 _knownEnemies 里，powers 也要到清扫末尾的
+        // RemovePowersAfterDeath 才摘掉。所以「在已知列表里、已经不在场上、死亡效果又没结算完」
+        // 正好刻画那个窗口。
+        IReadOnlyList<Creature> known = _knownEnemies;
+        if (known.Count == 0)
+            return false;
+        IReadOnlyList<PowerModel> powers = EffectivePowers();
+        for (int index = 0; index < known.Count; index++)
+        {
+            Creature enemy = known[index];
+            if (ContainsCreature(enemy) || HasCompletedDeathEffects(enemy))
+                continue;
+            for (int powerIndex = 0; powerIndex < powers.Count; powerIndex++)
+            {
+                PowerModel power = powers[powerIndex];
+                if (power.Owner == enemy && DeathPowerSupport.SpawnsPrimaryEnemyOnDeath(power))
+                    return true;
+            }
+        }
+        return false;
+    }
     public Creature? GetCreature(uint? combatId)
     {
         if (combatId == null)

--- a/src/Testing/UnattendedTestRunner.ForkBoundaries.cs
+++ b/src/Testing/UnattendedTestRunner.ForkBoundaries.cs
@@ -199,6 +199,7 @@ internal sealed partial class UnattendedTestRunner
         AssertPendingSpawnCanEnterIllusionRevive(combat);
         AssertPendingRandomBranchSpawnRollsAtTurnBoundary(combat);
         AssertDefeatedEnemyRejectsLatePowerApplication(combat, player);
+        AssertVictoryWaitsForStockRespawn(combat, player);
         AssertOrbSlotAdditionCapsAtVanillaMaximum(combat, player);
         AssertAutoPlayedBlockHonorsPriorTurnHistory(combat, player, card);
         AssertOrbDeathsSettleBetweenTurnEndPassives(combat, player);
@@ -2083,6 +2084,86 @@ internal sealed partial class UnattendedTestRunner
         simulatedCombat.Apply<VulnerablePower>(enemy, 2, player.Creature);
         if (simulatedCombat.GetAmount<VulnerablePower>(enemy) != 0)
             throw new InvalidOperationException("永久死亡的敌人仍然接收了后续 Power。");
+    }
+
+    /// <summary>
+    /// 补货还没结算完之前不能判定战斗结束；补货用尽时必须照常判定结束。
+    /// </summary>
+    /// <remarks>
+    /// 原版 <c>StockPower.ShouldStopCombatFromEnding()</c> 直接返回 <c>true</c>——场上还有补货，
+    /// 战斗就不能结束。求解器把死亡效果推迟到 <c>ApplyEnemyDeathPowers</c> 的清扫，而个体在死亡
+    /// 当时就被移出了 <c>State.Enemies</c>，于是中间出现一个「没有活着的主要敌人、但马上会有」的
+    /// 窗口。在那个窗口里 <c>CheckWinCondition</c> 会把胜利戳永久锁死
+    /// （第一行就是 <c>if (TerminalStamp.HasValue) return true;</c>），之后补货生成出来也不复查。
+    ///
+    /// 实机后果：一条路线同时报 <c>combat_ended_turn=7</c> 和 <c>final_enemy_hp=95</c>，还拿了
+    /// 胜利加成，而玩家第 7 回合面对的是一只满血 95、力量 6 的新机器人。
+    ///
+    /// 三段都要有，缺一段这条用例就不成立：先证明没有补货时照常结束（基线），再证明有补货时
+    /// 不结束（本次修的），最后证明清扫之后仍然不结束——那时是因为替补真的站上来了。
+    /// 末尾再补一条库存为零的反向对照，防止改成「见到巨斧机器人就永不结束」的另一个错。
+    /// </remarks>
+    private static void AssertVictoryWaitsForStockRespawn(CombatState combat, Player player)
+    {
+        // 基线：把场上清空，没有任何补货，战斗应当判定为正在结束。
+        {
+            SimulatedCombatState simulatedCombat = new(combat);
+            CombatPredictionSimulator simulator = new(simulatedCombat);
+            simulator.Kill(simulatedCombat.Enemies.ToArray(), force: true);
+            if (!simulator.IsEnding)
+                throw new InvalidOperationException("清空场上敌人后战斗没有判定为正在结束。");
+        }
+
+        // 有补货：死亡效果还没清扫，不能判定结束。
+        {
+            SimulatedCombatState simulatedCombat = new(combat);
+            CombatPredictionSimulator simulator = new(simulatedCombat);
+            Creature axebot = InjectAxebot(simulator, simulatedCombat, player, stockAmount: 1);
+            if (simulatedCombat.GetAmount<StockPower>(axebot) != 1)
+                throw new InvalidOperationException("注入的巨斧机器人没有拿到补货。");
+            simulator.Kill(simulatedCombat.Enemies.ToArray(), force: true);
+            if (simulator.IsEnding)
+            {
+                throw new InvalidOperationException(
+                    "补货的死亡效果还没结算，战斗就被判定为正在结束；胜利戳会被永久锁死。");
+            }
+
+            HashSet<uint> processed = [];
+            if (!CorePowerSupport.ApplyEnemyDeathPowers(
+                    simulator, simulatedCombat, simulatedCombat.KnownEnemies, processed))
+            {
+                throw new InvalidOperationException("补货的死亡效果清扫报告挂起。");
+            }
+            if (simulator.IsEnding)
+                throw new InvalidOperationException("补货已经生成出替补，战斗仍被判定为正在结束。");
+        }
+
+        // 反向对照：库存为零的巨斧机器人不带补货，打死之后必须照常结束。
+        {
+            SimulatedCombatState simulatedCombat = new(combat);
+            CombatPredictionSimulator simulator = new(simulatedCombat);
+            Creature axebot = InjectAxebot(simulator, simulatedCombat, player, stockAmount: 0);
+            if (simulatedCombat.GetAmount<StockPower>(axebot) != 0)
+                throw new InvalidOperationException("库存为零的巨斧机器人不应拿到补货。");
+            simulator.Kill(simulatedCombat.Enemies.ToArray(), force: true);
+            if (!simulator.IsEnding)
+                throw new InvalidOperationException("库存用尽后战斗没有判定为正在结束。");
+        }
+    }
+
+    private static Creature InjectAxebot(
+        CombatPredictionSimulator simulator,
+        SimulatedCombatState combat,
+        Player player,
+        int stockAmount)
+    {
+        Creature axebot = MonsterSpawnSupport.Create<MegaCrit.Sts2.Core.Models.Monsters.Axebot>(
+            simulator,
+            combat,
+            MonsterSpawnSupport.NextSlot(combat),
+            configure: monster => monster.StockAmount = stockAmount);
+        MonsterSpawnSupport.AddCreated(simulator, combat, player.Creature, axebot);
+        return axebot;
     }
 
     private static void AssertWhisperingEarringOnlyRunsOnFirstTurn(


### PR DESCRIPTION
## 现象

人类玩家和求解器面对巨斧机器人的差距

previous=18 current=7 difference=-11 original_turn=1 | 手打第 1 回合,比它自己的计划好 11 HP
previous=7 current=0 difference=-7 original_turn=2 | 第 2 回合又好 7 HP


## 症状

一份 `AXEBOTS_NORMAL` 问题包里，同一条路线的同一行同时报：

```
combat_ended_turn=7   final_enemy_hp=95   modeled_damage_exact=True
score=10001126951     ← 含 10^10 的 VictoryBonus
```

**一边宣布第 7 回合打完收工并拿了胜利加成，一边自己的终局状态里还站着一只 95 血的敌人。** 玩家实际在第 7 回合面对的是一只满血 `95`、力量 `6`、带 `10` 点格挡的新机器人；缓存计划里没有第 8 回合，`continuation_missing=1`，强制重算。

假胜利拿的是 `10^10` 的加成，所以这不只是显示错——**它会直接污染搜索的目标函数**。

## 原因

这条规则写得很直白：

```csharp
// StockPower
public override bool ShouldStopCombatFromEnding() => true;
```

场上还有补货，战斗就不能结束。求解器没有照这条走。

求解器把死亡效果推迟到 `CorePowerSupport.ApplyEnemyDeathPowers` 的清扫，而个体在**死亡当时**就被移出了 `State.Enemies`（`CombatPredictionSimulator.Damage.cs`，`State.RemoveCreature(creature)`）。于是中间出现一个「场上没有活着的主要敌人、但马上会有」的窗口。

`AdvanceRound` 里这个窗口是显式的：

```csharp
PlayerTurnEndLifecycle.RunPhaseOne(...)      // 内部调了两次 CheckWinCondition
CorePowerSupport.ApplyEnemyDeathPowers(...)  // 补货在这里才生成
```

而 `CheckWinCondition` 第一行是 `if (TerminalStamp.HasValue) return true;` —— **盖章即锁死**，补货随后生成出来也不会让它复查。

## 改法

`IsCombatEnding()` 在「还有已死个体欠着一个会生成主要敌人的死亡效果」时返回 `false`，把胜利推迟到清扫之后再判。判据集中在一处，和那个死亡效果 `switch` 放在一起维护：

```csharp
// DeathPowerSupport
public static bool SpawnsPrimaryEnemyOnDeath(PowerModel power)
    => power.Amount > 0 && power is StockPower or InfestedPower or SurprisePower;
```

覆盖三种：**补货**（巨斧机器人）、**寄生**（蠕虫）、**惊吓**（小恶魔）。这三条在 `DeathPowerSupport` 里走 `MonsterSpawnSupport.Spawn` 都**没有**传 `minion: true`，生成出来的是主要敌人，所以是同一个洞。

**幻象和重接没动**：它们复活的是同一个个体，走既有的 `SimulatedCombatState.RevivingEnemyHp` 有效生命路径，那条路已经让它们的有效生命大于零。

刻画那个窗口用的是「还在 `_knownEnemies` 里、已经不在场上（`!ContainsCreature`）、死亡效果又没结算完（`!HasCompletedDeathEffects`）」。所以新增的接口方法是**整场查询**而不是逐个问：那些个体已经不在 `State.Enemies` 里，调用方拿不到它们。powers 要到清扫末尾的 `RemovePowersAfterDeath` 才摘掉，所以窗口期内读得到。

## 回归

`AssertVictoryWaitsForStockRespawn` 加进 Fork 边界批，三段加一条反向对照：

1. **基线**：清空场上敌人、没有补货 → 必须判定为正在结束。
2. **本次修的**：注入库存 1 的巨斧机器人、打死、**还没清扫** → 必须**不**结束。
3. 跑完清扫 → 仍然不结束（此时是替补真的站上来了）。
4. **反向对照**：库存为零的巨斧机器人，打死之后必须照常结束 —— 防止改成「见到巨斧机器人就永不结束」的另一个错。

Release 构建 0 警告 0 错误。

## 顺带

同一批问题包还暴露了两件我**没有**放进这个 PR 的事，都属于估值口径、想先听你的意见：

1. **击杀补货怪时 `enemyHp` 会往上跳**（63 → 88 → 95）。`EffectiveEnemyHp` 只算当前生命，待生成的替补不计。所以在 Beam 打分里「打死当前这只」表现为负进展。
2. **卖血换伤害的汇率是全局常数,不看战斗还剩多长**。`Hp=30000`、`SoldHpPenalty=-20000`、`EnemyHp=-10000` ⇒ 求解器愿意用 **1 点自己的血换 5 点敌方生命**。补货战里三只合计 `246` 点生命而玩家只有 `59` 点血，按这个汇率全吃下来要花 `49` 点血。那份包里路线第 2 回合 `max_block=24` 却只起了 `7` 点、`sold_hp=5` 一次把普通战斗的预算用光，第 3 回合再卖 `4` 点；`18` 点预计战损里有 `9` 点是自愿卖的。同一场玩家手打两回合，求解器自己记的账是 `difference=-11` 和 `-7`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)