### PR TITLE
回合开始的能力结算改走注册表，第三方能力才有登记入口

### DIFF
--- a/docs/THIRD_PARTY_ADAPTERS.md
+++ b/docs/THIRD_PARTY_ADAPTERS.md
@@ -77,7 +77,7 @@ Power 来源也是语义的一部分：精确镜像可通过 `ICombatPredictionE
 
 ## 2. 登记点总表
 
-### 2.1 统一形状的镜像注册表（44 张）
+### 2.1 统一形状的镜像注册表（45 张）
 
 绝大多数登记走同一个形状：
 
@@ -85,7 +85,7 @@ Power 来源也是语义的一部分：精确镜像可通过 `ICombatPredictionE
 XxxMirrors.Registry.Register<TYourType>(handler);
 ```
 
-44 张注册表按域分布在 `src/Engine/InCombat/Mirrors/` 下：
+45 张注册表按域分布在 `src/Engine/InCombat/Mirrors/` 下：
 
 死亡后生成单位的镜像应保持原生生成时点。例如补货由 `AfterDeathMirrors` 调用分支生成入口，旧个体仍在阵容中，其最大生命参与替补生命判重。把生成延后到阵容清理后，即使 RNG 调用次数相同也会改变抽样结果；登记镜像时应同步移除原领域补偿中的同一生成动作。
 
@@ -95,17 +95,23 @@ XxxMirrors.Registry.Register<TYourType>(handler);
 
 | 目录 | 注册表数 | 覆盖什么 | 你多半要用的 |
 |---|---|---|---|
-| `Hooks/` | 37 | 战斗 hook：攻击、格挡、伤害、死亡、卡牌、球体、回合边界 | 按你重写了哪个 hook 挑，例如 `AfterDamageGivenMirrors` |
+| `Hooks/` | 38 | 战斗 hook：攻击、格挡、伤害、死亡、卡牌、球体、回合边界 | 按你重写了哪个 hook 挑，例如 `AfterDamageGivenMirrors` |
 | `Cards/` | 4 | 出牌、可打出性、回合结束留手、结算落点 | `CardOnPlayMirrors`、`CardIsPlayableMirrors` |
 | `Potions/` | 1 | 药水使用 | `PotionOnUseMirrors` |
 | `Enchantments/`、`Afflictions/` | 各 1 | 附魔与病症的出牌效果 | 少见 |
+
+**回合开始重置能量之后的能力结算走 `Hooks/Resources/AfterEnergyResetMirrors`。** 这一张是从
+`PersistentPowerSupport` 里那个写死五个原版类型的 switch 改过来的，所以以前第三方能力在这个
+时点既没有登记入口，漏了也不报——别的钩子漏登记会记一条 `MethodNotMirrored` 风险，那个 switch
+不经过注册表，只是静默跳过。重写了 `AfterEnergyReset` 的能力（每回合少一点能量、多一点能量、
+多抽一张这一类）现在必须在这里登记。层数为零的能力不分发，和原版每个重写第一件事都是空转一致。
 
 **注意目录里的文件数比注册表多。** `Cards/` 下有十几个 `*Mirrors.cs`，但注册表只有 4 张——
 `BespokeCardMirrors`、`CardGenerationCardMirrors` 这些是**处理器文件**，它们往
 `CardOnPlayMirrors.Registry` 这张共享注册表里登记，自己不持有注册表。找登记入口时认
 `static readonly Registry Registry` 这个字段，不要认文件名。
 
-**怎么知道自己要登记哪几个。** 把你的每个类型对基类虚方法的重写列出来，和这 44 张表逐一对照。
+**怎么知道自己要登记哪几个。** 把你的每个类型对基类虚方法的重写列出来，和这 45 张表逐一对照。
 只重写了求解器不分发的方法，不用登记；重写了它分发的方法，就要登记。这一步不要靠印象，
 要交叉核对——漏一个的表现是「效果看起来正常但其实没发生」。
 

--- a/src/Engine/Common/MirroredHookListenerFilter.cs
+++ b/src/Engine/Common/MirroredHookListenerFilter.cs
@@ -74,6 +74,7 @@ internal sealed class MirroredHookListenerFilter(bool enabled)
         [nameof(AbstractModel.AfterDamageReceived)] = MirroredHookMask.AfterDamageReceived,
         [nameof(AbstractModel.AfterDamageReceivedLate)] = MirroredHookMask.AfterDamageReceivedLate,
         [nameof(AbstractModel.AfterDeath)] = MirroredHookMask.AfterDeath,
+        [nameof(AbstractModel.AfterEnergyReset)] = MirroredHookMask.AfterEnergyReset,
         [nameof(AbstractModel.AfterModifyingBlockAmount)] = MirroredHookMask.AfterModifyingBlockAmount,
         [nameof(AbstractModel.AfterModifyingCardPlayCount)] = MirroredHookMask.AfterModifyingCardPlayCount,
         [nameof(AbstractModel.AfterModifyingCardPlayResultLocation)] = MirroredHookMask.AfterModifyingCardPlayResultLocation,
@@ -283,6 +284,7 @@ internal enum MirroredHookMask : ulong
     TryModifyEnergyCostInCombatLate = 1UL << 52,
     TryModifyStarCost = 1UL << 53,
     TryModifyKeywordsInCombat = 1UL << 54,
+    AfterEnergyReset = 1UL << 55,
     All = ulong.MaxValue,
 }
 

--- a/src/Engine/InCombat/Mirrors/Hooks/Resources/AfterEnergyResetMirrors.cs
+++ b/src/Engine/InCombat/Mirrors/Hooks/Resources/AfterEnergyResetMirrors.cs
@@ -1,0 +1,108 @@
+using MegaCrit.Sts2.Core.Entities.Players;
+using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Models.Orbs;
+using MegaCrit.Sts2.Core.Models.Powers;
+using CombatSolver.Engine.Common.Mirrors;
+using CombatSolver.Engine.InCombat.Simulation;
+
+namespace CombatSolver.Engine.InCombat.Mirrors.Hooks.Resources;
+
+using Registry = MethodMirrorRegistry<PowerModel, AfterEnergyResetMirrorContext>;
+
+/// <summary>
+/// 回合开始重置能量之后，能力那一轮结算。对应 <c>Hook.AfterEnergyReset</c> 的能力部分。
+/// </summary>
+/// <remarks>
+/// <para>
+/// 这一份原来是 <c>PersistentPowerSupport.TriggerAfterEnergyReset</c> 里的一个 switch，判据是写死的
+/// 五个原版类型。写死的判据有两个后果：第三方能力没有登记的地方；而且**没登记也不报**——
+/// 别的钩子走 <see cref="MethodMirrorRegistry{TBase, TContext}" />，重写了却没登记会记一条
+/// <c>MethodNotMirrored</c> 风险，这里因为不经过注册表，只是静默跳过。
+/// </para>
+/// <para>
+/// 发现它是因为一个真实的 mod：观者的斋戒挂 <c>EnergyDownPower</c>，重写 <c>AfterEnergyReset</c>
+/// 去扣一点能量。求解器从此每回合都以为自己多一点能量，执行下来和预测对不上，于是每回合重算，
+/// 而路线上没有任何提示说哪里算错了。
+/// </para>
+/// <para>
+/// 改成注册表之后：原版那五个照原样登记成 handler，行为逐位不变；
+/// <see cref="EnergyNextTurnPower" /> 登记成 Ignored——它的能量是在回合开始算能量时由
+/// <c>ConsumeEnergyNextTurn</c> 一次性取走的，在这里再结算一次就是重复计数；
+/// 其余任何重写了这个钩子的类型，登记过就按登记的算，没登记就记一条风险，不再静默。
+/// </para>
+/// </remarks>
+internal static class AfterEnergyResetMirrors
+{
+    private static readonly MirrorMethodSpec AfterEnergyReset = MirrorMethodSpec.Hook(
+        nameof(AbstractModel.AfterEnergyReset),
+        [typeof(Player)]);
+
+    private static readonly Registry Registry = CreateRegistry();
+
+    public static void Invoke(PowerModel power, AfterEnergyResetMirrorContext context)
+    {
+        Registry.Invoke(power, context);
+    }
+
+    private static Registry CreateRegistry()
+    {
+        var registry = new Registry(AfterEnergyReset);
+
+        registry.Register<GenesisPower>(HandleGenesisPower);
+        registry.Register<LightningRodPower>(HandleLightningRodPower);
+        registry.Register<RadiancePower>(HandleRadiancePower);
+        registry.Register<SpinnerPower>(HandleSpinnerPower);
+        registry.Register<StarNextTurnPower>(HandleStarNextTurnPower);
+
+        // 回合开始算能量的时候已经用 ConsumeEnergyNextTurn 取走并清零了，这里再给一次就是双份。
+        registry.RegisterIgnored<EnergyNextTurnPower>();
+
+        return registry;
+    }
+
+    private static void HandleGenesisPower(GenesisPower power, AfterEnergyResetMirrorContext context)
+    {
+        context.Simulator.GainStars(context.Player, power.Amount);
+    }
+
+    private static void HandleLightningRodPower(LightningRodPower power, AfterEnergyResetMirrorContext context)
+    {
+        context.Simulator.OrbChannel<LightningOrb>(context.Player);
+        // 起了选择就停在这里：调用方看见 HasPendingChoice 会中止整轮，层数留到下次重新结算。
+        if (context.Simulator.HasPendingChoice)
+            return;
+        context.Combat.SetAmount<LightningRodPower>(context.Player.Creature, power.Amount - 1);
+    }
+
+    private static void HandleRadiancePower(RadiancePower power, AfterEnergyResetMirrorContext context)
+    {
+        if (context.Combat.GetAmount<NoEnergyGainPower>(context.Player.Creature) <= 0)
+        {
+            context.Simulator.State.GetPlayerCombatState(context.Player)
+                .GainEnergy(power.DynamicVars.Energy.IntValue);
+        }
+        context.Combat.SetAmount<RadiancePower>(context.Player.Creature, power.Amount - 1);
+    }
+
+    private static void HandleSpinnerPower(SpinnerPower power, AfterEnergyResetMirrorContext context)
+    {
+        context.Simulator.OrbChannel<GlassOrb>(context.Player, power.Amount);
+    }
+
+    private static void HandleStarNextTurnPower(StarNextTurnPower power, AfterEnergyResetMirrorContext context)
+    {
+        context.Simulator.GainStars(context.Player, power.Amount);
+        if (context.Simulator.HasPendingChoice)
+            return;
+        context.Combat.SetAmount<StarNextTurnPower>(context.Player.Creature, 0);
+    }
+}
+
+internal sealed class AfterEnergyResetMirrorContext : CombatMirrorContext<PowerModel>
+{
+    /// <summary>刚刚重置过能量的那名玩家。原版每个重写第一件事都是拿它和自己的主人比对。</summary>
+    public required Player Player { get; init; }
+
+    public SimulatedCombatState Combat => CombatState as SimulatedCombatState
+        ?? throw new InvalidOperationException("回合开始的能力结算缺少分支回合状态。");
+}

--- a/src/Prediction/PersistentPowerSupport.cs
+++ b/src/Prediction/PersistentPowerSupport.cs
@@ -13,6 +13,7 @@ using MegaCrit.Sts2.Core.Rooms;
 using MegaCrit.Sts2.Core.ValueProps;
 using CombatSolver.Engine.Common;
 using CombatSolver.Engine.InCombat.Mirrors.Hooks.Card;
+using CombatSolver.Engine.InCombat.Mirrors.Hooks.Resources;
 using CombatSolver.Engine.InCombat.Simulation;
 
 namespace CombatSolver;
@@ -116,49 +117,22 @@ internal static class PersistentPowerSupport
             _ => 0m,
         };
 
-    public static bool ParticipatesInEnergyReset(PowerModel power)
-        => power.Amount > 0 && power is GenesisPower or LightningRodPower or RadiancePower
-            or SpinnerPower or StarNextTurnPower;
-
     public static bool TriggerAfterEnergyReset(
         CombatPredictionSimulator simulator,
         SimulatedCombatState combat,
         Player player)
     {
         Creature owner = player.Creature;
-        SimPlayerCombatState state = simulator.State.GetPlayerCombatState(player);
+        var context = new AfterEnergyResetMirrorContext { Simulator = simulator, Player = player };
 
         // Channel order affects the queue and the effects evoked when it is full.
         foreach (PowerModel power in combat.EffectivePowers())
         {
-            if (power.Owner != owner || !ParticipatesInEnergyReset(power))
+            // 层数为零的能力在原版里每一个重写都是空转：加零点星、抽零张、扣零点能量。
+            // 这道门保持原来的判据，顺带让没登记的第三方能力不会为了一次空转记风险。
+            if (power.Owner != owner || power.Amount <= 0)
                 continue;
-            switch (power)
-            {
-                case GenesisPower:
-                    simulator.GainStars(player, power.Amount);
-                    break;
-                case LightningRodPower:
-                    simulator.OrbChannel<LightningOrb>(player);
-                    if (simulator.HasPendingChoice)
-                        return false;
-                    combat.SetAmount<LightningRodPower>(owner, power.Amount - 1);
-                    break;
-                case RadiancePower:
-                    if (combat.GetAmount<NoEnergyGainPower>(owner) <= 0)
-                        state.GainEnergy(power.DynamicVars.Energy.IntValue);
-                    combat.SetAmount<RadiancePower>(owner, power.Amount - 1);
-                    break;
-                case SpinnerPower:
-                    simulator.OrbChannel<GlassOrb>(player, power.Amount);
-                    break;
-                case StarNextTurnPower:
-                    simulator.GainStars(player, power.Amount);
-                    if (simulator.HasPendingChoice)
-                        return false;
-                    combat.SetAmount<StarNextTurnPower>(owner, 0);
-                    break;
-            }
+            AfterEnergyResetMirrors.Invoke(power, context);
             if (simulator.HasPendingChoice)
                 return false;
         }


### PR DESCRIPTION
## 问题

`PersistentPowerSupport.TriggerAfterEnergyReset` 是一个写死五个原版类型的 `switch`。写死判据有两个后果：

1. **第三方能力没有登记入口。**
2. **漏了也不报。** 别的钩子都走 `MethodMirrorRegistry`：重写了却没登记会记一条 `MethodNotMirrored` 风险，玩家在路线上看得到红字。这一处不经过注册表，只是静默跳过。

这是一个真实 mod 暴露出来的。观者（工坊 `3747526116`）的**斋戒**挂 `EnergyDownPower`：

```csharp
public override async Task AfterEnergyReset(Player player)
{
    if (player == Owner.Player)
        await PlayerCmd.LoseEnergy(Amount, player);
}
```

求解器从此每回合都以为自己多一点能量，执行下来和预测对不上，于是**每回合重算**——而路线上没有任何提示说哪里算错了。玩家报上来的原话是「mod 不认识斋戒，每回合都要重算」。

顺带说明这不是个别情况：同一个 mod 的**天人形态**（`DevaPower`）也重写了这个钩子，适配层现在只能 Harmony postfix 掉 `TriggerAfterEnergyReset` 本身来补，这正是「没有登记点只好打补丁」的典型。

## 改动

- 新增 `Hooks/Resources/AfterEnergyResetMirrors`，形状照 `AfterStarsGainedMirrors`。原版五个（创世、避雷针、光辉、纺纱、下回合星）照原样登记成 handler，函数体从 switch 原样搬过来。
- `EnergyNextTurnPower` 登记成 `Ignored`：它的能量是在回合开始算能量时由 `ConsumeEnergyNextTurn` 一次性取走并清零的，在这个时点再结算一次就是双份。原来的 switch 判据也不含它，所以这是把「已经在别处处理」写进代码，不是行为改动。
- `MirroredHookListenerFilter` 补 `AfterEnergyReset` 的参与位——`tools/verify-refactor-boundaries.ps1` 要求 `src/Engine/InCombat/Mirrors` 下出现过的每个 hook 名字都有这份元数据。
- 同步 `docs/THIRD_PARTY_ADAPTERS.md`：注册表 44 → 45，`Hooks/` 37 → 38，并写清这一张的来历。

## 行为等价性

- **零层仍然不分发。** 原来的 `ParticipatesInEnergyReset` 要求 `power.Amount > 0`，那道门留在循环里，所以零层能力不会为了一次空转去记风险。
- **`HasPendingChoice` 的中止语义不变。** 原来是在 switch 分支里 `return false`，现在 handler 自己提前 return、调用方在每次 `Invoke` 之后检查，顺序和次数都一样。
- **原版不会多出任何 `MethodNotMirrored`。** 反编译 sts2.dll 全量核过：重写 `AfterEnergyReset` 的一共 10 个类型，6 个是 Power（5 个 handler + 1 个 Ignored 全部有归属），另外 4 个是遗物（`ArtOfWar`、`BoundPhylactery`、`VenerableTeaSet`、`FakeVenerableTeaSet`），走 `TurnStartRelicSupport`，这次没动。

## 验证

- Release 构建 **0 警告 0 错误**；`tools/verify-refactor-boundaries.ps1` 通过（`REFACTOR_BOUNDARIES_OK`）。
- 观者适配层的 33 条验收矩阵在**不含本改动**的 `v0.36.3` 构建上 **33/33**（2026-09-12 01:51–02:12，观者 `0.9.28` + 游戏 `0.111.0`）。这一轮是基线。
- 本改动的构建上单跑四条对照：`WATCHER-CALM-EXIT-ENERGY`、`WATCHER-MIRACLE-ENERGY`、`WATCHER-SCRY-SHUFFLES-EMPTY-DRAW` 通过；`WATCHER-DEVA-FORM-ENERGY` **只挂在「未镜像项 0」这一条断言上**。
- 把那条断言去掉重跑，路线逐项相同：`combatEndedTurn=2`、`HpLost=4`、`ProjectedBattleHpLost=4`、`Actions=1`，只有 `Unmirrored` 从 0 变成 1。**这一处多出来的只有提示，没有路线改变。**

## 对第三方的影响（需要适配层跟一版）

现在靠 Harmony 补丁补这个时点的适配层会多出一条风险提示，直到它改成登记。上面那条 Deva 就是：AutoWatcher 现在 postfix 掉 `TriggerAfterEnergyReset` 整个方法，本改动保留了这个方法的签名和返回语义，所以补丁照常生效、能量照常正确，只是它重写的那个类型现在会被注册表认出来「没登记」。

我会在这个 PR 合并并发版之后把 AutoWatcher 改成登记（顺带把斋戒登记上，那条现在根本补不了）。如果你觉得这个影响面需要更缓和的过渡，我也可以改成先只对**没有任何第三方登记**的情况记风险，请指个方向。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
